### PR TITLE
Update for C header export

### DIFF
--- a/FFXIV/Client/Graphics/Matrix44.cs
+++ b/FFXIV/Client/Graphics/Matrix44.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using FFXIVClientStructs.STD;
+using System.Runtime.InteropServices;
 
 namespace FFXIVClientStructs.FFXIV.Client.Graphics
 {
@@ -7,21 +8,21 @@ namespace FFXIVClientStructs.FFXIV.Client.Graphics
     {
         [FieldOffset(0x00)] public fixed float Matrix[16];
 
-        [FieldOffset(0x00)] public float Matrix_1_1;
-        [FieldOffset(0x04)] public float Matrix_1_2;
-        [FieldOffset(0x08)] public float Matrix_1_3;
-        [FieldOffset(0x0C)] public float Matrix_1_4;
-        [FieldOffset(0x10)] public float Matrix_2_1;
-        [FieldOffset(0x14)] public float Matrix_2_2;
-        [FieldOffset(0x18)] public float Matrix_2_3;
-        [FieldOffset(0x1C)] public float Matrix_2_4;
-        [FieldOffset(0x20)] public float Matrix_3_1;
-        [FieldOffset(0x24)] public float Matrix_3_2;
-        [FieldOffset(0x28)] public float Matrix_3_3;
-        [FieldOffset(0x2C)] public float Matrix_3_4;
-        [FieldOffset(0x30)] public float Matrix_4_1;
-        [FieldOffset(0x34)] public float Matrix_4_2;
-        [FieldOffset(0x38)] public float Matrix_4_3;
-        [FieldOffset(0x3C)] public float Matrix_4_4;
+        [NoExport] [FieldOffset(0x00)] public float Matrix_1_1;
+        [NoExport] [FieldOffset(0x04)] public float Matrix_1_2;
+        [NoExport] [FieldOffset(0x08)] public float Matrix_1_3;
+        [NoExport] [FieldOffset(0x0C)] public float Matrix_1_4;
+        [NoExport] [FieldOffset(0x10)] public float Matrix_2_1;
+        [NoExport] [FieldOffset(0x14)] public float Matrix_2_2;
+        [NoExport] [FieldOffset(0x18)] public float Matrix_2_3;
+        [NoExport] [FieldOffset(0x1C)] public float Matrix_2_4;
+        [NoExport] [FieldOffset(0x20)] public float Matrix_3_1;
+        [NoExport] [FieldOffset(0x24)] public float Matrix_3_2;
+        [NoExport] [FieldOffset(0x28)] public float Matrix_3_3;
+        [NoExport] [FieldOffset(0x2C)] public float Matrix_3_4;
+        [NoExport] [FieldOffset(0x30)] public float Matrix_4_1;
+        [NoExport] [FieldOffset(0x34)] public float Matrix_4_2;
+        [NoExport] [FieldOffset(0x38)] public float Matrix_4_3;
+        [NoExport] [FieldOffset(0x3C)] public float Matrix_4_4;
     }
 }

--- a/FFXIV/Client/UI/AddonNamePlate.cs
+++ b/FFXIV/Client/UI/AddonNamePlate.cs
@@ -20,8 +20,7 @@ namespace FFXIVClientStructs.FFXIV.Client.UI
         [StructLayout(LayoutKind.Explicit, Size = 0x230)]
         public unsafe struct BakePlateRenderer { }
 
-
-        public static int NumNamePlateObjects = 50;
+        public static int NumNamePlateObjects => 50;
 
         [StructLayout(LayoutKind.Explicit, Size = 0x70)]
         public unsafe struct NamePlateObject
@@ -47,7 +46,7 @@ namespace FFXIVClientStructs.FFXIV.Client.UI
             [FieldOffset(0x6A)] public byte ComponentNodeScale;
 
             public bool IsPlayerCharacter => UnkType == 0;
-            
+
             public bool IsLocalPlayer => IsLocalPlayerValue == 1;
 
             public bool IsVisible => IsVisibleByte == 0;

--- a/FFXIV/Client/UI/AddonTalk.cs
+++ b/FFXIV/Client/UI/AddonTalk.cs
@@ -22,9 +22,6 @@ namespace FFXIVClientStructs.FFXIV.Client.UI
         [FieldOffset(0x3F0)] public Utf8String String3F0;
         [FieldOffset(0x458)] public Utf8String String458;
         [FieldOffset(0x4C0)] public Utf8String String4C0;
-        [FieldOffset(0x590)] public void* vtbl590;
-        [FieldOffset(0x2F0)] public void* vtbl598;
-        [FieldOffset(0x2F8)] public void* unk2F8;
         [FieldOffset(0x5B8)] public AddonTalk* this5B8;
         [FieldOffset(0x5C0)] public AtkStage* AtkStage;
     }

--- a/FFXIVClientStructs.csproj
+++ b/FFXIVClientStructs.csproj
@@ -1,9 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{3DBAEE68-9D94-4807-BCB1-E42EDD52B489}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FFXIVClientStructs</RootNamespace>

--- a/STD/NoExportAttribute.cs
+++ b/STD/NoExportAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace FFXIVClientStructs.STD
+{
+    // This is a placeholder class to signify that the CExporter should not export this member
+    // Its a dirty fix for union issues.
+    public class NoExportAttribute : Attribute { }
+}

--- a/ida/README.md
+++ b/ida/README.md
@@ -1,0 +1,27 @@
+﻿## ffxiv_idarename.py
+
+Despite the name being a misnomer at this point, this script supports both Ghidra and IDA. 
+This script ingests the `data.yml` file in the same directory, and renames various offsets as globals, functions, vtables and such.
+
+Due to switching to a separate yaml format, it has a dependency on PyYaml. 
+
+#### IDA dependency installation:
+`pip install pyyaml` or `python -m pip install pyyaml` in whichever version of python you are currently using with IDA Pro. 
+This could be either Python2 or Python3. 
+
+#### Ghidra dependency installation:
+This is slightly more complicated as Ghidra uses an embedded version of Jython. 
+- Install a copy of Python2 from https://www.python.org/downloads/
+- Execute the following `python.exe -m pip install -t \<YourGhidraFolder\>\Ghidra\Features\Python\data\jython-2.7.2\Lib\site-packages pyyaml`
+- Add `FFXIVClientStructs\ida` as a script directory.
+
+## ffxiv_client_structs.h
+This file along with `ffxiv_client_structs_arrays.h` are rough exports of the C# struct implementations to a C header format.
+The idea being, you can import these into your choice of tool that supports them. At time of writing, both Ghidra and IDA Pro support importing C headers.
+The original file has "gaps" between struct members defined as sequential byte/short/int/long variables.
+The `_arrays` variant uses byte arrays instead.
+
+## classinformer.csv
+Once upon a time, someone did a bad thing and released FFXIV with the RTTI data intact.
+This is an export of that RTTI data using the ClassInformer IDA Pro plugin.
+It is useful as a baseline for many hierarchies and class names, be aware however it is several years old at this point.

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1,4 +1,4 @@
-﻿version: 2020.12.29.0000.0000
+version: 2020.12.29.0000.0000
 
 globals:
   0x14169A2A0: g_HUDScaleTable
@@ -647,7 +647,7 @@ classes:
       0x1404CE7F0: Init
       0x1404CE9C0: SetScale0  # SetScale jumps to this
   Component::GUI::AtkImageNode:
-    inherits_from: &Component::GUI::AtkResNode
+    inherits_from: Component::GUI::AtkResNode
     vtbl: 0x14169AE68
     funcs:
       0x14053FA70: ctor

--- a/ida/ffxiv_client_structs_arrays.h
+++ b/ida/ffxiv_client_structs_arrays.h
@@ -1,0 +1,2387 @@
+// Forward References
+struct Group::Buff;
+struct Group::BuffList;
+struct Group::GroupManager;
+struct Group::PartyMember;
+struct Common::Configuration::ConfigProperties;
+struct Common::Configuration::ConfigValue;
+struct Common::Configuration::ConfigEntry;
+struct Common::Configuration::ChangeEventInterface;
+struct Common::Configuration::ConfigBase;
+struct Common::Configuration::SystemConfig;
+struct Component::GUI::AgentHudLayout;
+struct Component::GUI::AgentInterface;
+struct Component::GUI::AtkCollisionNode;
+struct Component::GUI::AtkComponentBase;
+struct Component::GUI::AtkComponentButton;
+struct Component::GUI::AtkComponentCheckBox;
+struct Component::GUI::AtkComponentDragDrop;
+struct Component::GUI::AtkComponentGaugeBar;
+struct Component::GUI::AtkComponentGuildLeveCard;
+struct Component::GUI::AtkComponentIcon;
+struct Component::GUI::AtkComponentInputBase;
+struct Component::GUI::AtkComponentJournalCanvas;
+struct Component::GUI::AtkComponentList;
+struct Component::GUI::AtkComponentListItemRenderer;
+struct Component::GUI::AtkComponentNode;
+struct Component::GUI::AtkComponentRadioButton;
+struct Component::GUI::AtkComponentScrollBar;
+struct Component::GUI::AtkComponentSlider;
+struct Component::GUI::AtkComponentTextInput;
+struct Component::GUI::AtkComponentTextNineGrid;
+struct Component::GUI::AtkComponentTreeList;
+struct Component::GUI::AtkComponentUnknownButton;
+struct Component::GUI::AtkComponentWindow;
+struct Component::GUI::AtkCounterNode;
+struct Component::GUI::AtkEventListener;
+struct Component::GUI::AtkEventTarget;
+struct Component::GUI::AtkImageNode;
+struct Component::GUI::AtkEventInterface;
+struct Component::GUI::AtkNineGridNode;
+struct Component::GUI::AtkResNode;
+struct Component::GUI::TextureResource;
+struct Component::GUI::AtkStage;
+struct Component::GUI::AtkTextNode;
+struct Component::GUI::AtkTexture;
+struct Component::GUI::AtkUnitBase;
+struct Component::GUI::AtkUnitList;
+struct Component::GUI::AtkUnitManager;
+struct Component::GUI::ULD::ULDComponentDataBase;
+struct Component::GUI::ULD::ULDComponentDataButton;
+struct Component::GUI::ULD::ULDComponentDataCheckBox;
+struct Component::GUI::ULD::ULDComponentDataDragDrop;
+struct Component::GUI::ULD::ULDComponentDataDropDownList;
+struct Component::GUI::ULD::ULDComponentDataGaugeBar;
+struct Component::GUI::ULD::ULDComponentDataGuildLeveCard;
+struct Component::GUI::ULD::ULDComponentDataIcon;
+struct Component::GUI::ULD::ULDComponentDataIconText;
+struct Component::GUI::ULD::ULDComponentDataInputBase;
+struct Component::GUI::ULD::ULDComponentDataJournalCanvas;
+struct Component::GUI::ULD::ULDComponentDataList;
+struct Component::GUI::ULD::ULDComponentDataListItemRenderer;
+struct Component::GUI::ULD::ULDComponentDataMap;
+struct Component::GUI::ULD::ULDComponentDataMultipurpose;
+struct Component::GUI::ULD::ULDComponentDataNumericInput;
+struct Component::GUI::ULD::ULDComponentDataPreview;
+struct Component::GUI::ULD::ULDComponentDataRadioButton;
+struct Component::GUI::ULD::ULDComponentDataScrollBar;
+struct Component::GUI::ULD::ULDComponentDataSlider;
+struct Component::GUI::ULD::ULDComponentDataTab;
+struct Component::GUI::ULD::ULDComponentDataTextInput;
+struct Component::GUI::ULD::ULDComponentDataTextNineGrid;
+struct Component::GUI::ULD::ULDComponentDataTreeList;
+struct Component::GUI::ULD::ULDComponentDataUnknownButton;
+struct Component::GUI::ULD::ULDComponentDataWindow;
+struct Component::GUI::ULD::ULDComponentInfo;
+struct Component::GUI::ULD::ULDData;
+struct Component::GUI::ULD::ULDObjectInfo;
+struct Component::GUI::ULD::ULDPart;
+struct Component::GUI::ULD::ULDPartsList;
+struct Component::GUI::ULD::ULDTexture;
+struct Component::GUI::ULD::ULDWidgetInfo;
+struct Client::UI::AddonContextIconMenu;
+struct Client::UI::AddonGathering;
+struct Client::UI::AddonGatheringMasterpiece;
+struct Client::UI::AddonGuildLeve;
+struct Client::UI::MoveableAddonInfoStruct;
+struct Client::UI::AddonHudLayoutScreen;
+struct Client::UI::AddonHudLayoutWindow;
+struct Client::UI::AddonJournalDetail;
+struct Client::UI::AddonJournalResult;
+struct Client::UI::AddonLotteryDaily;
+struct Client::UI::AddonNamePlate;
+struct Client::UI::AddonRecipeNote;
+struct Client::UI::AddonRequest;
+struct Client::UI::AddonSelectIconString;
+struct Client::UI::AddonSelectString;
+struct Client::UI::AddonSelectYesno;
+struct Client::UI::AddonSynthesize;
+struct Client::UI::AddonTalk;
+struct Client::UI::AddonWeeklyBingo;
+struct Client::UI::StickerSlotList;
+struct Client::UI::StickerSlot;
+struct Client::UI::AddonWeeklyPuzzle;
+struct Client::UI::RaptureAtkModule;
+struct Client::UI::RaptureAtkUnitManager;
+struct Client::UI::UIModule;
+struct Client::System::String::Utf8String;
+struct Client::System::Resource::Handle::ResourceHandle;
+struct Client::System::Resource::Handle::TextureResourceHandle;
+struct Client::System::Framework::Framework;
+struct Client::System::Configuration::SystemConfig;
+struct Client::Graphics::ByteColor;
+struct Client::Graphics::Matrix44;
+struct Client::Graphics::Vector3;
+struct Client::Graphics::Scene::CharacterBase;
+struct Client::Graphics::Scene::DrawObject;
+struct Client::Graphics::Scene::Human;
+struct Client::Graphics::Scene::Object;
+struct Client::Graphics::Physics::BoneSimulators;
+struct Client::Graphics::Physics::BonePhysicsModule;
+struct Client::Graphics::Physics::BoneSimulator;
+struct Client::Graphics::Render::Notifier;
+struct Client::Graphics::Render::Texture;
+struct Client::Graphics::Render::OffscreenRenderingManager;
+struct Client::Game::Object::GameObject;
+struct Client::Game::Character::BattleChara;
+struct Client::Game::Character::Character;
+struct Client::Game::Character::Companion;
+struct Common::Configuration::ConfigProperties::UIntProperties;
+struct Common::Configuration::ConfigProperties::FloatProperties;
+struct Common::Configuration::ConfigProperties::StringProperties;
+struct Component::GUI::AtkComponentList::ListItem;
+struct Client::UI::AddonLotteryDaily::GameTileRow;
+struct Client::UI::AddonLotteryDaily::GameTileBoard;
+struct Client::UI::AddonLotteryDaily::LaneTileSelector;
+struct Client::UI::AddonLotteryDaily::GameNumberRow;
+struct Client::UI::AddonLotteryDaily::GameBoardNumbers;
+struct Client::UI::AddonNamePlate::BakePlateRenderer;
+struct Client::UI::AddonNamePlate::NamePlateObject;
+struct Client::UI::AddonSynthesize::CraftEffect;
+struct Client::UI::AddonWeeklyPuzzle::RewardPanelItem;
+struct Client::UI::AddonWeeklyPuzzle::GameTileBoard;
+struct Client::UI::AddonWeeklyPuzzle::GameTileRow;
+struct Client::UI::AddonWeeklyPuzzle::GameTileItem;
+struct Client::UI::RaptureAtkModule::NamePlateInfo;
+struct Client::UI::UIModule::Unk1;
+struct Client::UI::UIModule::Unk2;
+struct Client::UI::UIModule::Unk3;
+
+// Definitions
+struct Group::Buff /* Size=0xC */
+{
+    /* 0x0 */ unsigned __int16 StatusID;
+    /* 0x2 */ byte Param;
+    /* 0x3 */ byte StackCount;
+    /* 0x4 */ float RemainingTime;
+    /* 0x8 */ unsigned __int32 SourceID;
+};
+
+struct Client::Game::Object::GameObject /* Size=0x1A0 */
+{
+    /*       */ byte _gap_0x0[0x30];
+    /* 0x030 */ byte Name[0x1E];
+    /*       */ byte _gap_0x4E[0x2];
+    /*       */ byte _gap_0x50[0x20];
+    /*       */ byte _gap_0x70[0x4];
+    /* 0x074 */ unsigned __int32 ObjectID;
+    /*       */ byte _gap_0x78[0x10];
+    /*       */ byte _gap_0x88[0x4];
+    /* 0x08C */ byte ObjectKind;
+    /*       */ byte _gap_0x8D;
+    /*       */ byte _gap_0x8E[0x2];
+    /*       */ byte _gap_0x90[0x60];
+    /* 0x0F0 */ void* DrawObject;
+    /*       */ byte _gap_0xF8[0x8];
+    /*       */ byte _gap_0x100[0x4];
+    /* 0x104 */ __int32 RenderFlags;
+    /*       */ byte _gap_0x108[0x98];
+};
+
+struct Client::Game::Character::Character /* Size=0x1934 */
+{
+    /* 0x0000 */ Client::Game::Object::GameObject GameObject;
+    /*        */ byte _gap_0x1A0[0x1568];
+    /* 0x1708 */ byte EquipSlotData[0x28];
+    /*        */ byte _gap_0x1730[0x88];
+    /* 0x17B8 */ byte CustomizeData[0x1A];
+    /*        */ byte _gap_0x17D2[0x2];
+    /*        */ byte _gap_0x17D4[0x4];
+    /*        */ byte _gap_0x17D8[0x158];
+    /* 0x1930 */ unsigned __int32 OwnerID;
+};
+
+struct Group::BuffList /* Size=0x190 */
+{
+    /* 0x000 */ Client::Game::Character::Character* Owner;
+    /* 0x008 */ byte Buffs[0x168];
+    /* 0x170 */ unsigned __int32 Unk_170;
+    /* 0x174 */ unsigned __int16 Unk_174;
+    /*       */ byte _gap_0x176[0x2];
+    /* 0x178 */ __int64 Unk_178;
+    /* 0x180 */ byte Unk_180;
+    /*       */ byte _gap_0x181;
+    /*       */ byte _gap_0x182[0x2];
+    /*       */ byte _gap_0x184[0x4];
+    /*       */ byte _gap_0x188[0x8];
+};
+
+struct Group::GroupManager /* Size=0x3D70 */
+{
+    /* 0x0000 */ byte PartyMembers[0x1180];
+    /* 0x1180 */ byte AllianceMembers[0x2BC0];
+    /* 0x3D40 */ unsigned __int32 Unk_3D40;
+    /* 0x3D44 */ unsigned __int16 Unk_3D44;
+    /*        */ byte _gap_0x3D46[0x2];
+    /* 0x3D48 */ __int64 Unk_3D48;
+    /* 0x3D50 */ __int64 Unk_3D50;
+    /* 0x3D58 */ unsigned __int32 PartyLeaderIndex;
+    /* 0x3D5C */ byte MemberCount;
+    /* 0x3D5D */ byte Unk_3D5D;
+    /* 0x3D5E */ bool IsAlliance;
+    /* 0x3D5F */ byte Unk_3D5F;
+    /* 0x3D60 */ byte Unk_3D60;
+    /*        */ byte _gap_0x3D61;
+    /*        */ byte _gap_0x3D62[0x2];
+    /*        */ byte _gap_0x3D64[0x4];
+    /*        */ byte _gap_0x3D68[0x8];
+};
+
+struct Group::PartyMember /* Size=0x230 */
+{
+    /* 0x000 */ Group::BuffList BuffList;
+    /* 0x190 */ float X;
+    /* 0x194 */ float Y;
+    /* 0x198 */ float Z;
+    /*       */ byte _gap_0x19C[0x4];
+    /* 0x1A0 */ __int64 Unk_1A0;
+    /* 0x1A8 */ unsigned __int32 ObjectID;
+    /* 0x1AC */ unsigned __int32 Unk_ObjectID_1;
+    /* 0x1B0 */ unsigned __int32 Unk_ObjectID_2;
+    /* 0x1B4 */ unsigned __int32 CurrentHP;
+    /* 0x1B8 */ unsigned __int32 MaxHP;
+    /* 0x1BC */ unsigned __int16 CurrentMP;
+    /* 0x1BE */ unsigned __int16 MaxMP;
+    /* 0x1C0 */ unsigned __int16 TerritoryType;
+    /* 0x1C2 */ unsigned __int16 Unk_1C2;
+    /* 0x1C4 */ byte Name[0x40];
+    /* 0x204 */ byte Sex;
+    /* 0x205 */ byte ClassJob;
+    /* 0x206 */ byte Level;
+    /*       */ byte _gap_0x207;
+    /* 0x208 */ byte Unk_Struct_208__0;
+    /*       */ byte _gap_0x209;
+    /*       */ byte _gap_0x20A[0x2];
+    /* 0x20C */ unsigned __int32 Unk_Struct_208__4;
+    /* 0x210 */ unsigned __int16 Unk_Struct_208__8;
+    /*       */ byte _gap_0x212[0x2];
+    /* 0x214 */ unsigned __int32 Unk_Struct_208__C;
+    /* 0x218 */ unsigned __int16 Unk_Struct_208__10;
+    /* 0x21A */ unsigned __int16 Unk_Struct_208__14;
+    /*       */ byte _gap_0x21C[0x4];
+    /* 0x220 */ byte Unk_220;
+    /*       */ byte _gap_0x221;
+    /*       */ byte _gap_0x222[0x2];
+    /*       */ byte _gap_0x224[0x4];
+    /*       */ byte _gap_0x228[0x8];
+};
+
+enum ConfigType: __int32
+{
+    Unused = 0,
+    Category = 1,
+    UInt = 2,
+    Float = 3,
+    String = 4
+};
+
+struct Common::Configuration::ConfigProperties::UIntProperties /* Size=0xC */
+{
+    /* 0x0 */ unsigned __int32 DefaultValue;
+    /* 0x4 */ unsigned __int32 MinValue;
+    /* 0x8 */ unsigned __int32 MaxValue;
+};
+
+struct Common::Configuration::ConfigProperties::FloatProperties /* Size=0xC */
+{
+    /* 0x0 */ float DefaultValue;
+    /* 0x4 */ float MinValue;
+    /* 0x8 */ float MaxValue;
+};
+
+struct Client::System::String::Utf8String /* Size=0x68 */
+{
+    /* 0x00 */ byte* StringPtr;
+    /* 0x08 */ __int64 BufSize;
+    /* 0x10 */ __int64 BufUsed;
+    /* 0x18 */ __int64 StringLength;
+    /* 0x20 */ unsigned __int16 Unk;
+    /* 0x22 */ byte InlineBuffer[0x40];
+    /*      */ byte _gap_0x62[0x2];
+    /*      */ byte _gap_0x64[0x4];
+};
+
+struct Common::Configuration::ConfigProperties::StringProperties /* Size=0x8 */
+{
+    /* 0x0 */ Client::System::String::Utf8String* DefaultValue;
+};
+
+struct Common::Configuration::ConfigProperties /* Size=0x10 */
+{
+    union {
+    /* 0x00 */ Common::Configuration::ConfigProperties::UIntProperties UInt;
+    /* 0x00 */ Common::Configuration::ConfigProperties::FloatProperties Float;
+    /* 0x00 */ Common::Configuration::ConfigProperties::StringProperties String;
+    } _union_0x0;
+    /*      */ byte _gap_0x8[0x8];
+};
+
+struct Common::Configuration::ConfigValue /* Size=0x8 */
+{
+    union {
+    /* 0x0 */ unsigned __int32 UInt;
+    /* 0x0 */ float Float;
+    /* 0x0 */ Client::System::String::Utf8String* String;
+    } _union_0x0;
+};
+
+struct Common::Configuration::ChangeEventInterface /* Size=0x18 */
+{
+    /* 0x00 */ void* vtbl;
+    /* 0x08 */ Common::Configuration::ChangeEventInterface* Next;
+    /* 0x10 */ Common::Configuration::ConfigBase* Owner;
+};
+
+struct Common::Configuration::ConfigBase /* Size=0x110 */
+{
+    /* 0x000 */ void* vtbl;
+    /* 0x008 */ Common::Configuration::ChangeEventInterface* Listener;
+    /*       */ byte _gap_0x10[0x4];
+    /* 0x014 */ unsigned __int32 ConfigCount;
+    /* 0x018 */ Common::Configuration::ConfigEntry* ConfigEntry;
+    /*       */ byte _gap_0x20[0x30];
+    /* 0x050 */ Client::System::String::Utf8String UnkString;
+    /*       */ byte _gap_0xB8[0x58];
+};
+
+struct Common::Configuration::ConfigEntry /* Size=0x38 */
+{
+    /* 0x00 */ Common::Configuration::ConfigProperties Properties;
+    /* 0x10 */ byte* Name;
+    /* 0x18 */ __int32 Type;
+    /*      */ byte _gap_0x1C[0x4];
+    /* 0x20 */ Common::Configuration::ConfigValue Value;
+    /* 0x28 */ Common::Configuration::ConfigBase* Owner;
+    /* 0x30 */ unsigned __int32 Index;
+    /* 0x34 */ unsigned __int32 _Padding;
+};
+
+struct Common::Configuration::SystemConfig /* Size=0x450 */
+{
+    /* 0x000 */ Common::Configuration::ConfigBase ConfigBase;
+    /*       */ byte _gap_0x110[0x340];
+};
+
+struct Component::GUI::AtkEventInterface /* Size=0x8 */
+{
+    /* 0x0 */ void* vtbl;
+};
+
+struct Component::GUI::AgentInterface /* Size=0x28 */
+{
+    /* 0x00 */ Component::GUI::AtkEventInterface AtkEventInterface;
+    /*      */ byte _gap_0x8[0x20];
+};
+
+struct Component::GUI::AgentHudLayout /* Size=0x78 */
+{
+    /* 0x00 */ Component::GUI::AgentInterface AgentInterface;
+    /*      */ byte _gap_0x28[0x48];
+    /* 0x70 */ bool NeedToSave;
+    /*      */ byte _gap_0x71;
+    /*      */ byte _gap_0x72[0x2];
+    /*      */ byte _gap_0x74[0x4];
+};
+
+enum CollisionType: unsigned __int16
+{
+    Hit = 0,
+    Focus = 1,
+    Move = 2
+};
+
+struct Component::GUI::AtkEventTarget /* Size=0x8 */
+{
+    union {
+    /* 0x0 */ void* vtbl;
+    /* 0x0 */ void** vfunc;
+    } _union_0x0;
+};
+
+enum NodeType: unsigned __int16
+{
+    Res = 1,
+    Image = 2,
+    Text = 3,
+    NineGrid = 4,
+    Counter = 5,
+    Collision = 8
+};
+
+struct Client::Graphics::ByteColor /* Size=0x4 */
+{
+    /* 0x0 */ byte R;
+    /* 0x1 */ byte G;
+    /* 0x2 */ byte B;
+    /* 0x3 */ byte A;
+};
+
+struct Component::GUI::AtkResNode /* Size=0xA8 */
+{
+    /* 0x00 */ Component::GUI::AtkEventTarget AtkEventTarget;
+    /* 0x08 */ unsigned __int32 NodeID;
+    /*      */ byte _gap_0xC[0x4];
+    /*      */ byte _gap_0x10[0x10];
+    /* 0x20 */ Component::GUI::AtkResNode* ParentNode;
+    /* 0x28 */ Component::GUI::AtkResNode* PrevSiblingNode;
+    /* 0x30 */ Component::GUI::AtkResNode* NextSiblingNode;
+    /* 0x38 */ Component::GUI::AtkResNode* ChildNode;
+    /* 0x40 */ Component::GUI::NodeType Type;
+    /* 0x42 */ unsigned __int16 ChildCount;
+    /* 0x44 */ float X;
+    /* 0x48 */ float Y;
+    /* 0x4C */ float ScaleX;
+    /* 0x50 */ float ScaleY;
+    /* 0x54 */ float Rotation;
+    /* 0x58 */ float UnkMatrix[0x6];
+    /* 0x70 */ Client::Graphics::ByteColor Color;
+    /* 0x74 */ float Depth;
+    /* 0x78 */ float Depth_2;
+    /* 0x7C */ unsigned __int16 AddRed;
+    /* 0x7E */ unsigned __int16 AddGreen;
+    /* 0x80 */ unsigned __int16 AddBlue;
+    /* 0x82 */ unsigned __int16 AddRed_2;
+    /* 0x84 */ unsigned __int16 AddGreen_2;
+    /* 0x86 */ unsigned __int16 AddBlue_2;
+    /* 0x88 */ byte MultiplyRed;
+    /* 0x89 */ byte MultiplyGreen;
+    /* 0x8A */ byte MultiplyBlue;
+    /* 0x8B */ byte MultiplyRed_2;
+    /* 0x8C */ byte MultiplyGreen_2;
+    /* 0x8D */ byte MultiplyBlue_2;
+    /* 0x8E */ byte Alpha_2;
+    /* 0x8F */ byte UnkByte_1;
+    /* 0x90 */ unsigned __int16 Width;
+    /* 0x92 */ unsigned __int16 Height;
+    /* 0x94 */ float OriginX;
+    /* 0x98 */ float OriginY;
+    /* 0x9C */ unsigned __int16 Priority;
+    /* 0x9E */ __int16 Flags;
+    /* 0xA0 */ unsigned __int32 Flags_2;
+    /*      */ byte _gap_0xA4[0x4];
+};
+
+struct Component::GUI::AtkEventListener /* Size=0x8 */
+{
+    union {
+    /* 0x0 */ void* vtbl;
+    /* 0x0 */ void** vfunc;
+    } _union_0x0;
+};
+
+struct Client::System::Resource::Handle::ResourceHandle /* Size=0xA8 */
+{
+    /*      */ byte _gap_0x0[0x10];
+    /*      */ byte _gap_0x10[0x2];
+    /* 0x12 */ unsigned __int32 FileType;
+    /*      */ byte _gap_0x16[0x2];
+    /*      */ byte _gap_0x18[0x30];
+    /* 0x48 */ char* FileName;
+    /*      */ byte _gap_0x50[0x58];
+};
+
+struct Client::System::Resource::Handle::TextureResourceHandle /* Size=0x128 */
+{
+    /* 0x000 */ Client::System::Resource::Handle::ResourceHandle ResourceHandle;
+    /*       */ byte _gap_0xA8[0x80];
+};
+
+struct Client::Graphics::Render::Notifier /* Size=0x18 */
+{
+    /* 0x00 */ void* vtbl;
+    /* 0x08 */ Client::Graphics::Render::Notifier* Next;
+    /* 0x10 */ Client::Graphics::Render::Notifier* Prev;
+};
+
+enum TextureFormat: unsigned __int32
+{
+    R8G8B8A8 = 5200,
+    D24S8 = 16976
+};
+
+struct Client::Graphics::Render::Texture /* Size=0xA8 */
+{
+    /* 0x00 */ void* vtbl;
+    /*      */ byte _gap_0x8[0x18];
+    /* 0x20 */ Client::Graphics::Render::Notifier Notifier;
+    /* 0x38 */ unsigned __int32 Width;
+    /* 0x3C */ unsigned __int32 Height;
+    /* 0x40 */ unsigned __int32 Depth;
+    /* 0x44 */ byte MipLevel;
+    /* 0x45 */ byte Unk_35;
+    /* 0x46 */ byte Unk_36;
+    /* 0x47 */ byte Unk_37;
+    /* 0x48 */ Client::Graphics::Render::TextureFormat TextureFormat;
+    /* 0x4C */ unsigned __int32 Flags;
+    /* 0x50 */ void* D3D11Texture2D;
+    /* 0x58 */ void* D3D11ShaderResourceView;
+    /*      */ byte _gap_0x60[0x48];
+};
+
+struct Component::GUI::TextureResource /* Size=0x20 */
+{
+    /* 0x00 */ unsigned __int32 TexPathHash;
+    /* 0x04 */ unsigned __int32 Unk_1;
+    /* 0x08 */ Client::System::Resource::Handle::TextureResourceHandle* TexFileResourceHandle;
+    /* 0x10 */ Client::Graphics::Render::Texture* KernelTextureObject;
+    /* 0x18 */ unsigned __int16 Count_1;
+    /* 0x1A */ byte Count_2;
+    /*      */ byte _gap_0x1B;
+    /*      */ byte _gap_0x1C[0x4];
+};
+
+enum TextureType: byte
+{
+    Resource = 1,
+    Crest = 2,
+    KernelTexture = 3
+};
+
+struct Component::GUI::AtkTexture /* Size=0x18 */
+{
+    /* 0x00 */ void* vtbl;
+    union {
+    /* 0x08 */ Component::GUI::TextureResource* Resource;
+    /* 0x08 */ void* Crest;
+    /* 0x08 */ Client::Graphics::Render::Texture* KernelTexture;
+    } _union_0x8;
+    /* 0x10 */ Component::GUI::TextureType TextureType;
+    /* 0x11 */ byte UnkBool_2;
+    /*      */ byte _gap_0x12[0x2];
+    /*      */ byte _gap_0x14[0x4];
+};
+
+struct Component::GUI::ULD::ULDTexture /* Size=0x20 */
+{
+    /* 0x00 */ unsigned __int32 Id;
+    /*      */ byte _gap_0x4[0x4];
+    /* 0x08 */ Component::GUI::AtkTexture AtkTexture;
+};
+
+struct Component::GUI::ULD::ULDPart /* Size=0x10 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDTexture* ULDTexture;
+    /* 0x08 */ unsigned __int16 U;
+    /* 0x0A */ unsigned __int16 V;
+    /* 0x0C */ unsigned __int16 Width;
+    /* 0x0E */ unsigned __int16 Height;
+};
+
+struct Component::GUI::ULD::ULDPartsList /* Size=0x10 */
+{
+    /* 0x00 */ unsigned __int32 Id;
+    /* 0x04 */ unsigned __int32 PartCount;
+    /* 0x08 */ Component::GUI::ULD::ULDPart* Parts;
+};
+
+struct Component::GUI::ULD::ULDObjectInfo /* Size=0x10 */
+{
+    /* 0x00 */ unsigned __int32 Id;
+    /* 0x04 */ __int32 NodeCount;
+    /* 0x08 */ Component::GUI::AtkResNode** NodeList;
+};
+
+struct Component::GUI::ULD::ULDComponentDataBase /* Size=0x9 */
+{
+    /* 0x0 */ byte Index;
+    /* 0x1 */ byte Up;
+    /* 0x2 */ byte Down;
+    /* 0x3 */ byte Left;
+    /* 0x4 */ byte Right;
+    /* 0x5 */ byte Cursor;
+    /* 0x6 */ byte OffsetX;
+    /* 0x7 */ byte OffsetY;
+    /* 0x8 */ byte Unk;
+};
+
+struct Component::GUI::ULD::ULDData /* Size=0x90 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDTexture* Textures;
+    /* 0x08 */ Component::GUI::ULD::ULDPartsList* PartsList;
+    /* 0x10 */ Component::GUI::ULD::ULDObjectInfo* Objects;
+    /* 0x18 */ Component::GUI::ULD::ULDComponentDataBase* ComponentData;
+    /* 0x20 */ unsigned __int16 TextureCount;
+    /* 0x22 */ unsigned __int16 PartsListCount;
+    /* 0x24 */ unsigned __int16 ObjectCount;
+    /*      */ byte _gap_0x26[0x2];
+    /* 0x28 */ void* UldResourceHandle;
+    /*      */ byte _gap_0x30[0x10];
+    /*      */ byte _gap_0x40[0x2];
+    /* 0x42 */ unsigned __int16 NodeListCount;
+    /*      */ byte _gap_0x44[0x4];
+    /* 0x48 */ void* AtkResourceRendererManager;
+    /* 0x50 */ Component::GUI::AtkResNode** NodeList;
+    /*      */ byte _gap_0x58[0x20];
+    /* 0x78 */ Component::GUI::AtkResNode* RootNode;
+    /* 0x80 */ unsigned __int16 RootNodeWidth;
+    /* 0x82 */ unsigned __int16 RootNodeHeight;
+    /*      */ byte _gap_0x84[0x2];
+    /* 0x86 */ byte Flags1;
+    /*      */ byte _gap_0x87;
+    /*      */ byte _gap_0x88;
+    /* 0x89 */ byte LoadedState;
+    /*      */ byte _gap_0x8A[0x2];
+    /*      */ byte _gap_0x8C[0x4];
+};
+
+struct Component::GUI::AtkComponentNode /* Size=0xB0 */
+{
+    /* 0x00 */ Component::GUI::AtkResNode AtkResNode;
+    /* 0xA8 */ Component::GUI::AtkComponentBase* Component;
+};
+
+struct Component::GUI::AtkComponentBase /* Size=0xC0 */
+{
+    /* 0x00 */ Component::GUI::AtkEventListener AtkEventListener;
+    /* 0x08 */ Component::GUI::ULD::ULDData ULDData;
+    /*      */ byte _gap_0x98[0x10];
+    /* 0xA8 */ Component::GUI::AtkComponentNode* OwnerNode;
+    /*      */ byte _gap_0xB0[0x10];
+};
+
+struct Component::GUI::AtkCollisionNode /* Size=0xB8 */
+{
+    /* 0x00 */ Component::GUI::AtkResNode AtkResNode;
+    /* 0xA8 */ unsigned __int16 CollisionType;
+    /* 0xAA */ unsigned __int16 Uses;
+    /*      */ byte _gap_0xAC[0x4];
+    /* 0xB0 */ Component::GUI::AtkComponentBase* LinkedComponent;
+};
+
+enum ComponentType: byte
+{
+    Base = 0,
+    Button = 1,
+    Window = 2,
+    CheckBox = 3,
+    RadioButton = 4,
+    GaugeBar = 5,
+    Slider = 6,
+    TextInput = 7,
+    NumericInput = 8,
+    List = 9,
+    DropDownList = 10,
+    Tab = 11,
+    TreeList = 12,
+    ScrollBar = 13,
+    ListItemRenderer = 14,
+    Icon = 15,
+    IconText = 16,
+    DragDrop = 17,
+    GuildLeveCard = 18,
+    TextNineGrid = 19,
+    JournalCanvas = 20,
+    Multipurpose = 21,
+    Map = 22,
+    Preview = 23,
+    UnknownButton = 24
+};
+
+struct Component::GUI::AtkTextNode /* Size=0x158 */
+{
+    /* 0x000 */ Component::GUI::AtkResNode AtkResNode;
+    /* 0x0A8 */ unsigned __int32 TextId;
+    /* 0x0AC */ Client::Graphics::ByteColor TextColor;
+    /* 0x0B0 */ Client::Graphics::ByteColor EdgeColor;
+    /* 0x0B4 */ Client::Graphics::ByteColor BackgroundColor;
+    /* 0x0B8 */ Client::System::String::Utf8String NodeText;
+    /*       */ byte _gap_0x120[0x8];
+    /* 0x128 */ unsigned __int32 SelectStart;
+    /* 0x12C */ unsigned __int32 SelectEnd;
+    /*       */ byte _gap_0x130[0x18];
+    /*       */ byte _gap_0x148[0x2];
+    /* 0x14A */ byte LineSpacing;
+    /* 0x14B */ byte CharSpacing;
+    /* 0x14C */ byte AlignmentFontType;
+    /* 0x14D */ byte FontSize;
+    /* 0x14E */ byte SheetType;
+    /*       */ byte _gap_0x14F;
+    /*       */ byte _gap_0x150[0x2];
+    /* 0x152 */ byte TextFlags;
+    /* 0x153 */ byte TextFlags2;
+    /*       */ byte _gap_0x154[0x4];
+};
+
+struct Component::GUI::AtkComponentButton /* Size=0xF0 */
+{
+    /* 0x00 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /* 0xC0 */ __int16 Left;
+    /* 0xC2 */ __int16 Top;
+    /* 0xC4 */ __int16 Right;
+    /* 0xC6 */ __int16 Bottom;
+    /* 0xC8 */ Component::GUI::AtkTextNode* ButtonTextNode;
+    /* 0xD0 */ Component::GUI::AtkResNode* ButtonBGNode;
+    /*      */ byte _gap_0xD8[0x18];
+};
+
+struct Component::GUI::AtkComponentCheckBox /* Size=0x110 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentButton AtkComponentButton;
+    /*       */ byte _gap_0xF0[0x20];
+};
+
+struct Component::GUI::AtkComponentDragDrop /* Size=0x110 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /*       */ byte _gap_0xC0[0x50];
+};
+
+struct Component::GUI::AtkComponentGaugeBar /* Size=0x1A8 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /*       */ byte _gap_0xC0[0xE8];
+};
+
+struct Component::GUI::AtkComponentGuildLeveCard /* Size=0xF0 */
+{
+    /* 0x00 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /*      */ byte _gap_0xC0[0x30];
+};
+
+struct Component::GUI::AtkImageNode /* Size=0xB8 */
+{
+    /* 0x00 */ Component::GUI::AtkResNode AtkResNode;
+    /* 0xA8 */ Component::GUI::ULD::ULDPartsList* PartsList;
+    /* 0xB0 */ unsigned __int16 PartId;
+    /* 0xB2 */ byte WrapMode;
+    /* 0xB3 */ byte Flags;
+    /*      */ byte _gap_0xB4[0x4];
+};
+
+enum IconComponentFlags: unsigned __int32
+{
+    None = 0,
+    DyeIcon = 8,
+    Macro = 16,
+    GlamourIcon = 32,
+    Moving = 256,
+    Casting = 1024,
+    InventoryItem = 2048
+};
+
+struct Component::GUI::AtkComponentIcon /* Size=0x118 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /* 0x0C0 */ __int64 IconId;
+    /* 0x0C8 */ Component::GUI::ULD::ULDTexture* Texture;
+    /* 0x0D0 */ Component::GUI::AtkResNode* IconAdditionsContainer;
+    /* 0x0D8 */ Component::GUI::AtkResNode* ComboBorder;
+    /* 0x0E0 */ Component::GUI::AtkResNode* Frame;
+    /* 0x0E8 */ __int64 Unknown0E8;
+    /* 0x0F0 */ Component::GUI::AtkImageNode* IconImage;
+    /* 0x0F8 */ Component::GUI::AtkImageNode* FrameIcon;
+    /* 0x100 */ Component::GUI::AtkImageNode* UnknownImageNode;
+    /* 0x108 */ Component::GUI::AtkTextNode* QuantityText;
+    /*       */ byte _gap_0x110[0x4];
+    /* 0x114 */ Component::GUI::IconComponentFlags Flags;
+};
+
+struct Component::GUI::AtkComponentInputBase /* Size=0x1B0 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /*       */ byte _gap_0xC0[0x20];
+    /* 0x0E0 */ Client::System::String::Utf8String UnkText1;
+    /* 0x148 */ Client::System::String::Utf8String UnkText2;
+};
+
+struct Component::GUI::AtkComponentJournalCanvas /* Size=0x520 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /*       */ byte _gap_0xC0[0x460];
+};
+
+struct Component::GUI::AtkComponentListItemRenderer /* Size=0x1A8 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentButton AtkComponentButton;
+    /*       */ byte _gap_0xF0[0xB8];
+};
+
+struct Component::GUI::AtkComponentScrollBar /* Size=0x140 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /*       */ byte _gap_0xC0[0x80];
+};
+
+struct Component::GUI::AtkComponentList::ListItem /* Size=0x18 */
+{
+    /*      */ byte _gap_0x0[0x8];
+    /* 0x08 */ Component::GUI::AtkComponentListItemRenderer* AtkComponentListItemRenderer;
+    /*      */ byte _gap_0x10[0x8];
+};
+
+struct Component::GUI::AtkComponentList /* Size=0x1A8 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /* 0x0C0 */ Component::GUI::AtkComponentListItemRenderer* FirstAtkComponentListItemRenderer;
+    /* 0x0C8 */ Component::GUI::AtkComponentScrollBar* AtkComponentScrollBarC8;
+    /*       */ byte _gap_0xD0[0x20];
+    /* 0x0F0 */ Component::GUI::AtkComponentList::ListItem* ItemRendererList;
+    /*       */ byte _gap_0xF8[0x20];
+    /* 0x118 */ __int32 ListLength;
+    /*       */ byte _gap_0x11C[0x4];
+    /*       */ byte _gap_0x120[0x88];
+};
+
+struct Component::GUI::AtkComponentRadioButton /* Size=0xF8 */
+{
+    /* 0x00 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /*      */ byte _gap_0xC0[0x38];
+};
+
+struct Component::GUI::AtkComponentSlider /* Size=0x100 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /*       */ byte _gap_0xC0[0x40];
+};
+
+struct Component::GUI::AtkComponentTextInput /* Size=0x600 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentInputBase AtkComponentInputBase;
+    /*       */ byte _gap_0x1B0[0xD0];
+    /* 0x280 */ Client::System::String::Utf8String UnkText1;
+    /* 0x2E8 */ Client::System::String::Utf8String UnkText2;
+    /* 0x350 */ Client::System::String::Utf8String UnkText3;
+    /*       */ byte _gap_0x3B8[0x98];
+    /* 0x450 */ Client::System::String::Utf8String UnkText4;
+    /* 0x4B8 */ Client::System::String::Utf8String UnkText5;
+    /*       */ byte _gap_0x520[0xE0];
+};
+
+struct Component::GUI::AtkComponentTextNineGrid /* Size=0xD8 */
+{
+    /* 0x00 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /*      */ byte _gap_0xC0[0x18];
+};
+
+struct Component::GUI::AtkComponentTreeList /* Size=0x220 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentList AtkComponentList;
+    /*       */ byte _gap_0x1A8[0x78];
+};
+
+struct Component::GUI::AtkComponentUnknownButton /* Size=0x120 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /*       */ byte _gap_0xC0[0x60];
+};
+
+struct Component::GUI::AtkComponentWindow /* Size=0x108 */
+{
+    /* 0x000 */ Component::GUI::AtkComponentBase AtkComponentBase;
+    /*       */ byte _gap_0xC0[0x48];
+};
+
+struct Component::GUI::AtkCounterNode /* Size=0x128 */
+{
+    /* 0x000 */ Component::GUI::AtkResNode AtkResNode;
+    /* 0x0A8 */ Component::GUI::ULD::ULDPartsList* PartsList;
+    /* 0x0B0 */ unsigned __int32 PartId;
+    /* 0x0B4 */ byte NumberWidth;
+    /* 0x0B5 */ byte CommaWidth;
+    /* 0x0B6 */ byte SpaceWidth;
+    /*       */ byte _gap_0xB7;
+    /* 0x0B8 */ unsigned __int16 TextAlign;
+    /*       */ byte _gap_0xBA[0x2];
+    /* 0x0BC */ float Width;
+    /* 0x0C0 */ Client::System::String::Utf8String NodeText;
+};
+
+enum ImageNodeFlags: __int32
+{
+    FlipH = 1,
+    FlipV = 2,
+    AutoFit = 128
+};
+
+struct Component::GUI::AtkNineGridNode /* Size=0xC8 */
+{
+    /* 0x00 */ Component::GUI::AtkResNode AtkResNode;
+    /* 0xA8 */ Component::GUI::ULD::ULDPartsList* PartsList;
+    /* 0xB0 */ unsigned __int32 PartID;
+    /* 0xB4 */ __int16 TopOffset;
+    /* 0xB6 */ __int16 BottomOffset;
+    /* 0xB8 */ __int16 LeftOffset;
+    /* 0xBA */ __int16 RightOffset;
+    /* 0xBC */ unsigned __int32 BlendMode;
+    /* 0xC0 */ byte PartsTypeRenderType;
+    /*      */ byte _gap_0xC1;
+    /*      */ byte _gap_0xC2[0x2];
+    /*      */ byte _gap_0xC4[0x4];
+};
+
+enum NodeFlags: __int32
+{
+    AnchorTop = 1,
+    AnchorLeft = 2,
+    AnchorBottom = 4,
+    AnchorRight = 8,
+    Visible = 16,
+    Enabled = 32,
+    Clip = 64,
+    Fill = 128,
+    HasCollision = 256,
+    RespondToMouse = 512
+};
+
+struct Component::GUI::AtkUnitBase /* Size=0x220 */
+{
+    /* 0x000 */ Component::GUI::AtkEventListener AtkEventListener;
+    /* 0x008 */ byte Name[0x20];
+    /* 0x028 */ Component::GUI::ULD::ULDData ULDData;
+    /*       */ byte _gap_0xB8[0x10];
+    /* 0x0C8 */ Component::GUI::AtkResNode* RootNode;
+    /*       */ byte _gap_0xD0[0x38];
+    /* 0x108 */ Component::GUI::AtkComponentNode* WindowNode;
+    /*       */ byte _gap_0x110[0x70];
+    /*       */ byte _gap_0x180[0x2];
+    /* 0x182 */ byte Flags;
+    /*       */ byte _gap_0x183;
+    /*       */ byte _gap_0x184[0x4];
+    /*       */ byte _gap_0x188[0x20];
+    /*       */ byte _gap_0x1A8[0x4];
+    /* 0x1AC */ float Scale;
+    /*       */ byte _gap_0x1B0[0x8];
+    /*       */ byte _gap_0x1B8[0x4];
+    /* 0x1BC */ __int16 X;
+    /* 0x1BE */ __int16 Y;
+    /*       */ byte _gap_0x1C0[0x10];
+    /*       */ byte _gap_0x1D0[0x4];
+    /*       */ byte _gap_0x1D4;
+    /* 0x1D5 */ byte Alpha;
+    /*       */ byte _gap_0x1D6[0x2];
+    /* 0x1D8 */ Component::GUI::AtkCollisionNode** CollisionNodeList;
+    /* 0x1E0 */ unsigned __int32 CollisionNodeListCount;
+    /*       */ byte _gap_0x1E4[0x4];
+    /*       */ byte _gap_0x1E8[0x38];
+};
+
+struct Component::GUI::AtkUnitList /* Size=0x810 */
+{
+    /* 0x000 */ void* vtbl;
+    /* 0x008 */ Component::GUI::AtkUnitBase* AtkUnitEntries;
+    /*       */ byte _gap_0x10[0x7F8];
+    /* 0x808 */ unsigned __int32 Count;
+    /*       */ byte _gap_0x80C[0x4];
+};
+
+struct Component::GUI::AtkUnitManager /* Size=0x9C80 */
+{
+    /* 0x0000 */ Component::GUI::AtkEventListener AtkEventListener;
+    /*        */ byte _gap_0x8[0x28];
+    /* 0x0030 */ Component::GUI::AtkUnitList DepthLayerOneList;
+    /* 0x0840 */ Component::GUI::AtkUnitList DepthLayerTwoList;
+    /* 0x1050 */ Component::GUI::AtkUnitList DepthLayerThreeList;
+    /* 0x1860 */ Component::GUI::AtkUnitList DepthLayerFourList;
+    /* 0x2070 */ Component::GUI::AtkUnitList DepthLayerFiveList;
+    /* 0x2880 */ Component::GUI::AtkUnitList DepthLayerSixList;
+    /* 0x3090 */ Component::GUI::AtkUnitList DepthLayerSevenList;
+    /* 0x38A0 */ Component::GUI::AtkUnitList DepthLayerEightList;
+    /* 0x40B0 */ Component::GUI::AtkUnitList DepthLayerNineList;
+    /* 0x48C0 */ Component::GUI::AtkUnitList DepthLayerTenList;
+    /* 0x50D0 */ Component::GUI::AtkUnitList DepthLayerElevenList;
+    /* 0x58E0 */ Component::GUI::AtkUnitList DepthLayerTwelveList;
+    /* 0x60F0 */ Component::GUI::AtkUnitList DepthLayerThirteenList;
+    /* 0x6900 */ Component::GUI::AtkUnitList AllLoadedUnitsList;
+    /* 0x7110 */ Component::GUI::AtkUnitList FocusedUnitsList;
+    /* 0x7920 */ Component::GUI::AtkUnitList UnitList16;
+    /* 0x8130 */ Component::GUI::AtkUnitList UnitList17;
+    /* 0x8940 */ Component::GUI::AtkUnitList UnitList18;
+    /*        */ byte _gap_0x9150[0xB30];
+};
+
+struct Client::UI::RaptureAtkUnitManager /* Size=0x9D2C */
+{
+    /* 0x0000 */ Component::GUI::AtkUnitManager AtkUnitManager;
+    /*        */ byte _gap_0x9C80[0xA8];
+    /*        */ byte _gap_0x9D28[0x4];
+};
+
+struct Component::GUI::AtkStage /* Size=0x75DF8 */
+{
+    /* 0x00000 */ Component::GUI::AtkEventTarget AtkEventTarget;
+    /*         */ byte _gap_0x8[0x18];
+    /* 0x00020 */ Client::UI::RaptureAtkUnitManager* RaptureAtkUnitManager;
+    /*         */ byte _gap_0x28[0x75DD0];
+};
+
+enum TextFlags: __int32
+{
+    Unk = 1,
+    Bold = 2,
+    Italic = 4,
+    Edge = 8,
+    Glare = 16,
+    Emboss = 32,
+    WordWrap = 64,
+    MultiLine = 128
+};
+
+enum TextFlags2: __int32
+{
+    Ellipsis = 4
+};
+
+struct Component::GUI::ULD::ULDComponentDataButton /* Size=0x18 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x2];
+    /* 0x14 */ unsigned __int32 TextId;
+};
+
+struct Component::GUI::ULD::ULDComponentDataCheckBox /* Size=0x1C */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x3];
+    /* 0x18 */ unsigned __int32 TextId;
+};
+
+struct Component::GUI::ULD::ULDComponentDataDragDrop /* Size=0x10 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x1];
+};
+
+struct Component::GUI::ULD::ULDComponentDataDropDownList /* Size=0x14 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x2];
+};
+
+struct Component::GUI::ULD::ULDComponentDataGaugeBar /* Size=0x3C */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x6];
+    /* 0x24 */ unsigned __int16 MarginV;
+    /* 0x26 */ unsigned __int16 MarginH;
+    /* 0x28 */ byte Vertical;
+    /*      */ byte _gap_0x29;
+    /*      */ byte _gap_0x2A[0x2];
+    /* 0x2C */ __int32 Indicator;
+    /* 0x30 */ __int32 Min;
+    /* 0x34 */ __int32 Max;
+    /* 0x38 */ __int32 Value;
+};
+
+struct Component::GUI::ULD::ULDComponentDataGuildLeveCard /* Size=0x1C */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x3];
+    /*      */ byte _gap_0x18[0x4];
+};
+
+struct Component::GUI::ULD::ULDComponentDataIcon /* Size=0x2C */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x8];
+};
+
+struct Component::GUI::ULD::ULDComponentDataIconText /* Size=0x14 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x2];
+};
+
+struct Component::GUI::ULD::ULDComponentDataInputBase /* Size=0x10 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ Client::Graphics::ByteColor FocusColor;
+};
+
+struct Component::GUI::ULD::ULDComponentDataJournalCanvas /* Size=0x94 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x20];
+    /* 0x8C */ unsigned __int16 ItemMargin;
+    /* 0x8E */ unsigned __int16 BasicMargin;
+    /* 0x90 */ unsigned __int16 AnotherMargin;
+    /* 0x92 */ unsigned __int16 Padding;
+};
+
+struct Component::GUI::ULD::ULDComponentDataList /* Size=0x28 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x5];
+    /* 0x20 */ byte Wrap;
+    /* 0x21 */ byte Orientation;
+    /* 0x22 */ unsigned __int16 RowNum;
+    /* 0x24 */ unsigned __int16 ColNum;
+    /*      */ byte _gap_0x26[0x2];
+};
+
+struct Component::GUI::ULD::ULDComponentDataListItemRenderer /* Size=0x20 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x4];
+    /* 0x1C */ byte CanToggle;
+    /*      */ byte _gap_0x1D;
+    /*      */ byte _gap_0x1E[0x2];
+};
+
+struct Component::GUI::ULD::ULDComponentDataMap /* Size=0x34 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0xA];
+};
+
+struct Component::GUI::ULD::ULDComponentDataMultipurpose /* Size=0x18 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x3];
+};
+
+struct Component::GUI::ULD::ULDComponentDataNumericInput /* Size=0x3C */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataInputBase InputBase;
+    /* 0x10 */ unsigned __int32 Nodes[0x5];
+    /* 0x24 */ __int32 Value;
+    /* 0x28 */ __int32 Min;
+    /* 0x2C */ __int32 Max;
+    /* 0x30 */ __int32 Add;
+    /* 0x34 */ unsigned __int32 EndLetterId;
+    /* 0x38 */ byte Comma;
+    /*      */ byte _gap_0x39;
+    /*      */ byte _gap_0x3A[0x2];
+};
+
+struct Component::GUI::ULD::ULDComponentDataPreview /* Size=0x14 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x2];
+};
+
+struct Component::GUI::ULD::ULDComponentDataRadioButton /* Size=0x24 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x4];
+    /* 0x1C */ unsigned __int32 TextId;
+    /* 0x20 */ unsigned __int32 GroupId;
+};
+
+struct Component::GUI::ULD::ULDComponentDataScrollBar /* Size=0x20 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x4];
+    /* 0x1C */ unsigned __int16 Margin;
+    /* 0x1E */ byte Vertical;
+    /*      */ byte _gap_0x1F;
+};
+
+struct Component::GUI::ULD::ULDComponentDataSlider /* Size=0x34 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x4];
+    /* 0x1C */ __int32 Min;
+    /* 0x20 */ __int32 Max;
+    /* 0x24 */ __int32 Step;
+    /* 0x28 */ __int32 OfffsetL;
+    /* 0x2C */ __int32 OffsetR;
+    /* 0x30 */ byte Vertical;
+    /*      */ byte _gap_0x31;
+    /*      */ byte _gap_0x32[0x2];
+};
+
+struct Component::GUI::ULD::ULDComponentDataTab /* Size=0x24 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x4];
+    /* 0x1C */ unsigned __int32 TextId;
+    /* 0x20 */ unsigned __int32 GroupId;
+};
+
+enum TextInputFlags1: __int32
+{
+    Capitalize = 1,
+    Mask = 2,
+    EnableDictionary = 4,
+    EnableHistory = 8,
+    EnableIME = 16,
+    EscapeClears = 32,
+    AllowUpperCase = 64,
+    AllowLowerCase = 128
+};
+
+enum TextInputFlags2: __int32
+{
+    AllowNumberInput = 1,
+    AllowSymbolInput = 2,
+    WordWrap = 4,
+    MultiLine = 8,
+    AutoMaxWidth = 16
+};
+
+struct Component::GUI::ULD::ULDComponentDataTextInput /* Size=0x7C */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataInputBase InputBase;
+    /* 0x10 */ unsigned __int32 Nodes[0x10];
+    /* 0x50 */ Client::Graphics::ByteColor CandidateColor;
+    /* 0x54 */ Client::Graphics::ByteColor IMEColor;
+    /* 0x58 */ unsigned __int32 MaxWidth;
+    /* 0x5C */ unsigned __int32 MaxLine;
+    /* 0x60 */ unsigned __int32 MaxByte;
+    /* 0x64 */ unsigned __int32 MaxChar;
+    /* 0x68 */ unsigned __int16 CharSet;
+    /* 0x6A */ byte Flags1;
+    /* 0x6B */ byte Flags2;
+    /* 0x6C */ byte CharSetExtras[0x10];
+};
+
+struct Component::GUI::ULD::ULDComponentDataTextNineGrid /* Size=0x18 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x2];
+    /* 0x14 */ unsigned __int32 TextId;
+};
+
+struct Component::GUI::ULD::ULDComponentDataTreeList /* Size=0x28 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x5];
+    /* 0x20 */ byte Wrap;
+    /* 0x21 */ byte Orientation;
+    /* 0x22 */ unsigned __int16 RowNum;
+    /* 0x24 */ unsigned __int16 ColNum;
+    /*      */ byte _gap_0x26[0x2];
+};
+
+struct Component::GUI::ULD::ULDComponentDataUnknownButton /* Size=0x20 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x4];
+    /* 0x1C */ unsigned __int32 TextId;
+};
+
+struct Component::GUI::ULD::ULDComponentDataWindow /* Size=0x38 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDComponentDataBase Base;
+    /*      */ byte _gap_0x9;
+    /*      */ byte _gap_0xA[0x2];
+    /* 0x0C */ unsigned __int32 Nodes[0x8];
+    /* 0x2C */ unsigned __int32 TitleTextId;
+    /* 0x30 */ unsigned __int32 SubtitleTextId;
+    /* 0x34 */ byte ShowCloseButton;
+    /* 0x35 */ byte ShowConfigButton;
+    /* 0x36 */ byte ShowHelpButton;
+    /* 0x37 */ byte ShowHeader;
+};
+
+struct Component::GUI::ULD::ULDComponentInfo /* Size=0x18 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDObjectInfo ObjectInfo;
+    /* 0x10 */ Component::GUI::ComponentType ComponentType;
+    /*      */ byte _gap_0x11;
+    /*      */ byte _gap_0x12[0x2];
+    /*      */ byte _gap_0x14[0x4];
+};
+
+enum AlignmentType: __int32
+{
+    TopLeft = 0,
+    Top = 1,
+    TopRight = 2,
+    Left = 3,
+    Center = 4,
+    Right = 5,
+    BottomLeft = 6,
+    Bottom = 7,
+    BottomRight = 8
+};
+
+struct Component::GUI::ULD::ULDWidgetInfo /* Size=0x20 */
+{
+    /* 0x00 */ Component::GUI::ULD::ULDObjectInfo ObjectInfo;
+    /* 0x10 */ unsigned __int32 AlignmentType;
+    /* 0x14 */ float X;
+    /* 0x18 */ float Y;
+    /*      */ byte _gap_0x1C[0x4];
+};
+
+struct Client::UI::AddonContextIconMenu /* Size=0x2B0 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /*       */ byte _gap_0x220[0x20];
+    /* 0x240 */ Component::GUI::AtkComponentList* AtkComponentList240;
+    /* 0x248 */ void* unk248;
+    /* 0x250 */ Component::GUI::AtkComponentRadioButton* AtkComponentRadioButton250;
+    /* 0x258 */ Component::GUI::AtkComponentRadioButton* AtkComponentRadioButton258;
+    /* 0x260 */ Component::GUI::AtkComponentRadioButton* AtkComponentRadioButton260;
+    /* 0x268 */ Component::GUI::AtkComponentRadioButton* AtkComponentRadioButton268;
+    /* 0x270 */ Component::GUI::AtkComponentRadioButton* AtkComponentRadioButton270;
+    /* 0x278 */ Component::GUI::AtkComponentRadioButton* AtkComponentRadioButton278;
+    /* 0x280 */ Component::GUI::AtkComponentRadioButton* AtkComponentRadioButton280;
+    /* 0x288 */ Component::GUI::AtkComponentRadioButton* AtkComponentRadioButton288;
+    /* 0x290 */ Component::GUI::AtkComponentRadioButton* AtkComponentRadioButton290;
+    /* 0x298 */ Component::GUI::AtkComponentRadioButton* AtkComponentRadioButton298;
+    /*       */ byte _gap_0x2A0[0x10];
+};
+
+struct Client::UI::AddonGathering /* Size=0x300 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /* 0x220 */ Component::GUI::AtkResNode* UnkResNode220;
+    /* 0x228 */ Component::GUI::AtkComponentCheckBox* GatheredItemComponentCheckBox1;
+    /* 0x230 */ Component::GUI::AtkComponentCheckBox* GatheredItemComponentCheckBox2;
+    /* 0x238 */ Component::GUI::AtkComponentCheckBox* GatheredItemComponentCheckBox3;
+    /* 0x240 */ Component::GUI::AtkComponentCheckBox* GatheredItemComponentCheckBox4;
+    /* 0x248 */ Component::GUI::AtkComponentCheckBox* GatheredItemComponentCheckBox5;
+    /* 0x250 */ Component::GUI::AtkComponentCheckBox* GatheredItemComponentCheckBox6;
+    /* 0x258 */ Component::GUI::AtkComponentCheckBox* GatheredItemComponentCheckBox7;
+    /* 0x260 */ Component::GUI::AtkComponentCheckBox* GatheredItemComponentCheckBox8;
+    /* 0x268 */ Component::GUI::AtkTextNode* InventoryQuantityTextNode;
+    /* 0x270 */ Component::GUI::AtkResNode* UnkResNode270;
+    /* 0x278 */ Component::GUI::AtkComponentCheckBox* QuickGatheringComponentCheckBox;
+    /* 0x280 */ Component::GUI::AtkResNode* UnkResNode;
+    /* 0x288 */ unsigned __int64 unk288;
+    /* 0x290 */ unsigned __int64 unk290;
+    /* 0x298 */ unsigned __int64 unk298;
+    /* 0x2A0 */ unsigned __int64 unk2A0;
+    /* 0x2A8 */ unsigned __int64 unk2A8;
+    /* 0x2B0 */ unsigned __int64 unk2B0;
+    /* 0x2B8 */ unsigned __int64 unk2B8;
+    /* 0x2C0 */ unsigned __int64 unk2C0;
+    /* 0x2C8 */ unsigned __int64 unk2C8;
+    /* 0x2D0 */ unsigned __int64 unk2D0;
+    /* 0x2D8 */ unsigned __int64 unk2D8;
+    /* 0x2E0 */ unsigned __int64 unk2E0;
+    /* 0x2E8 */ unsigned __int64 unk2E8;
+    /* 0x2F0 */ unsigned __int64 unk2F0;
+    /* 0x2F8 */ __int32 unk2F8;
+    /* 0x2FC */ __int16 unk2FC;
+    /*       */ byte _gap_0x2FE[0x2];
+};
+
+struct Client::UI::AddonGatheringMasterpiece /* Size=0x750 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /*       */ byte _gap_0x220[0x168];
+    /* 0x388 */ Component::GUI::AtkComponentDragDrop* CollectDragDrop;
+    /*       */ byte _gap_0x390[0x3C0];
+};
+
+struct Client::UI::AddonGuildLeve /* Size=0x17F0 */
+{
+    /* 0x0000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /*        */ byte _gap_0x220[0x8];
+    /* 0x0228 */ Component::GUI::AtkComponentTreeList* AtkComponentTreeList228;
+    /* 0x0230 */ Component::GUI::AtkComponentRadioButton* FieldcraftButton;
+    /* 0x0238 */ Component::GUI::AtkComponentRadioButton* TradecraftButton;
+    union {
+    /* 0x0240 */ Component::GUI::AtkComponentRadioButton* CarpenterButton;
+    /* 0x0240 */ Component::GUI::AtkComponentRadioButton* MinerButton;
+    } _union_0x248;
+    union {
+    /* 0x0248 */ Component::GUI::AtkComponentRadioButton* BlacksmithButton;
+    /* 0x0248 */ Component::GUI::AtkComponentRadioButton* BotanistButton;
+    } _union_0x250;
+    union {
+    /* 0x0250 */ Component::GUI::AtkComponentRadioButton* ArmorerButton;
+    /* 0x0250 */ Component::GUI::AtkComponentRadioButton* FisherButton;
+    } _union_0x258;
+    /*        */ byte _gap_0x258[0x8];
+    /* 0x0260 */ Component::GUI::AtkComponentRadioButton* GoldsmithButton;
+    /* 0x0268 */ Component::GUI::AtkComponentRadioButton* LeatherworkerButton;
+    /* 0x0270 */ Component::GUI::AtkComponentRadioButton* WeaverButton;
+    /* 0x0278 */ Component::GUI::AtkComponentRadioButton* AlchemistButton;
+    /* 0x0280 */ Component::GUI::AtkComponentRadioButton* CulinarianButton;
+    /* 0x0288 */ Component::GUI::AtkResNode* AtkResNode288;
+    union {
+    /* 0x0290 */ Client::System::String::Utf8String CarpenterString;
+    /* 0x0290 */ Client::System::String::Utf8String MinerString;
+    } _union_0x290;
+    union {
+    /* 0x0298 */ Client::System::String::Utf8String BlacksmithString;
+    /* 0x0298 */ Client::System::String::Utf8String BotanistString;
+    } _union_0x2F8;
+    union {
+    /* 0x02A0 */ Client::System::String::Utf8String ArmorerString;
+    /* 0x02A0 */ Client::System::String::Utf8String FisherString;
+    } _union_0x360;
+    /*        */ byte _gap_0x2A8[0x120];
+    /* 0x03C8 */ Client::System::String::Utf8String GoldsmithString;
+    /* 0x0430 */ Client::System::String::Utf8String LeatherworkerString;
+    /* 0x0498 */ Client::System::String::Utf8String WeaverString;
+    /* 0x0500 */ Client::System::String::Utf8String AlchemistString;
+    /* 0x0568 */ Client::System::String::Utf8String CulinarianString;
+    /* 0x05D0 */ Component::GUI::AtkComponentButton* JournalButton;
+    /* 0x05D8 */ Component::GUI::AtkTextNode* AtkTextNode298;
+    /* 0x05E0 */ Component::GUI::AtkComponentBase* AtkComponentBase290;
+    /* 0x05E8 */ Component::GUI::AtkComponentBase* AtkComponentBase298;
+    /*        */ byte _gap_0x5F0[0x1200];
+};
+
+struct Client::UI::AddonHudLayoutWindow /* Size=0x7E8 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /*       */ byte _gap_0x220[0x18];
+    /* 0x238 */ Component::GUI::AtkComponentButton* SaveButton;
+    /*       */ byte _gap_0x240[0x5A8];
+};
+
+struct Client::UI::AddonHudLayoutScreen /* Size=0x7E8 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /*       */ byte _gap_0x220[0xA8];
+    /* 0x2C8 */ Client::UI::AddonHudLayoutWindow* HudLayoutWindow;
+    /*       */ byte _gap_0x2D0[0x270];
+    /* 0x540 */ Component::GUI::AtkComponentNode* SelectedOverlayNode;
+    /*       */ byte _gap_0x548[0x268];
+    /* 0x7B0 */ Client::UI::MoveableAddonInfoStruct* SelectedAddon;
+    /*       */ byte _gap_0x7B8[0x30];
+};
+
+struct Client::UI::MoveableAddonInfoStruct /* Size=0x50 */
+{
+    /*      */ byte _gap_0x0[0x20];
+    /* 0x20 */ Client::UI::AddonHudLayoutScreen* hudLayoutScreen;
+    /* 0x28 */ Component::GUI::AtkUnitBase* SelectedAtkUnit;
+    /*      */ byte _gap_0x30[0x8];
+    /*      */ byte _gap_0x38[0x4];
+    /* 0x3C */ __int32 Flags;
+    /*      */ byte _gap_0x40[0x4];
+    /* 0x44 */ __int16 XOffset;
+    /* 0x46 */ __int16 YOffset;
+    /* 0x48 */ __int16 OverlayWidth;
+    /* 0x4A */ __int16 OverlayHeight;
+    /*      */ byte _gap_0x4C;
+    /* 0x4D */ byte Slot;
+    /*      */ byte _gap_0x4E;
+    /* 0x4F */ byte PositionHasChanged;
+};
+
+struct Client::UI::AddonJournalDetail /* Size=0x2F8 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /*       */ byte _gap_0x220[0x10];
+    /* 0x230 */ Component::GUI::AtkComponentScrollBar* AtkComponentScrollBar230;
+    /* 0x238 */ Component::GUI::AtkComponentGuildLeveCard* AtkComponentGuildLeveCard238;
+    /* 0x240 */ Component::GUI::AtkTextNode* AtkTextNode240;
+    /* 0x248 */ Component::GUI::AtkTextNode* AtkTextNode248;
+    /* 0x250 */ Component::GUI::AtkImageNode* AtkImageNode250;
+    /* 0x258 */ Component::GUI::AtkImageNode* AtkImageNode258;
+    /* 0x260 */ Component::GUI::AtkImageNode* AtkImageNode260;
+    /* 0x268 */ Component::GUI::AtkResNode* AtkResNode268;
+    /* 0x270 */ Component::GUI::AtkTextNode* AtkTextNode270;
+    /* 0x278 */ Component::GUI::AtkResNode* AtkResNode278;
+    /* 0x280 */ Component::GUI::AtkComponentButton* AcceptButton;
+    /* 0x288 */ Component::GUI::AtkComponentButton* DeclineButton;
+    /* 0x290 */ Component::GUI::AtkComponentButton* AtkComponentButton290;
+    /* 0x298 */ Component::GUI::AtkResNode* AtkResNode298;
+    /* 0x2A0 */ Component::GUI::AtkImageNode* AtkImageNode2A0;
+    /* 0x2A8 */ Component::GUI::AtkTextNode* AtkTextNode2A8;
+    /* 0x2B0 */ Component::GUI::AtkTextNode* AtkTextNode2B0;
+    /* 0x2B8 */ Component::GUI::AtkTextNode* AtkTextNode2B8;
+    /* 0x2C0 */ Component::GUI::AtkTextNode* AtkTextNode2C0;
+    /* 0x2C8 */ Component::GUI::AtkComponentButton* AtkComponentButton2C8;
+    /* 0x2D0 */ Component::GUI::AtkComponentJournalCanvas* AtkComponentJournalCanvas2D0;
+    /*       */ byte _gap_0x2D8[0x20];
+};
+
+struct Client::UI::AddonJournalResult /* Size=0x288 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /* 0x220 */ Component::GUI::AtkImageNode* AtkImageNode220;
+    /* 0x228 */ Component::GUI::AtkImageNode* AtkImageNode228;
+    /* 0x230 */ Component::GUI::AtkImageNode* AtkImageNode230;
+    /* 0x238 */ Component::GUI::AtkComponentGuildLeveCard* AtkComponentGuildLeveCard238;
+    /* 0x240 */ Component::GUI::AtkComponentButton* CompleteButton;
+    /* 0x248 */ Component::GUI::AtkComponentButton* DeclineButton;
+    /* 0x250 */ Component::GUI::AtkTextNode* AtkTextNode250;
+    /* 0x258 */ Component::GUI::AtkTextNode* AtkTextNode258;
+    /* 0x260 */ Component::GUI::AtkImageNode* AtkImageNode260;
+    /* 0x268 */ Component::GUI::AtkComponentJournalCanvas* AtkComponentJournalCanvas268;
+    /*       */ byte _gap_0x270[0x18];
+};
+
+struct Client::UI::AddonLotteryDaily::GameTileRow /* Size=0x18 */
+{
+    /* 0x00 */ Component::GUI::AtkComponentCheckBox* Col1;
+    /* 0x08 */ Component::GUI::AtkComponentCheckBox* Col2;
+    /* 0x10 */ Component::GUI::AtkComponentCheckBox* Col3;
+};
+
+struct Client::UI::AddonLotteryDaily::GameTileBoard /* Size=0x48 */
+{
+    /* 0x00 */ Client::UI::AddonLotteryDaily::GameTileRow Row1;
+    /* 0x18 */ Client::UI::AddonLotteryDaily::GameTileRow Row2;
+    /* 0x30 */ Client::UI::AddonLotteryDaily::GameTileRow Row3;
+};
+
+struct Client::UI::AddonLotteryDaily::LaneTileSelector /* Size=0x40 */
+{
+    /* 0x00 */ Component::GUI::AtkComponentRadioButton* MajorDiagonal;
+    /* 0x08 */ Component::GUI::AtkComponentRadioButton* Col1;
+    /* 0x10 */ Component::GUI::AtkComponentRadioButton* Col2;
+    /* 0x18 */ Component::GUI::AtkComponentRadioButton* Col3;
+    /* 0x20 */ Component::GUI::AtkComponentRadioButton* MinorDiagonal;
+    /* 0x28 */ Component::GUI::AtkComponentRadioButton* Row1;
+    /* 0x30 */ Component::GUI::AtkComponentRadioButton* Row2;
+    /* 0x38 */ Component::GUI::AtkComponentRadioButton* Row3;
+};
+
+struct Client::UI::AddonLotteryDaily::GameNumberRow /* Size=0xC */
+{
+    /* 0x0 */ __int32 Col1;
+    /* 0x4 */ __int32 Col2;
+    /* 0x8 */ __int32 Col3;
+};
+
+struct Client::UI::AddonLotteryDaily::GameBoardNumbers /* Size=0x24 */
+{
+    /* 0x00 */ Client::UI::AddonLotteryDaily::GameNumberRow Row1;
+    /* 0x0C */ Client::UI::AddonLotteryDaily::GameNumberRow Row2;
+    /* 0x18 */ Client::UI::AddonLotteryDaily::GameNumberRow Row3;
+};
+
+struct Client::UI::AddonLotteryDaily /* Size=0x408 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /* 0x220 */ Client::UI::AddonLotteryDaily::GameTileBoard GameBoard;
+    /* 0x268 */ Client::UI::AddonLotteryDaily::LaneTileSelector LaneSelector;
+    /* 0x2A8 */ Component::GUI::AtkComponentBase* UnkCompBase2A8;
+    /* 0x2B0 */ Component::GUI::AtkComponentBase* UnkCompBase2B0;
+    /* 0x2B8 */ Component::GUI::AtkComponentBase* UnkCompBase2B8;
+    /* 0x2C0 */ Component::GUI::AtkComponentBase* UnkCompBase2C0;
+    /* 0x2C8 */ Component::GUI::AtkComponentBase* UnkCompBase2C8;
+    /* 0x2D0 */ Component::GUI::AtkComponentBase* UnkCompBase2D0;
+    /* 0x2D8 */ Component::GUI::AtkComponentBase* UnkCompBase2D8;
+    /* 0x2E0 */ Component::GUI::AtkComponentBase* UnkCompBase2E0;
+    /* 0x2E8 */ Component::GUI::AtkComponentBase* UnkCompBase2E8;
+    /* 0x2F0 */ Component::GUI::AtkResNode* UnkResNode2F0;
+    /* 0x2F8 */ Component::GUI::AtkResNode* UnkResNode2F8;
+    /* 0x300 */ Component::GUI::AtkResNode* UnkResNode300;
+    /* 0x308 */ Component::GUI::AtkComponentBase* UnkCompBase308;
+    /* 0x310 */ Component::GUI::AtkComponentBase* UnkCompBase310;
+    /* 0x318 */ Component::GUI::AtkComponentBase* UnkCompBase318;
+    /* 0x320 */ Component::GUI::AtkComponentButton* UnkCompButton320;
+    /* 0x328 */ Component::GUI::AtkTextNode* UnkTextNode328;
+    /* 0x330 */ Component::GUI::AtkComponentBase* UnkCompBase330;
+    /* 0x338 */ Component::GUI::AtkComponentBase* UnkCompBase338;
+    /* 0x340 */ Component::GUI::AtkComponentBase* UnkCompBase340;
+    /* 0x348 */ Component::GUI::AtkComponentBase* UnkCompBase348;
+    /* 0x350 */ Component::GUI::AtkComponentBase* UnkCompBase350;
+    /* 0x358 */ Component::GUI::AtkComponentBase* UnkCompBase358;
+    /* 0x360 */ Component::GUI::AtkComponentBase* UnkCompBase360;
+    /* 0x368 */ Component::GUI::AtkComponentBase* UnkCompBase368;
+    /* 0x370 */ Component::GUI::AtkComponentBase* UnkCompBase370;
+    /* 0x378 */ Component::GUI::AtkComponentBase* UnkCompBase378;
+    /* 0x380 */ Component::GUI::AtkComponentBase* UnkCompBase380;
+    /* 0x388 */ Component::GUI::AtkComponentBase* UnkCompBase388;
+    /* 0x390 */ Component::GUI::AtkComponentBase* UnkCompBase390;
+    /* 0x398 */ Component::GUI::AtkComponentBase* UnkCompBase398;
+    /* 0x3A0 */ Component::GUI::AtkComponentBase* UnkCompBase3A0;
+    /* 0x3A8 */ Component::GUI::AtkComponentBase* UnkCompBase3A8;
+    /* 0x3B0 */ Component::GUI::AtkComponentBase* UnkCompBase3B0;
+    /* 0x3B8 */ Component::GUI::AtkComponentBase* UnkCompBase3B8;
+    /* 0x3C0 */ Component::GUI::AtkComponentBase* UnkCompBase3C0;
+    /* 0x3C8 */ Component::GUI::AtkImageNode* UnkImageNode3C8;
+    /* 0x3D0 */ __int32 UnkNumber3D0;
+    /* 0x3D4 */ __int32 UnkNumber3D4;
+    /* 0x3D8 */ Client::UI::AddonLotteryDaily::GameBoardNumbers GameNumbers;
+    /* 0x3FC */ __int32 UnkNumber3FC;
+    /* 0x400 */ __int32 UnkNumber400;
+    /* 0x404 */ __int32 UnkNumber404;
+};
+
+struct Client::UI::AddonNamePlate::BakePlateRenderer /* Size=0x230 */
+{
+    /*       */ byte _gap_0x0[0x230];
+};
+
+struct Client::UI::AddonNamePlate::NamePlateObject /* Size=0x70 */
+{
+    /* 0x00 */ Component::GUI::AtkComponentNode* ComponentNode;
+    /* 0x08 */ Component::GUI::AtkResNode* ResNode;
+    /* 0x10 */ Component::GUI::AtkTextNode* TextNode10;
+    /* 0x18 */ Component::GUI::AtkImageNode* IconImageNode;
+    /* 0x20 */ Component::GUI::AtkImageNode* ImageNode2;
+    /* 0x28 */ Component::GUI::AtkImageNode* ImageNode3;
+    /* 0x30 */ Component::GUI::AtkImageNode* ImageNode4;
+    /* 0x38 */ Component::GUI::AtkImageNode* ImageNode5;
+    /* 0x40 */ Component::GUI::AtkCollisionNode* CollisionNode1;
+    /* 0x48 */ Component::GUI::AtkCollisionNode* CollisionNode2;
+    /* 0x50 */ __int32 Layer;
+    /* 0x54 */ __int16 TextW;
+    /* 0x56 */ __int16 TextH;
+    /* 0x58 */ __int16 IconXAdjust;
+    /* 0x5A */ __int16 IconYAdjust;
+    /* 0x5C */ __int16 UnkType;
+    /* 0x5E */ __int16 IsLocalPlayerValue;
+    /* 0x60 */ byte IsVisibleByte;
+    /*      */ byte _gap_0x61;
+    /*      */ byte _gap_0x62[0x2];
+    /*      */ byte _gap_0x64[0x4];
+    /*      */ byte _gap_0x68[0x2];
+    /* 0x6A */ byte ComponentNodeScale;
+    /*      */ byte _gap_0x6B;
+    /*      */ byte _gap_0x6C[0x4];
+};
+
+struct Client::UI::AddonNamePlate /* Size=0x460 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /* 0x220 */ Client::UI::AddonNamePlate::BakePlateRenderer BakePlate;
+    /* 0x450 */ Client::UI::AddonNamePlate::NamePlateObject* NamePlateObjectArray;
+    /*       */ byte _gap_0x458[0x8];
+};
+
+struct Client::UI::AddonRecipeNote /* Size=0x21A0 */
+{
+    /* 0x0000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /* 0x0220 */ Component::GUI::AtkTextNode* Unk220;
+    /* 0x0228 */ Component::GUI::AtkTextNode* Unk228;
+    /* 0x0230 */ Component::GUI::AtkTextNode* Unk230;
+    /* 0x0238 */ Component::GUI::AtkImageNode* Unk238;
+    /*        */ byte _gap_0x240[0x8];
+    /* 0x0248 */ Component::GUI::AtkResNode* Unk248;
+    /* 0x0250 */ Component::GUI::AtkResNode* Unk250;
+    /* 0x0258 */ Component::GUI::AtkResNode* Unk258;
+    /* 0x0260 */ Component::GUI::AtkComponentRadioButton* Unk260;
+    /* 0x0268 */ Component::GUI::AtkComponentRadioButton* Unk268;
+    /* 0x0270 */ Component::GUI::AtkComponentRadioButton* Unk270;
+    /* 0x0278 */ Component::GUI::AtkComponentRadioButton* Unk278;
+    /* 0x0280 */ Component::GUI::AtkComponentRadioButton* Unk280;
+    /* 0x0288 */ Component::GUI::AtkComponentRadioButton* Unk288;
+    /* 0x0290 */ Component::GUI::AtkComponentRadioButton* Unk290;
+    /* 0x0298 */ Component::GUI::AtkComponentRadioButton* Unk298;
+    /* 0x02A0 */ Component::GUI::AtkComponentRadioButton* Unk2A0;
+    /*        */ byte _gap_0x2A8[0x28];
+    /* 0x02D0 */ Component::GUI::AtkImageNode* Unk2D0;
+    /* 0x02D8 */ Component::GUI::AtkImageNode* Unk2D8;
+    /* 0x02E0 */ Component::GUI::AtkImageNode* Unk2E0;
+    /* 0x02E8 */ Component::GUI::AtkImageNode* Unk2E8;
+    /* 0x02F0 */ Component::GUI::AtkImageNode* Unk2F0;
+    /* 0x02F8 */ Component::GUI::AtkImageNode* Unk2F8;
+    /* 0x0300 */ Component::GUI::AtkImageNode* Unk300;
+    /* 0x0308 */ Component::GUI::AtkImageNode* Unk308;
+    /* 0x0310 */ Component::GUI::AtkImageNode* Unk310;
+    /* 0x0318 */ Component::GUI::AtkComponentButton* TrialSynthesisButton;
+    /* 0x0320 */ Component::GUI::AtkComponentButton* QuickSynthesisButton;
+    /* 0x0328 */ Component::GUI::AtkComponentButton* SynthesizeButton;
+    /* 0x0330 */ Component::GUI::AtkComponentButton* Unk330;
+    /* 0x0338 */ Component::GUI::AtkComponentButton* Unk338;
+    /* 0x0340 */ Component::GUI::AtkComponentButton* Unk340;
+    /* 0x0348 */ Component::GUI::AtkComponentButton* Unk348;
+    /* 0x0350 */ Component::GUI::AtkComponentButton* Unk350;
+    /* 0x0358 */ Component::GUI::AtkResNode* Unk358;
+    /* 0x0360 */ Component::GUI::AtkTextNode* Unk360;
+    /* 0x0368 */ Component::GUI::AtkComponentBase* Unk368;
+    /* 0x0370 */ Component::GUI::AtkComponentBase* Unk370;
+    /* 0x0378 */ Component::GUI::AtkComponentBase* Unk378;
+    /* 0x0380 */ Component::GUI::AtkComponentBase* Unk380;
+    /* 0x0388 */ Component::GUI::AtkComponentBase* Unk388;
+    /* 0x0390 */ Component::GUI::AtkTextNode* Unk390;
+    /* 0x0398 */ Component::GUI::AtkTextNode* Unk398;
+    /* 0x03A0 */ Component::GUI::AtkTextNode* Unk3A0;
+    /* 0x03A8 */ Component::GUI::AtkTextNode* Unk3A8;
+    /* 0x03B0 */ Component::GUI::AtkTextNode* Unk3B0;
+    /* 0x03B8 */ Component::GUI::AtkTextNode* Unk3B8;
+    /* 0x03C0 */ Component::GUI::AtkResNode* Unk3C0;
+    /* 0x03C8 */ void* Unk3C8;
+    /* 0x03D0 */ Component::GUI::AtkComponentButton* Unk3D0;
+    /* 0x03D8 */ Component::GUI::AtkResNode* Unk3D8;
+    /* 0x03E0 */ Component::GUI::AtkComponentButton* Unk3E0;
+    /* 0x03E8 */ Component::GUI::AtkResNode* Unk3E8;
+    /* 0x03F0 */ Component::GUI::AtkResNode* Unk3F0;
+    /* 0x03F8 */ void* Unk3F8;
+    /* 0x0400 */ void* Unk400;
+    /* 0x0408 */ void* Unk408;
+    /* 0x0410 */ Client::UI::AddonRecipeNote* this410;
+    /* 0x0418 */ void* Unk418;
+    /* 0x0420 */ void* Unk420;
+    /* 0x0428 */ void* Unk428;
+    /* 0x0430 */ Client::UI::AddonRecipeNote* this430;
+    /* 0x0438 */ void* Unk438;
+    /* 0x0440 */ void* Unk440;
+    /* 0x0448 */ void* Unk448;
+    /* 0x0450 */ void* Unk450;
+    /* 0x0458 */ void* Unk458;
+    /* 0x0460 */ void* Unk460;
+    /* 0x0468 */ void* Unk468;
+    /* 0x0470 */ void* Unk470;
+    /* 0x0478 */ void* Unk478;
+    /* 0x0480 */ void* Unk480;
+    /* 0x0488 */ void* Unk488;
+    /* 0x0490 */ void* Unk490;
+    /* 0x0498 */ void* Unk498;
+    /* 0x04A0 */ void* Unk4A0;
+    /* 0x04A8 */ void* Unk4A8;
+    /* 0x04B0 */ void* Unk4B0;
+    /* 0x04B8 */ void* Unk4B8;
+    /* 0x04C0 */ void* Unk4C0;
+    /* 0x04C8 */ void* Unk4C8;
+    /* 0x04D0 */ void* Unk4D0;
+    /* 0x04D8 */ void* Unk4D8;
+    /* 0x04E0 */ void* Unk4E0;
+    /* 0x04E8 */ void* Unk4E8;
+    /* 0x04F0 */ void* Unk4F0;
+    /* 0x04F8 */ void* Unk4F8;
+    /* 0x0500 */ void* Unk500;
+    /* 0x0508 */ void* Unk508;
+    /* 0x0510 */ void* Unk510;
+    /* 0x0518 */ void* Unk518;
+    /* 0x0520 */ void* Unk520;
+    /* 0x0528 */ void* Unk528;
+    /* 0x0530 */ void* Unk530;
+    /* 0x0538 */ void* Unk538;
+    /* 0x0540 */ void* Unk540;
+    /* 0x0548 */ void* Unk548;
+    /* 0x0550 */ void* Unk550;
+    /* 0x0558 */ void* Unk558;
+    /* 0x0560 */ void* Unk560;
+    /*        */ byte _gap_0x568[0x10];
+    /* 0x0578 */ void* Unk578;
+    /* 0x0580 */ void* Unk580;
+    /* 0x0588 */ void* Unk588;
+    /* 0x0590 */ void* Unk590;
+    /* 0x0598 */ void* Unk598;
+    /* 0x05A0 */ void* Unk5A0;
+    /* 0x05A8 */ void* Unk5A8;
+    /* 0x05B0 */ void* Unk5B0;
+    /* 0x05B8 */ void* Unk5B8;
+    /* 0x05C0 */ void* Unk5C0;
+    /* 0x05C8 */ void* Unk5C8;
+    /* 0x05D0 */ void* Unk5D0;
+    /*        */ byte _gap_0x5D8[0x10];
+    /* 0x05E8 */ void* Unk5E8;
+    /* 0x05F0 */ void* Unk5F0;
+    /* 0x05F8 */ void* Unk5F8;
+    /* 0x0600 */ void* Unk600;
+    /* 0x0608 */ void* Unk608;
+    /* 0x0610 */ void* Unk610;
+    /* 0x0618 */ void* Unk618;
+    /* 0x0620 */ void* Unk620;
+    /* 0x0628 */ void* Unk628;
+    /* 0x0630 */ void* Unk630;
+    /* 0x0638 */ void* Unk638;
+    /* 0x0640 */ void* Unk640;
+    /*        */ byte _gap_0x648[0x10];
+    /* 0x0658 */ void* Unk658;
+    /* 0x0660 */ void* Unk660;
+    /* 0x0668 */ void* Unk668;
+    /* 0x0670 */ void* Unk670;
+    /* 0x0678 */ void* Unk678;
+    /* 0x0680 */ void* Unk680;
+    /* 0x0688 */ void* Unk688;
+    /* 0x0690 */ void* Unk690;
+    /* 0x0698 */ void* Unk698;
+    /* 0x06A0 */ void* Unk6A0;
+    /* 0x06A8 */ void* Unk6A8;
+    /* 0x06B0 */ void* Unk6B0;
+    /*        */ byte _gap_0x6B8[0x10];
+    /* 0x06C8 */ void* Unk6C8;
+    /* 0x06D0 */ void* Unk6D0;
+    /* 0x06D8 */ void* Unk6D8;
+    /* 0x06E0 */ void* Unk6E0;
+    /* 0x06E8 */ void* Unk6E8;
+    /* 0x06F0 */ void* Unk6F0;
+    /* 0x06F8 */ void* Unk6F8;
+    /* 0x0700 */ void* Unk700;
+    /* 0x0708 */ void* Unk708;
+    /* 0x0710 */ void* Unk710;
+    /* 0x0718 */ void* Unk718;
+    /* 0x0720 */ void* Unk720;
+    /*        */ byte _gap_0x728[0x10];
+    /* 0x0738 */ void* Unk738;
+    /* 0x0740 */ void* Unk740;
+    /* 0x0748 */ void* Unk748;
+    /* 0x0750 */ void* Unk750;
+    /* 0x0758 */ void* Unk758;
+    /* 0x0760 */ void* Unk760;
+    /* 0x0768 */ void* Unk768;
+    /* 0x0770 */ void* Unk770;
+    /* 0x0778 */ void* Unk778;
+    /* 0x0780 */ void* Unk780;
+    /* 0x0788 */ void* Unk788;
+    /* 0x0790 */ void* Unk790;
+    /*        */ byte _gap_0x798[0x10];
+    /* 0x07A8 */ void* Unk7A8;
+    /*        */ byte _gap_0x7B0[0x50];
+    /* 0x0800 */ Client::UI::AddonRecipeNote* this800;
+    /* 0x0808 */ Component::GUI::AtkStage* Unk808;
+    /* 0x0810 */ Component::GUI::AtkComponentTextInput* Unk810;
+    /* 0x0818 */ Client::UI::AddonRecipeNote* this818;
+    /*        */ byte _gap_0x820[0x330];
+    /* 0x0B50 */ char* UnkB50;
+    /*        */ byte _gap_0xB58[0x8];
+    /* 0x0B60 */ char* UnkB60;
+    /*        */ byte _gap_0xB68[0x8];
+    /* 0x0B70 */ char* UnkB70;
+    /*        */ byte _gap_0xB78[0x8];
+    /* 0x0B80 */ char* UnkB80;
+    /*        */ byte _gap_0xB88[0x8];
+    /* 0x0B90 */ char* UnkB90;
+    /*        */ byte _gap_0xB98[0x8];
+    /* 0x0BA0 */ char* UnkBA0;
+    /*        */ byte _gap_0xBA8[0x8];
+    /* 0x0BB0 */ char* UnkBB0;
+    /*        */ byte _gap_0xBB8[0x8];
+    /* 0x0BC0 */ char* UnkBC0;
+    /*        */ byte _gap_0xBC8[0x8];
+    /* 0x0BD0 */ char* UnkBD0;
+    /*        */ byte _gap_0xBD8[0x8];
+    /* 0x0BE0 */ char* UnkBE0;
+    /*        */ byte _gap_0xBE8[0x8];
+    /* 0x0BF0 */ char* UnkBF0;
+    /*        */ byte _gap_0xBF8[0x8];
+    /* 0x0C00 */ char* UnkC00;
+    /*        */ byte _gap_0xC08[0x8];
+    /* 0x0C10 */ char* UnkC10;
+    /*        */ byte _gap_0xC18[0x1520];
+    /* 0x2138 */ char* Unk2138;
+    /* 0x2140 */ char* Unk2140;
+    /* 0x2148 */ char* Unk2148;
+    /* 0x2150 */ char* Unk2150;
+    /* 0x2158 */ char* Unk2158;
+    /* 0x2160 */ char* Unk2160;
+    /* 0x2168 */ char* Unk2168;
+    /* 0x2170 */ char* Unk2170;
+    /* 0x2178 */ char* Unk2178;
+    /*        */ byte _gap_0x2180[0x20];
+};
+
+struct Client::UI::AddonRequest /* Size=0x2E0 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /* 0x220 */ Component::GUI::AtkCollisionNode* AtkCollisionNode220;
+    /* 0x228 */ Component::GUI::AtkComponentIcon* AtkComponentIcon228;
+    /* 0x230 */ Component::GUI::AtkComponentIcon* AtkComponentIcon230;
+    /* 0x238 */ Component::GUI::AtkComponentIcon* AtkComponentIcon238;
+    /* 0x240 */ Component::GUI::AtkComponentIcon* AtkComponentIcon240;
+    /* 0x248 */ Component::GUI::AtkComponentIcon* AtkComponentIcon248;
+    /* 0x250 */ Component::GUI::AtkComponentDragDrop* AtkComponentDragDrop250;
+    /* 0x258 */ Component::GUI::AtkComponentDragDrop* AtkComponentDragDrop258;
+    /* 0x260 */ Component::GUI::AtkComponentDragDrop* AtkComponentDragDrop260;
+    /* 0x268 */ Component::GUI::AtkComponentDragDrop* AtkComponentDragDrop268;
+    /* 0x270 */ Component::GUI::AtkComponentDragDrop* AtkComponentDragDrop270;
+    /* 0x278 */ Component::GUI::AtkComponentButton* HandOverButton;
+    /* 0x280 */ Component::GUI::AtkComponentButton* CancelButton;
+    /* 0x288 */ Component::GUI::AtkComponentIcon* AtkComponentIcon288;
+    /* 0x290 */ Component::GUI::AtkComponentIcon* AtkComponentIcon290;
+    /* 0x298 */ Component::GUI::AtkComponentIcon* AtkComponentIcon298;
+    /* 0x2A0 */ Component::GUI::AtkComponentIcon* AtkComponentIcon2A0;
+    /* 0x2A8 */ Component::GUI::AtkComponentIcon* AtkComponentIcon2A8;
+    /* 0x2B0 */ Component::GUI::AtkComponentDragDrop* AtkComponentDragDrop2B0;
+    /* 0x2B8 */ Component::GUI::AtkComponentDragDrop* AtkComponentDragDrop2B8;
+    /* 0x2C0 */ Component::GUI::AtkComponentDragDrop* AtkComponentDragDrop2C0;
+    /* 0x2C8 */ Component::GUI::AtkComponentDragDrop* AtkComponentDragDrop2C8;
+    /* 0x2D0 */ Component::GUI::AtkComponentDragDrop* AtkComponentDragDrop2D0;
+    /*       */ byte _gap_0x2D8[0x8];
+};
+
+struct Client::UI::AddonSelectIconString /* Size=0x2A0 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /*       */ byte _gap_0x220[0x18];
+    /* 0x238 */ void* vtbl238;
+    /* 0x240 */ Component::GUI::AtkStage* AtkStage;
+    /* 0x248 */ char** SelectStrings;
+    /*       */ byte _gap_0x250[0x8];
+    /* 0x258 */ void* unk258;
+    /*       */ byte _gap_0x260[0x8];
+    /* 0x268 */ Component::GUI::AtkComponentWindow* AtkComponentWindow;
+    /* 0x270 */ Component::GUI::AtkComponentList* AtkComponentList;
+    /* 0x278 */ Client::UI::AddonSelectIconString* this278;
+    /*       */ byte _gap_0x280[0x18];
+    /* 0x298 */ void* unk298;
+};
+
+struct Client::UI::AddonSelectString /* Size=0x28A */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /*       */ byte _gap_0x220[0x18];
+    /* 0x238 */ void* vtbl238;
+    /* 0x240 */ Component::GUI::AtkStage* AtkStage;
+    /* 0x248 */ char** SelectStrings;
+    /*       */ byte _gap_0x250[0x8];
+    /* 0x258 */ void* unk258;
+    /*       */ byte _gap_0x260[0x8];
+    /* 0x268 */ Component::GUI::AtkComponentWindow* AtkComponentWindow;
+    /* 0x270 */ Component::GUI::AtkComponentList* AtkComponentList;
+    /* 0x278 */ Client::UI::AddonSelectString* this278;
+    /*       */ byte _gap_0x280[0x8];
+    /*       */ byte _gap_0x288[0x2];
+};
+
+struct Client::UI::AddonSelectYesno /* Size=0x2D0 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /* 0x220 */ Component::GUI::AtkTextNode* AtkTextNode220;
+    /* 0x228 */ Component::GUI::AtkComponentButton* YesButton;
+    /* 0x230 */ Component::GUI::AtkComponentButton* NoButton;
+    /* 0x238 */ Component::GUI::AtkComponentButton* AtkComponentUnknownButton238;
+    /* 0x240 */ Component::GUI::AtkResNode* AtkResNode240;
+    /* 0x248 */ Component::GUI::AtkResNode* AtkResNode248;
+    /*       */ byte _gap_0x250[0x8];
+    /* 0x258 */ Component::GUI::AtkResNode* AtkResNode258;
+    /* 0x260 */ Component::GUI::AtkComponentButton* AtkComponentButton260;
+    /* 0x268 */ Component::GUI::AtkComponentButton* AtkComponentButton268;
+    /* 0x270 */ Component::GUI::AtkComponentButton* AtkComponentButton270;
+    /* 0x278 */ Component::GUI::AtkComponentUnknownButton* AtkComponentUnknownButton278;
+    /* 0x280 */ Component::GUI::AtkComponentUnknownButton* AtkComponentUnknownButton280;
+    /* 0x288 */ Component::GUI::AtkComponentUnknownButton* AtkComponentUnknownButton288;
+    /* 0x290 */ Component::GUI::AtkComponentCheckBox* ConfirmCheckBox;
+    /* 0x298 */ Component::GUI::AtkTextNode* AtkTextNode298;
+    /* 0x2A0 */ Component::GUI::AtkComponentBase* AtkComponentBase2A0;
+    /*       */ byte _gap_0x2A8[0x28];
+};
+
+struct Client::UI::AddonSynthesize::CraftEffect /* Size=0x20 */
+{
+    /* 0x00 */ Component::GUI::AtkComponentBase* Container;
+    /* 0x08 */ Component::GUI::AtkImageNode* Image;
+    /* 0x10 */ Component::GUI::AtkTextNode* StepsRemaining;
+    /* 0x18 */ Component::GUI::AtkTextNode* Name;
+};
+
+struct Client::UI::AddonSynthesize /* Size=0x838 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /* 0x220 */ Component::GUI::AtkCollisionNode* RootCollisionNode;
+    /* 0x228 */ Component::GUI::AtkComponentButton* QuitButton;
+    /* 0x230 */ Component::GUI::AtkComponentButton* CalculationsButton;
+    /* 0x238 */ Component::GUI::AtkComponentIcon* AtkComponentIcon238;
+    /* 0x240 */ Component::GUI::AtkCollisionNode* AtkCollisionNode240;
+    /* 0x248 */ Component::GUI::AtkTextNode* CraftedItemName;
+    /* 0x250 */ Component::GUI::AtkResNode* AtkResNode250;
+    /* 0x258 */ Component::GUI::AtkComponentBase* AtkComponentBase258;
+    /* 0x260 */ Component::GUI::AtkTextNode* Condition;
+    /* 0x268 */ Component::GUI::AtkResNode* ConditionResNode;
+    /* 0x270 */ Component::GUI::AtkTextNode* CurrentQuality;
+    /* 0x278 */ Component::GUI::AtkTextNode* MaxQuality;
+    /* 0x280 */ Component::GUI::AtkResNode* AtkResNode280;
+    /* 0x288 */ Component::GUI::AtkTextNode* HQLiteral;
+    /* 0x290 */ Component::GUI::AtkTextNode* HQPercentage;
+    /* 0x298 */ Component::GUI::AtkTextNode* StepNumber;
+    /* 0x2A0 */ Component::GUI::AtkComponentGaugeBar* ProgressGauge;
+    /* 0x2A8 */ Component::GUI::AtkComponentGaugeBar* QualityGauge;
+    /* 0x2B0 */ Component::GUI::AtkTextNode* CurrentProgress;
+    /* 0x2B8 */ Component::GUI::AtkTextNode* MaxProgress;
+    /* 0x2C0 */ Component::GUI::AtkResNode* AtkResNode2C0;
+    /* 0x2C8 */ Component::GUI::AtkTextNode* CurrentDurability;
+    /* 0x2D0 */ Component::GUI::AtkTextNode* StartingDurability;
+    /* 0x2D8 */ Component::GUI::AtkComponentBase* AtkComponentBase2D8;
+    /* 0x2E0 */ Component::GUI::AtkComponentBase* AtkComponentBase2E0;
+    /* 0x2E8 */ Component::GUI::AtkComponentBase* AtkComponentBase2E8;
+    /* 0x2F0 */ Component::GUI::AtkComponentBase* AtkComponentBase2F0;
+    /* 0x2F8 */ Component::GUI::AtkComponentBase* AtkComponentBase2F8;
+    /* 0x300 */ Component::GUI::AtkComponentBase* AtkComponentBase300;
+    /* 0x308 */ Component::GUI::AtkComponentBase* AtkComponentBase308;
+    /* 0x310 */ Component::GUI::AtkComponentBase* AtkComponentBase310;
+    /* 0x318 */ Component::GUI::AtkComponentCheckBox* AtkComponentCheckBox318;
+    /* 0x320 */ Component::GUI::AtkResNode* AtkResNode320;
+    /* 0x328 */ Component::GUI::AtkResNode* AtkResNode328;
+    /* 0x330 */ Component::GUI::AtkResNode* AtkResNode330;
+    /* 0x338 */ Component::GUI::AtkTextNode* AtkTextNode338;
+    /* 0x340 */ Client::UI::AddonSynthesize::CraftEffect CraftEffect1;
+    /* 0x360 */ Client::UI::AddonSynthesize::CraftEffect CraftEffect2;
+    /* 0x380 */ Client::UI::AddonSynthesize::CraftEffect CraftEffect3;
+    /* 0x3A0 */ Client::UI::AddonSynthesize::CraftEffect CraftEffect4;
+    /* 0x3C0 */ Client::UI::AddonSynthesize::CraftEffect CraftEffect5;
+    /* 0x3E0 */ Client::UI::AddonSynthesize::CraftEffect CraftEffect6;
+    /* 0x400 */ Client::UI::AddonSynthesize::CraftEffect CraftEffect7;
+    /* 0x420 */ Client::UI::AddonSynthesize::CraftEffect CraftEffect8;
+    /* 0x440 */ Client::UI::AddonSynthesize::CraftEffect CraftEffect9;
+    /*       */ byte _gap_0x460[0x18];
+    /* 0x478 */ Component::GUI::AtkComponentTextNineGrid* AtkComponentTextNineGrid478;
+    /* 0x480 */ Component::GUI::AtkResNode* AtkResNode480;
+    /* 0x488 */ Client::System::String::Utf8String CraftEffect1HoverText;
+    /* 0x4F0 */ Client::System::String::Utf8String CraftEffect2HoverText;
+    /* 0x558 */ Client::System::String::Utf8String CraftEffect3HoverText;
+    /* 0x5C0 */ Client::System::String::Utf8String CraftEffect4HoverText;
+    /* 0x628 */ Client::System::String::Utf8String CraftEffect5HoverText;
+    /* 0x690 */ Client::System::String::Utf8String CraftEffect6HoverText;
+    /* 0x6F8 */ Client::System::String::Utf8String CraftEffect7HoverText;
+    /* 0x760 */ Client::System::String::Utf8String CraftEffect8HoverText;
+    /* 0x7C8 */ Client::System::String::Utf8String CraftEffect9HoverText;
+    /*       */ byte _gap_0x830[0x8];
+};
+
+struct Client::UI::AddonTalk /* Size=0x5F8 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /* 0x220 */ Component::GUI::AtkTextNode* AtkTextNode220;
+    /* 0x228 */ Component::GUI::AtkTextNode* AtkTextNode228;
+    /* 0x230 */ Component::GUI::AtkResNode* AtkResNode230;
+    /*       */ byte _gap_0x238[0x10];
+    /* 0x248 */ void* unk248;
+    /* 0x250 */ Client::System::String::Utf8String String250;
+    /* 0x2B8 */ Client::System::String::Utf8String String2B8;
+    /* 0x320 */ Client::System::String::Utf8String String320;
+    /* 0x388 */ Client::System::String::Utf8String String388;
+    /* 0x3F0 */ Client::System::String::Utf8String String3F0;
+    /* 0x458 */ Client::System::String::Utf8String String458;
+    /* 0x4C0 */ Client::System::String::Utf8String String4C0;
+    /*       */ byte _gap_0x528[0x90];
+    /* 0x5B8 */ Client::UI::AddonTalk* this5B8;
+    /* 0x5C0 */ Component::GUI::AtkStage* AtkStage;
+    /*       */ byte _gap_0x5C8[0x30];
+};
+
+struct Client::UI::StickerSlot /* Size=0x58 */
+{
+    /* 0x00 */ void** vtbl;
+    /* 0x08 */ void* addon;
+    /* 0x10 */ __int32 index;
+    /*      */ byte _gap_0x14[0x4];
+    /*      */ byte _gap_0x18[0x8];
+    /* 0x20 */ Component::GUI::AtkComponentButton* Button;
+    /* 0x28 */ Component::GUI::AtkComponentBase* StickerComponentBase;
+    /* 0x30 */ Component::GUI::AtkComponentBase* StickerShadowComponentBase;
+    /* 0x38 */ Component::GUI::AtkResNode* StickerResNode;
+    /* 0x40 */ Component::GUI::AtkResNode* StickerShadowResNode;
+    /* 0x48 */ Component::GUI::AtkComponentBase* StickerSidebarBase;
+    /* 0x50 */ Component::GUI::AtkResNode* StickerSidebarResNode;
+};
+
+struct Client::UI::StickerSlotList /* Size=0x590 */
+{
+    /* 0x000 */ void** vtbl;
+    /* 0x008 */ void* addon;
+    /* 0x010 */ Client::UI::StickerSlot StickerSlot1;
+    /* 0x068 */ Client::UI::StickerSlot StickerSlot2;
+    /* 0x0C0 */ Client::UI::StickerSlot StickerSlot3;
+    /* 0x118 */ Client::UI::StickerSlot StickerSlot4;
+    /* 0x170 */ Client::UI::StickerSlot StickerSlot5;
+    /* 0x1C8 */ Client::UI::StickerSlot StickerSlot6;
+    /* 0x220 */ Client::UI::StickerSlot StickerSlot7;
+    /* 0x278 */ Client::UI::StickerSlot StickerSlot8;
+    /* 0x2D0 */ Client::UI::StickerSlot StickerSlot9;
+    /* 0x328 */ Client::UI::StickerSlot StickerSlot10;
+    /* 0x380 */ Client::UI::StickerSlot StickerSlot11;
+    /* 0x3D8 */ Client::UI::StickerSlot StickerSlot12;
+    /* 0x430 */ Client::UI::StickerSlot StickerSlot13;
+    /* 0x488 */ Client::UI::StickerSlot StickerSlot14;
+    /* 0x4E0 */ Client::UI::StickerSlot StickerSlot15;
+    /* 0x538 */ Client::UI::StickerSlot StickerSlot16;
+};
+
+struct Client::UI::AddonWeeklyBingo /* Size=0x23C8 */
+{
+    /* 0x0000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /*        */ byte _gap_0x220[0x1718];
+    /* 0x1938 */ Client::UI::StickerSlotList StickerSlotList;
+    /*        */ byte _gap_0x1EC8[0x500];
+};
+
+struct Client::UI::AddonWeeklyPuzzle::RewardPanelItem /* Size=0x28 */
+{
+    /* 0x00 */ Component::GUI::AtkComponentBase* CompBase;
+    /* 0x08 */ Component::GUI::AtkResNode* Res;
+    /* 0x10 */ Component::GUI::AtkTextNode* NameText;
+    /* 0x18 */ Component::GUI::AtkTextNode* RewardText;
+    /* 0x20 */ __int64 Unk20;
+};
+
+struct Client::UI::AddonWeeklyPuzzle::GameTileItem /* Size=0x30 */
+{
+    /* 0x00 */ Client::UI::AddonWeeklyPuzzle* self;
+    /* 0x08 */ Component::GUI::AtkComponentButton* Button;
+    /* 0x10 */ Component::GUI::AtkResNode* RevealedIconResNode;
+    /* 0x18 */ Component::GUI::AtkResNode* UnkRes20;
+    /* 0x20 */ Component::GUI::AtkResNode* RevealedTileResNode;
+    /* 0x28 */ __int64 Unk28;
+};
+
+struct Client::UI::AddonWeeklyPuzzle::GameTileRow /* Size=0x120 */
+{
+    /* 0x000 */ Client::UI::AddonWeeklyPuzzle::GameTileItem Col1;
+    /* 0x030 */ Client::UI::AddonWeeklyPuzzle::GameTileItem Col2;
+    /* 0x060 */ Client::UI::AddonWeeklyPuzzle::GameTileItem Col3;
+    /* 0x090 */ Client::UI::AddonWeeklyPuzzle::GameTileItem Col4;
+    /* 0x0C0 */ Client::UI::AddonWeeklyPuzzle::GameTileItem Col5;
+    /* 0x0F0 */ Client::UI::AddonWeeklyPuzzle::GameTileItem Col6;
+};
+
+struct Client::UI::AddonWeeklyPuzzle::GameTileBoard /* Size=0x6C0 */
+{
+    /* 0x000 */ Client::UI::AddonWeeklyPuzzle::GameTileRow Row1;
+    /* 0x120 */ Client::UI::AddonWeeklyPuzzle::GameTileRow Row2;
+    /* 0x240 */ Client::UI::AddonWeeklyPuzzle::GameTileRow Row3;
+    /* 0x360 */ Client::UI::AddonWeeklyPuzzle::GameTileRow Row4;
+    /* 0x480 */ Client::UI::AddonWeeklyPuzzle::GameTileRow Row5;
+    /* 0x5A0 */ Client::UI::AddonWeeklyPuzzle::GameTileRow Row6;
+};
+
+struct Client::UI::AddonWeeklyPuzzle /* Size=0xD00 */
+{
+    /* 0x000 */ Component::GUI::AtkUnitBase AtkUnitBase;
+    /* 0x220 */ Client::UI::AddonWeeklyPuzzle::RewardPanelItem RewardPanelCommander;
+    /* 0x248 */ Client::UI::AddonWeeklyPuzzle::RewardPanelItem RewardPanelCoffer;
+    /* 0x270 */ Client::UI::AddonWeeklyPuzzle::RewardPanelItem RewardPanelGiftBox;
+    /* 0x298 */ Client::UI::AddonWeeklyPuzzle::RewardPanelItem RewardPanelDualBlades;
+    /* 0x2C0 */ Component::GUI::AtkComponentButton* AtkComponentButton2C0;
+    /* 0x2C8 */ Component::GUI::AtkResNode* AtkResNode2C8;
+    /* 0x2D0 */ Component::GUI::AtkTextNode* AtkTextNode2D0;
+    /* 0x2D8 */ Component::GUI::AtkTextNode* AtkTextNode2D8;
+    /* 0x2E0 */ Component::GUI::AtkResNode* AtkResNode2E0;
+    /* 0x2E8 */ Component::GUI::AtkTextNode* AtkTextNode2E8;
+    /* 0x2F0 */ Component::GUI::AtkTextNode* AtkTextNode2F0;
+    /* 0x2F8 */ Client::UI::AddonWeeklyPuzzle::GameTileBoard GameBoard;
+    /*       */ byte _gap_0x9B8[0x80];
+    /* 0xA38 */ Component::GUI::AtkResNode* AtkResNodeA38;
+    /*       */ byte _gap_0xA40[0x108];
+    /* 0xB48 */ Client::System::String::Utf8String CommanderStr;
+    /* 0xBB0 */ Client::System::String::Utf8String CofferStr;
+    /* 0xC18 */ Client::System::String::Utf8String GiftBoxStr;
+    /* 0xC80 */ Client::System::String::Utf8String DualBladesStr;
+    /*       */ byte _gap_0xCE8[0x18];
+};
+
+struct Client::UI::RaptureAtkModule::NamePlateInfo /* Size=0x248 */
+{
+    /* 0x000 */ __int32 ActorID;
+    /*       */ byte _gap_0x4[0x4];
+    /*       */ byte _gap_0x8[0x28];
+    /* 0x030 */ Client::System::String::Utf8String Name;
+    /* 0x098 */ Client::System::String::Utf8String FcName;
+    /* 0x100 */ Client::System::String::Utf8String Title;
+    /* 0x168 */ Client::System::String::Utf8String DisplayTitle;
+    /* 0x1D0 */ Client::System::String::Utf8String LevelText;
+    /*       */ byte _gap_0x238[0x8];
+    /* 0x240 */ __int32 Flags;
+    /*       */ byte _gap_0x244[0x4];
+};
+
+struct Client::UI::RaptureAtkModule /* Size=0x275E8 */
+{
+    /* 0x00000 */ void* vtbl;
+    /*         */ byte _gap_0x8[0x1A240];
+    /* 0x1A248 */ Client::UI::RaptureAtkModule::NamePlateInfo NamePlateInfoArray;
+    /*         */ byte _gap_0x1A490[0xD158];
+};
+
+struct Client::UI::UIModule::Unk1 /* Size=0x8 */
+{
+    union {
+    /* 0x0 */ void* vtbl;
+    /* 0x0 */ void** vfunc;
+    } _union_0x0;
+};
+
+struct Client::UI::UIModule::Unk2 /* Size=0x8 */
+{
+    union {
+    /* 0x0 */ void* vtbl;
+    /* 0x0 */ void** vfunc;
+    } _union_0x0;
+};
+
+struct Client::UI::UIModule::Unk3 /* Size=0x8 */
+{
+    union {
+    /* 0x0 */ void* vtbl;
+    /* 0x0 */ void** vfunc;
+    } _union_0x0;
+};
+
+struct Client::UI::UIModule /* Size=0xDE750 */
+{
+    union {
+    /* 0x00000 */ void* vtbl;
+    /* 0x00000 */ void** vfunc;
+    } _union_0x0;
+    /* 0x00008 */ Client::UI::UIModule::Unk1 UnkObj1;
+    /* 0x00010 */ Client::UI::UIModule::Unk2 UnkObj2;
+    /* 0x00018 */ Client::UI::UIModule::Unk3 UnkObj3;
+    /* 0x00020 */ void* unk;
+    /* 0x00028 */ void* SystemConfig;
+    /*         */ byte _gap_0x30[0xB47A0];
+    /* 0xB47D0 */ Client::UI::RaptureAtkModule RaptureAtkModule;
+    /*         */ byte _gap_0xDBDB8[0x2998];
+};
+
+struct Client::System::Configuration::SystemConfig /* Size=0x450 */
+{
+    /* 0x000 */ Common::Configuration::SystemConfig CommonSystemConfig;
+};
+
+struct Client::System::Framework::Framework /* Size=0x2B50 */
+{
+    /*        */ byte _gap_0x0[0x10];
+    /* 0x0010 */ Client::System::Configuration::SystemConfig SystemConfig;
+    /*        */ byte _gap_0x460[0x2598];
+    /* 0x29F8 */ void* UIModule;
+    /*        */ byte _gap_0x2A00[0x150];
+};
+
+struct Client::Graphics::Matrix44 /* Size=0x40 */
+{
+    /* 0x00 */ float Matrix[0x10];
+};
+
+struct Client::Graphics::Vector3 /* Size=0x10 */
+{
+    /* 0x00 */ float X;
+    /* 0x04 */ float Y;
+    /* 0x08 */ float Z;
+    /*      */ byte _gap_0xC[0x4];
+};
+
+struct Client::Graphics::Scene::Object /* Size=0x80 */
+{
+    /*      */ byte _gap_0x0[0x30];
+    /* 0x30 */ Client::Graphics::Scene::Object* ChildObject;
+    /*      */ byte _gap_0x38[0x48];
+};
+
+struct Client::Graphics::Scene::DrawObject /* Size=0x90 */
+{
+    /* 0x00 */ Client::Graphics::Scene::Object Object;
+    /*      */ byte _gap_0x80[0x10];
+};
+
+struct Client::Graphics::Physics::BoneSimulator /* Size=0x100 */
+{
+    /* 0x000 */ void* vtbl;
+    /*       */ byte _gap_0x8[0x8];
+    /* 0x010 */ unsigned __int32 PhysicsGroup;
+    /*       */ byte _gap_0x14[0x4];
+    /* 0x018 */ void* Skeleton;
+    /* 0x020 */ Client::Graphics::Vector3 CharacterPosition;
+    /* 0x030 */ Client::Graphics::Vector3 Gravity;
+    /* 0x040 */ Client::Graphics::Vector3 Wind;
+    /*       */ byte _gap_0x50[0xB0];
+};
+
+struct PointerVector::ClientGraphicsPhysicsBoneSimulator /* Size=0x18 */
+{
+    /* 0x00 */ Client::Graphics::Physics::BoneSimulator** First;
+    /* 0x08 */ Client::Graphics::Physics::BoneSimulator** Last;
+    /* 0x10 */ Client::Graphics::Physics::BoneSimulator** End;
+};
+
+struct Client::Graphics::Physics::BoneSimulators /* Size=0x78 */
+{
+    /* 0x00 */ PointerVector::ClientGraphicsPhysicsBoneSimulator BoneSimulator_1;
+    /* 0x18 */ PointerVector::ClientGraphicsPhysicsBoneSimulator BoneSimulator_2;
+    /* 0x30 */ PointerVector::ClientGraphicsPhysicsBoneSimulator BoneSimulator_3;
+    /* 0x48 */ PointerVector::ClientGraphicsPhysicsBoneSimulator BoneSimulator_4;
+    /* 0x60 */ PointerVector::ClientGraphicsPhysicsBoneSimulator BoneSimulator_5;
+};
+
+struct Client::Graphics::Physics::BonePhysicsModule /* Size=0x1C0 */
+{
+    /* 0x000 */ void* vtbl;
+    /*       */ byte _gap_0x8[0x8];
+    /* 0x010 */ Client::Graphics::Matrix44 SkeletonWorldMatrix;
+    /* 0x050 */ Client::Graphics::Matrix44 SkeletonInvWorldMatrix;
+    /* 0x090 */ float WindScale;
+    /* 0x094 */ float WindVariation;
+    /* 0x098 */ void* Skeleton;
+    /* 0x0A0 */ Client::Graphics::Physics::BoneSimulators BoneSimulators;
+    /*       */ byte _gap_0x118[0xA8];
+};
+
+struct Client::Graphics::Scene::CharacterBase /* Size=0x8F0 */
+{
+    /* 0x000 */ Client::Graphics::Scene::DrawObject DrawObject;
+    /* 0x090 */ byte UnkFlags_01;
+    /*       */ byte _gap_0x91;
+    /*       */ byte _gap_0x92[0x2];
+    /*       */ byte _gap_0x94[0x4];
+    /* 0x098 */ __int32 SlotCount;
+    /*       */ byte _gap_0x9C[0x4];
+    /* 0x0A0 */ void* Skeleton;
+    /* 0x0A8 */ void** ModelArray;
+    /*       */ byte _gap_0xB0[0x98];
+    /* 0x148 */ void* PostBoneDeformer;
+    /* 0x150 */ Client::Graphics::Physics::BonePhysicsModule* BonePhysicsModule;
+    /*       */ byte _gap_0x158[0xE8];
+    /* 0x240 */ void* CharacterDataCB;
+    /*       */ byte _gap_0x248[0x80];
+    /* 0x2C8 */ unsigned __int32 HasModelInSlotLoaded;
+    /* 0x2CC */ unsigned __int32 HasModelFilesInSlotLoaded;
+    /* 0x2D0 */ void* TempData;
+    /* 0x2D8 */ void* TempSlotData;
+    /*       */ byte _gap_0x2E0[0x8];
+    /* 0x2E8 */ void** MaterialArray;
+    /* 0x2F0 */ void* EID;
+    /* 0x2F8 */ void** IMCArray;
+    /*       */ byte _gap_0x300[0x5F0];
+};
+
+struct Client::Graphics::Scene::Human /* Size=0xA80 */
+{
+    /* 0x000 */ Client::Graphics::Scene::CharacterBase CharacterBase;
+    /* 0x8F0 */ byte CustomizeData[0x1A];
+    /*       */ byte _gap_0x90A[0x2];
+    /* 0x90C */ unsigned __int32 SlotNeedsUpdateBitfield;
+    /* 0x910 */ byte EquipSlotData[0x28];
+    /* 0x938 */ unsigned __int16 RaceSexId;
+    /* 0x93A */ unsigned __int16 HairId;
+    /* 0x93C */ unsigned __int16 FaceId;
+    /* 0x93E */ unsigned __int16 TailEarId;
+    /*       */ byte _gap_0x940[0xF8];
+    /* 0xA38 */ byte* ChangedEquipData;
+    /*       */ byte _gap_0xA40[0x40];
+};
+
+struct Client::Graphics::Render::OffscreenRenderingManager /* Size=0x150 */
+{
+    /* 0x000 */ void* vtbl;
+    /* 0x008 */ void* JobSystem_vtbl;
+    /*       */ byte _gap_0x10[0xB8];
+    /* 0x0C8 */ void* Camera_1;
+    /* 0x0D0 */ void* Camera_2;
+    /* 0x0D8 */ void* Camera_3;
+    /* 0x0E0 */ void* Camera_4;
+    /*       */ byte _gap_0xE8[0x68];
+};
+
+struct Client::Game::Character::BattleChara /* Size=0x2B60 */
+{
+    /* 0x0000 */ Client::Game::Character::Character Character;
+    /*        */ byte _gap_0x1934[0x4];
+    /*        */ byte _gap_0x1938[0x1228];
+};
+
+struct Client::Game::Character::Companion /* Size=0x19C0 */
+{
+    /* 0x0000 */ Client::Game::Character::Character Character;
+    /*        */ byte _gap_0x1934[0x4];
+    /*        */ byte _gap_0x1938[0x88];
+};
+

--- a/ida/ffxiv_idarename.py
+++ b/ida/ffxiv_idarename.py
@@ -21,6 +21,14 @@ if sys.version_info[0] >= 3:
 
 
 class BaseApi(object):
+    @property
+    @abstractmethod
+    def data_file_path(self):
+        """
+        Get the Path to the data.yml File
+        :return: Path to the data.yml File
+        :rtype: str
+        """
 
     @property
     @abstractmethod
@@ -210,9 +218,15 @@ if api is None:
         import idaapi  # noqa
         import idc  # noqa
         import idautils  # noqa
-
-
+    except ImportError:
+        print("Warning: Unable to load IDA")
+    else:
+        # noinspection PyUnresolvedReferences
         class IdaApi(BaseApi):
+
+            @property
+            def data_file_path(self):
+                return os.path.join(os.path.dirname(os.path.realpath(__file__)), "data.yml")
 
             @property
             def sub_prefixes(self):
@@ -292,8 +306,6 @@ if api is None:
 
 
         api = IdaApi()
-    except ImportError:
-        print("Warning: Unable to load IDA")
 
 # endregion
 # region Ghidra Api
@@ -301,12 +313,19 @@ if api is None:
 if api is None:
     try:
         import ghidra
-        from ghidra.program.model.data import CategoryPath
-        from ghidra.program.model.data import StructureDataType
-        from ghidra.program.model.data import PointerDataType
 
-
+        from ghidra.program.model.data import CategoryPath  # noqa
+        from ghidra.program.model.data import StructureDataType  # noqa
+        from ghidra.program.model.data import PointerDataType  # noqa
+    except ImportError:
+        print("Warning: Unable to load Ghidra")
+    else:
+        # noinspection PyUnresolvedReferences
         class GhidraApi(BaseApi):
+
+            @property
+            def data_file_path(self):
+                return os.path.join(os.path.dirname(str(sourceFile)), "data.yml")
 
             @property
             def sub_prefixes(self):
@@ -396,8 +415,6 @@ if api is None:
 
 
         api = GhidraApi()
-    except ImportError:
-        print("Warning: Unable to load Ghidra")
 
 # endregion
 
@@ -406,8 +423,7 @@ if api is None:
 
 
 def load_data():
-    data_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data.yml")
-    with open(data_file, "r") as fd:
+    with open(api.data_file_path, "r") as fd:
         data = yaml.safe_load(fd)
 
     for ea, name in data["globals"].items():


### PR DESCRIPTION
Handle generics by creating \<GenericType\>::\<ImplentingType\>. For example, PointerVector::BoneSimulator.
Handle stupid union issues by just not exporting things. See Matrix44. 
Implement bytearray gap strategy, fill with byte[] instead of sequential longs. Makes importing to ida a breeze. Different strokes for different folks.

Rolling in ida script fix to this PR after collaborating with @pohky 