### PR TITLE
Add Discovered AddonActionBarBase Fields

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonActionBarBase.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonActionBarBase.cs
@@ -6,6 +6,27 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 public unsafe partial struct AddonActionBarBase {
     [FieldOffset(0x00)] public AtkUnitBase AtkUnitBase;
 
+    /// <summary>
+    /// Bitfield representing currently active pulses.
+    /// </summary>
+    [FieldOffset(0x238)] public short CurrentPulsingSlots;
+    
+    /// <summary>
+    /// The ID of the hotbar in RaptureHotbarModule that this ActionBar is currently referencing.
+    /// </summary>
+    [FieldOffset(0x23C)] public byte RaptureHotbarId;
+    
+    /// <summary>
+    /// Whether the current hotbar is considered a "shared" hotbar or not.
+    /// </summary>
+    [FieldOffset(0x240)] public bool IsSharedHotbar;
+
+    /// <summary>
+    /// Trigger the "pulse" effect for the specified hotbar slot, similar to what happens on hotbar slot keypress.
+    ///
+    /// Note that this method *CAN* trigger pulses on hotbar slots that don't have an item in them!
+    /// </summary>
+    /// <param name="slotIndex">A zero-indexed value of which slot to pulse.</param>
     [VirtualFunction(76)]
     public partial void PulseActionBarSlot(int slotIndex);
 }


### PR DESCRIPTION
This PR seeks to add the following fields:

- **`0x238` - `CurrentPulsingSlots`**  
This field is a `WORD` that lists all currently pulsing hotbar slots as a bitmask. Written to by `PulseActionBarSlot` and possibly others.
- **`0x23C` - `RaptureHotbarId`**  
This field is a byte (!) that denotes the `RaptureHotbarModule` hotbar ID that this ActionBar is currently referencing. This field will change in response to cycles on `_ActionBar` or `_ActionCross`, but is also present on fixed hotbar slots. There is some oddness in the value of this field for WXHB slots presently, but this may be a limitation/misunderstanding of `RaptureHotbarModule` as well.
- **`0x240` - `IsSharedHotbar`**
This field is set to `01` when the currently-viewed hotbar is "shared", and `00` otherwise. What this value impacts exactly is unknown at the time of writing.

Documentation has also been added to relevant fields/methods.