### PR TITLE
Private MemberFunction

### DIFF
--- a/FFXIVClientStructs.Generators/FunctionGenerator/FunctionModels.cs
+++ b/FFXIVClientStructs.Generators/FunctionGenerator/FunctionModels.cs
@@ -24,5 +24,6 @@ namespace FFXIVClientStructs.Generators.FunctionGenerator
         public string Signature;
         public int VirtualOffset;
         public bool IsStatic;
+        public bool IsPrivate;
     }
 }

--- a/FFXIVClientStructs.Generators/FunctionGenerator/FunctionSyntaxContextReceiver.cs
+++ b/FFXIVClientStructs.Generators/FunctionGenerator/FunctionSyntaxContextReceiver.cs
@@ -53,8 +53,8 @@ namespace FFXIVClientStructs.Generators.FunctionGenerator
                         { } memberFuncAttr)
                     {
                         functionObj.Signature = (string)memberFuncAttr.ConstructorArguments[0].Value;
-                        functionObj.IsStatic = memberFuncAttr.NamedArguments.Any() &&
-                                               (bool)(memberFuncAttr.NamedArguments[0].Value.Value ?? false);
+                        functionObj.IsStatic = memberFuncAttr.NamedArguments.Any(na => na.Value.Value != null && na.Key == "IsStatic" && (bool)na.Value.Value);
+                        functionObj.IsPrivate = memberFuncAttr.NamedArguments.Any(na => na.Value.Value != null && na.Key == "IsPrivate" && (bool) na.Value.Value);
                         structObj.MemberFunctions.Add(functionObj);
                         if (ms.Name == "Ctor")
                             structObj.HasCtor = true;

--- a/FFXIVClientStructs.Generators/FunctionGenerator/FunctionTemplates.cs
+++ b/FFXIVClientStructs.Generators/FunctionGenerator/FunctionTemplates.cs
@@ -10,7 +10,7 @@ namespace {{ struct.namespace }} {
         {{~ for mf in struct.member_functions ~}}
         public static delegate* unmanaged[Stdcall] <{{ if !mf.is_static }}{{ struct.name }}*,{{ end }}{{ if mf.has_params }}{{ mf.param_type_list }},{{ end }}{{ if mf.has_bool_return }}byte{{ else }}{{ mf.return_type }}{{ end }}> fp{{ mf.name }} { internal set; get; }
 
-        public{{ if mf.is_static }} static{{ end }} partial {{ mf.return_type }} {{ mf.name }}({{ mf.param_list }})
+        {{ if mf.is_private }}private{{ else }}public{{ end}}{{ if mf.is_static }} static{{ end }} partial {{ mf.return_type }} {{ mf.name }}({{ mf.param_list }})
         {
             if (fp{{ mf.name }} is null)
             {

--- a/FFXIVClientStructs/Attributes/MemberFunctionAttribute.cs
+++ b/FFXIVClientStructs/Attributes/MemberFunctionAttribute.cs
@@ -12,4 +12,5 @@ public class MemberFunctionAttribute : Attribute
 
     public string Signature { get; }
     public bool IsStatic { get; set; } = false;
+    public bool IsPrivate { get; set; } = false;
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -2,7 +2,7 @@
 
 //ctor 40 53 48 83 EC 20 48 8B D9 48 8D 81 ?? ?? ?? ?? BA
 [StructLayout(LayoutKind.Explicit, Size = 0x778)]
-public unsafe struct PlayerState
+public unsafe partial struct PlayerState
 {
     [FieldOffset(0x00)] public byte IsLoaded;
     [FieldOffset(0x01)] public fixed byte CharacterName[64];
@@ -47,4 +47,18 @@ public unsafe struct PlayerState
     {
         return classJobId is < 8 or > 15 ? 0 : DesynthesisLevels[classJobId - 8] / 100f;
     }
+
+    [MemberFunction("E8 ?? ?? ?? ?? BE ?? ?? ?? ?? 84 C0 75 0C")]
+    public partial byte GetBeastTribeRank(byte beastTribeIndex);
+
+    [MemberFunction("45 33 C9 48 81 C1 ?? ?? ?? ?? 45 8D 51 02", IsStatic = true, IsPrivate = true)]
+    private static partial ulong GetBeastTribeAllowance(void* ptr);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 4C 8B E8 BB", IsStatic = true, IsPrivate = true)]
+    private static partial void* GetBeastTribeAllowancePointer();
+
+    public static ulong GetBeastTribeAllowance() {
+        return GetBeastTribeAllowance(GetBeastTribeAllowancePointer());
+    }
+
 }


### PR DESCRIPTION
PR because its changing the generator
Adds ability to make member functions private, with an example of its usage