### PR TITLE
Add AddonAttribute

### DIFF
--- a/FFXIV/Client/UI/Addon.cs
+++ b/FFXIV/Client/UI/Addon.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI {
+    public class Addon : Attribute {
+        
+        public IEnumerable<string> AddonIdentifiers { get; }
+        
+        public Addon(params string[] addonIdentifiers) {
+            AddonIdentifiers = addonIdentifiers;
+        }
+    }
+}

--- a/FFXIV/Client/UI/AddonChatLogPanel.cs
+++ b/FFXIV/Client/UI/AddonChatLogPanel.cs
@@ -7,6 +7,7 @@ namespace FFXIVClientStructs.FFXIV.Client.UI
     //   Component::GUI::AtkUnitBase
     //     Component::GUI::AtkEventListener
     [StructLayout(LayoutKind.Explicit, Size = 0x3D0)]
+    [Addon("ChatLogPanel_0", "ChatLogPanel_1", "ChatLogPanel_2", "ChatLogPanel_3")]
     public unsafe struct AddonChatLogPanel
     {
         [FieldOffset(0x0)] public AtkUnitBase AtkUnitBase;


### PR DESCRIPTION
A request or something
A way to label structs with what addons they apply to would be nice
this is purely for debugging purposes really, would allow automatic identification and easy parsing of addon data

Only added to ChatLogPanel for now because cbf adding it to them all if you hate the idea