### PR TITLE
Add submarine and airship functions names

### DIFF
--- a/ida/data.yml
+++ b/ida/data.yml
@@ -445,7 +445,11 @@ classes:
     funcs:
       0x140B90740: IsSubmarineExplorationUnlocked # static
       0x140B90780: IsSubmarineExplorationUnlocked2 # static
-      0x140B907E0: GetSurveyDuration
+      0x140B907E0: GetSubmarineSurveyDuration
+      0x140B8F740: GetSubmarineVoyageDistance
+      0x140B91CB0: GetSubmarineVoyageTime
+      0x140B84590: GetAirshipVoyageTimeAndDistance
+      0x140B846B0: GetAirshipSurveyDuration
   InventoryContainer:
     funcs:
       0x1406D83C0: GetInventorySlot  # (this, slotIndex)
@@ -2042,6 +2046,8 @@ classes:
       0x1404A02B0: GetSheetByName  # (ExdModule* this, char* pcszName) -> ExcelSheet*
       0x140641240: IsColumnRsv  # (ExdModule* this, int nSheetIndex, int nRowId, int nSubRowId, int nColumnIndex) -> bool
       0x1406ADD50: GetItemRow # static (uint itemId)
+      0x1406B4590: GetAirshipExplorationPointRow # (uint rowId)
+      0x1406B4690: GetSubmarineExplorationRow # (uint rowid)
   Client::System::Scheduler::ScheduleManagement:
     vtbls:
       - ea: 0x14181EA00

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -445,11 +445,11 @@ classes:
     funcs:
       0x140B90740: IsSubmarineExplorationUnlocked # static
       0x140B90780: IsSubmarineExplorationUnlocked2 # static
-      0x140B907E0: GetSubmarineSurveyDuration
-      0x140B8F740: GetSubmarineVoyageDistance
-      0x140B91CB0: GetSubmarineVoyageTime
-      0x140B84590: GetAirshipVoyageTimeAndDistance
-      0x140B846B0: GetAirshipSurveyDuration
+      0x140B907E0: GetSubmarineSurveyDuration # (unsigned __int8 point, __int16 speed) -> SurveyDuration (return is time in seconds)
+      0x140B91E50: GetSubmarineVoyageDistance # (unsigned __int8 point, unsigned __int8 speed) -> VoyageDistance (return is integer)
+      0x140B91CB0: GetSubmarineVoyageTime # (unsigned __int8 pointA, unsigned __int8 pointB, __int16 speed) -> VoyageTime (return is time in seconds)
+      0x140B84590: GetAirshipVoyageTimeAndDistance # (unsigned __int8 pointA, unsigned __int8 pointB, __int16 speed, _DWORD *voyageTime, int *voyageDistance)
+      0x140B846B0: GetAirshipSurveyDuration # (unsigned __int8 point, __int16 speed) -> SurveyDuration (return is time in seconds)
   InventoryContainer:
     funcs:
       0x1406D83C0: GetInventorySlot  # (this, slotIndex)

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2047,7 +2047,7 @@ classes:
       0x140641240: IsColumnRsv  # (ExdModule* this, int nSheetIndex, int nRowId, int nSubRowId, int nColumnIndex) -> bool
       0x1406ADD50: GetItemRow # static (uint itemId)
       0x1406B4590: GetAirshipExplorationPointRow # (uint rowId)
-      0x1406B4690: GetSubmarineExplorationRow # (uint rowid)
+      0x1406B4690: GetSubmarineExplorationRow # (uint rowId)
   Client::System::Scheduler::ScheduleManagement:
     vtbls:
       - ea: 0x14181EA00


### PR DESCRIPTION
Just adds some functions that I know what they do to the list.

Also, yes SE has 2 different `SurveyDuration` calculations so renamed one to say which one it is from.

For patch `2022.06.21.0000.0000` if I'm not done before patch drop