### PR TITLE
Update dragoon gauge

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
@@ -143,9 +143,10 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Gauge
     [StructLayout(LayoutKind.Explicit, Size = 0x10)]
     public struct DragoonGauge
     {
-        [FieldOffset(0x08)] public short BotdTimer;
-        [FieldOffset(0x0A)] public byte BotdState;
+        [FieldOffset(0x08)] public short LotdTimer;
+        [FieldOffset(0x0A)] public byte LotdState; // This seems to only ever be 0 or 2 now
         [FieldOffset(0x0B)] public byte EyeCount;
+        [FieldOffset(0x0C)] public byte FirstmindsFocusCount;
     }
 
     [StructLayout(LayoutKind.Explicit, Size = 0x18)]


### PR DESCRIPTION
- Added the new Firstminds' Focus count.
- Renamed Botd to Lotd since Blood of the Dragon is baseline now and these values only track Life of the Dragon now.