### PR TITLE
Scholar guage, seraph timer offset is wrong.

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
@@ -17,9 +17,9 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Gauge {
 
     [StructLayout(LayoutKind.Explicit, Size = 0x10)]
     public struct ScholarGauge {
-        [FieldOffset(0x08)] public short SeraphTimer;
         [FieldOffset(0x0A)] public byte Aetherflow;
         [FieldOffset(0x0B)] public byte FairyGauge;
+        [FieldOffset(0x0C)] public short SeraphTimer;
         [FieldOffset(0x0E)] public byte DismissedFairy;
     }
 


### PR DESCRIPTION
From Dalamud API3, offsets listed below are -8 
```        /// <summary>
        /// Gets the amount of Aetherflow stacks available.
        /// </summary>
        [FieldOffset(2)]
        public byte NumAetherflowStacks;

        /// <summary>
        /// Gets the current level of the Fairy Gauge.
        /// </summary>
        [FieldOffset(3)]
        public byte FairyGaugeAmount;

        /// <summary>
        /// Gets the Seraph time remaining in milliseconds.
        /// </summary>
        [FieldOffset(4)]
        public short SeraphTimer;

        /// <summary>
        /// Gets the last dismissed fairy.
        /// </summary>
        [FieldOffset(6)]
        public DismissedFairy DismissedFairy;```