### PR TITLE
add SelectedCharacterId offset to AgentLobby

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
@@ -11,6 +11,7 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Agent {
         public static AgentLobby* Instance() => (AgentLobby*) Framework.Instance()->GetUiModule()->GetAgentModule()->GetAgentByInternalId(AgentId.Lobby);
 
         [FieldOffset(0x0)] public AgentInterface AgentInterface;
+        [FieldOffset(0x818)] public ulong SelectedCharacterId;
         [FieldOffset(0x820)] public byte DataCenter;
         [FieldOffset(0x840)] public uint IdleTime;
     }


### PR DESCRIPTION
This represents the character ID (same as in the `FFXIV_CHR*` folder names) of the currently previewed character on the character select screen.