### PR TITLE
NodeType and ComponentType,

### DIFF
--- a/Component/GUI/AtkComponentBase.cs
+++ b/Component/GUI/AtkComponentBase.cs
@@ -1,10 +1,10 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 
 using FFXIVClientStructs.Component.GUI.ULD;
 
 namespace FFXIVClientStructs.Component.GUI
 {    public enum ComponentType
-    { 
+    public enum ComponentType : byte
         Base = 0, 
         Button = 1,
         Window = 2, 

--- a/Component/GUI/AtkComponentBase.cs
+++ b/Component/GUI/AtkComponentBase.cs
@@ -1,34 +1,35 @@
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 using FFXIVClientStructs.Component.GUI.ULD;
 
 namespace FFXIVClientStructs.Component.GUI
-{    public enum ComponentType
+{
     public enum ComponentType : byte
-        Base = 0, 
+    {
+        Base = 0,
         Button = 1,
-        Window = 2, 
+        Window = 2,
         CheckBox = 3,
         RadioButton = 4,
-        GaugeBar = 5, 
+        GaugeBar = 5,
         Slider = 6,
-        TextInput = 7, 
-        NumericInput = 8, 
-        List = 9, 
+        TextInput = 7,
+        NumericInput = 8,
+        List = 9,
         DropDownList = 10,
-        Tab = 11, 
+        Tab = 11,
         TreeList = 12,
         ScrollBar = 13,
         ListItemRenderer = 14,
-        Icon = 15, 
+        Icon = 15,
         IconText = 16,
-        DragDrop = 17, 
+        DragDrop = 17,
         GuildLeveCard = 18,
-        TextNineGrid = 19, 
-        JournalCanvas = 20, 
-        Multipurpose = 21, 
-        Map = 22, 
-        Preview = 23, 
+        TextNineGrid = 19,
+        JournalCanvas = 20,
+        Multipurpose = 21,
+        Map = 22,
+        Preview = 23,
         // derives from Button
         UnknownButton = 24
     }

--- a/Component/GUI/AtkResNode.cs
+++ b/Component/GUI/AtkResNode.cs
@@ -1,9 +1,9 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace FFXIVClientStructs.Component.GUI
 {
-    public enum NodeType
+    public enum NodeType : ushort
     {
         Res = 1,
         Image = 2,
@@ -47,7 +47,7 @@ namespace FFXIVClientStructs.Component.GUI
         [FieldOffset(0x28)] public AtkResNode* PrevSiblingNode;
         [FieldOffset(0x30)] public AtkResNode* NextSiblingNode;
         [FieldOffset(0x38)] public AtkResNode* ChildNode;
-        [FieldOffset(0x40)] public ushort Type;
+        [FieldOffset(0x40)] public NodeType Type;
         [FieldOffset(0x42)] public ushort ChildCount;
         [FieldOffset(0x44)] public float X; // X,Y converted to floats on load, file is int16
         [FieldOffset(0x48)] public float Y;

--- a/Component/GUI/ULD/ULDComponentInfo.cs
+++ b/Component/GUI/ULD/ULDComponentInfo.cs
@@ -6,6 +6,6 @@ namespace FFXIVClientStructs.Component.GUI.ULD
     public unsafe struct ULDComponentInfo
     {
         [FieldOffset(0x0)] public ULDObjectInfo ObjectInfo;
-        [FieldOffset(0x10)] public byte ComponentType;
+        [FieldOffset(0x10)] public ComponentType ComponentType;
     }
 }

--- a/Component/GUI/ULD/ULDObjectInfo.cs
+++ b/Component/GUI/ULD/ULDObjectInfo.cs
@@ -8,6 +8,5 @@ namespace FFXIVClientStructs.Component.GUI.ULD
         [FieldOffset(0x0)] public uint Id;
         [FieldOffset(0x4)] public int NodeCount;
         [FieldOffset(0x8)] public AtkResNode** NodeList;
-        [FieldOffset(0x10)] public ComponentType ComponentType;
     }
 }

--- a/Component/GUI/ULD/ULDObjectInfo.cs
+++ b/Component/GUI/ULD/ULDObjectInfo.cs
@@ -8,5 +8,6 @@ namespace FFXIVClientStructs.Component.GUI.ULD
         [FieldOffset(0x0)] public uint Id;
         [FieldOffset(0x4)] public int NodeCount;
         [FieldOffset(0x8)] public AtkResNode** NodeList;
+        [FieldOffset(0x10)] public ComponentType ComponentType;
     }
 }


### PR DESCRIPTION
When the ULD objects were moved, ComponentType got deleted for some reason. I still use it in my UIDebug fork, so I know it works at least for my purposes. 

Also, lets make the Structs contain the enum rather than the raw value. if we're going to compare it anyways, just save a step.

Although ComponentType might be a short instead of an int, dunno.