### PR TITLE
Fixing BLM Enochian

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
@@ -59,6 +59,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Gauge {
         public int UmbralStacks => ElementStance >= 0 ? 0 : ElementStance * -1;
         public int AstralStacks => ElementStance <= 0 ? 0 : ElementStance;
         public bool EnochianActive => Enochian != 0;
+        public bool ParadoxActive => Enochian == 3;
     }
 
     [StructLayout(LayoutKind.Explicit, Size = 0x10)]

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
@@ -58,8 +58,8 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Gauge {
 
         public int UmbralStacks => ElementStance >= 0 ? 0 : ElementStance * -1;
         public int AstralStacks => ElementStance <= 0 ? 0 : ElementStance;
-        public bool EnochianActive => Enochian != 0;
-        public bool ParadoxActive => Enochian == 3;
+        public bool EnochianActive => Enochian == 1 || Enochian == 3;
+        public bool ParadoxActive => Enochian > 1;
     }
 
     [StructLayout(LayoutKind.Explicit, Size = 0x10)]


### PR DESCRIPTION
Paradox is a new thing BLM has when swapping between Umbral and Astral stances.
It seems like they reused the Enochian value to track this state.

Also Enochian != 0 doesn't mean enochian is active now, since Enochian == 2 means its not up but Paradox is active.