### PR TITLE
Add AtkUnitBase VisibilityFlags

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -26,6 +26,7 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI
         [FieldOffset(0x108)] public AtkComponentNode* WindowNode;
         [FieldOffset(0x1AC)] public float Scale;
         [FieldOffset(0x182)] public byte Flags;
+        [FieldOffset(0x1B6)] public byte VisibilityFlags;
         [FieldOffset(0x1BC)] public short X;
         [FieldOffset(0x1BE)] public short Y;
         [FieldOffset(0x1CC)] public ushort ID;


### PR DESCRIPTION
not sure how to call that flags since they aren't the only ones that control visibility 🤷 

i use them to show addons only on mouseover

```c#
[Flags]
public enum AddonVisibility : byte
{
	UserHidden = 1 << 0, // Hidden by the user in current HUD layout
	GameHidden = 1 << 2 // Hidden by the game, Scenario Guide during duty for example
}
```
