### PR TITLE
Update InfoProxyCrossRealm.cs

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCrossRealm.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCrossRealm.cs
@@ -56,7 +56,7 @@ public unsafe partial struct InfoProxyCrossRealm
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B F8 8B 46 10", IsStatic = true)]
     public static partial CrossRealmMember* GetMemberByContentId(ulong contentId);
 
-    [MemberFunction("40 53 4C 8B 05", IsStatic = true)]
+    [MemberFunction("40 53 4C 8B 05", IsStatic = true), Obsolete("This function is bugged, results are not reliable.", false)]
     public static partial CrossRealmMember* GetMemberByObjectId(uint objectId);
 
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 2E 0F B6 5E 11", IsStatic = true)]


### PR DESCRIPTION
The function is indeed what the name says, but SE used the wrong variable when indexing the array, so it's not actually iterating over all members, rending the results unreliable.
```
currPartyMemberIndex = ++nextPartyMemberIndex;
if ( nextPartyMemberIndex >= g_Client::UI::Info::InfoProxyCrossRealm_Instance->CrossRealmGroupArray[0x288 * nextPartyMemberIndex] )
  goto LABEL_10;
```
Instead of using the current group id (v2), they used the next party member index (v3).