### PR TITLE
Add Unlock Research

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Cabinet.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Cabinet.cs
@@ -1,0 +1,34 @@
+﻿namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
+
+/// <summary>
+/// A struct representing the UIState Cabinet (otherwise known as the "Armoire" in-game) and the bitfield for stores
+/// items.
+/// </summary>
+[StructLayout(LayoutKind.Explicit, Size = 0x45)]
+public unsafe partial struct Cabinet {
+    [FieldOffset(0x00)] public int CabinetLoaded; // This becomes 2 for some reason, unsure why or what it means.
+    [FieldOffset(0x04)] public fixed byte UnlockedItems[0x41];
+
+    /// <summary>
+    /// Check if an item is stored in the player's armoire.
+    /// </summary>
+    /// <param name="cabinetItemId">The armoire item entry ID to check against. This is not an item ID but a specific ID
+    /// from the Cabinet table.</param>
+    /// <returns>Returns true if the armoire contains the specified item.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 16 8B CB")]
+    public partial bool IsItemInCabinet(int cabinetItemId);
+
+    /// <summary>
+    /// Check if the armoire is reporting as "loaded" from the server.
+    /// </summary>
+    /// <remarks>
+    /// The armoire will only load when requested (so, when a player goes to an inn room and chooses to add/remove an
+    /// item or performs certain glamour operations). As such, before any check can take place, a developer must first
+    /// validate that the armoire is loaded. Generally, this will be when CabinetLoaded == 1, but for some reason this
+    /// can have a value of 2 as well.
+    /// </remarks>
+    /// <returns>Returns true if the armoire has been retrieved.</returns>
+    public bool IsCabinetLoaded() {
+        return this.CabinetLoaded > 0;
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -42,6 +42,9 @@ public unsafe partial struct PlayerState
     [FieldOffset(0x458)] public short PlayerCommendations;
 
     [FieldOffset(0x70A)] public fixed ushort DesynthesisLevels[8];
+    
+    [StaticAddress("48 8D 0D ?? ?? ?? ?? E9 ?? ?? ?? ?? CC 40 53")]
+    public static partial PlayerState* Instance();
 
     public float GetDesynthesisLevel(uint classJobId)
     {
@@ -61,4 +64,65 @@ public unsafe partial struct PlayerState
         return GetBeastTribeAllowance(GetBeastTribeAllowancePointer());
     }
 
+    /// <summary>
+    /// Check if a specific mount has been unlocked by the player.
+    /// </summary>
+    /// <param name="mountId">The ID of the mount to look up.</param>
+    /// <returns>Returns true if the mount has been unlocked.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 5C 8B CB")]
+    public partial bool IsMountUnlocked(uint mountId);
+
+    /// <summary>
+    /// Check if a specific ornament (fashion accessory) has been unlocked by the player.
+    /// </summary>
+    /// <param name="ornamentId">The ID of the ornament to look up.</param>
+    /// <returns>Returns true if the ornament has been unlocked.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? BA ?? ?? ?? ?? 41 0F B6 CE")]
+    public partial bool IsOrnamentUnlocked(uint ornamentId);
+
+    /// <summary>
+    /// Check if a specific orchestrion roll has been unlocked by the player.
+    /// </summary>
+    /// <param name="rollId">The ID of the roll to look up.</param>
+    /// <returns>Returns true if the roll has been unlocked.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 88 44 3B 08")]
+    public partial bool IsOrchestrionRollUnlocked(uint rollId);
+
+    /// <summary>
+    /// Check if a Secret Recipe Book (DoH Master Tome) is unlocked and (indirectly) if the player can craft recipes
+    /// from that specific book.
+    /// </summary>
+    /// <param name="tomeId">The ID of the book to check for. Can be retrieved from the SecretRecipeBook sheet.</param>
+    /// <returns>Returns true if the book is unlocked.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 0F B6 4D 9A")]
+    public partial bool IsSecretRecipeBookUnlocked(uint tomeId);
+
+    /// <summary>
+    /// Check if a Folklore Book (DoL Master Tome) is unlocked and (indirectly) if the player can find legendary nodes
+    /// revealed by that book.
+    /// </summary>
+    /// <param name="tomeId">The ID of the book to check for. Can be retrieved from GatheringSubCategory.Division</param>
+    /// <returns></returns>
+    [MemberFunction("E9 ?? ?? ?? ?? 0F B7 57 70")]
+    public partial bool IsFolkloreBookUnlocked(uint tomeId);
+
+    /// <summary>
+    /// Check if a specific McGuffin (Collectible/Curiosity) has been unlocked by the player.
+    /// </summary>
+    /// <param name="mcGuffinId">The ID of the McGuffin to look up, generally from the McGuffin sheet.</param>
+    /// <returns>Returns true if the McGuffin has been unlocked.</returns>
+    [MemberFunction("8D 42 FF 3C ?? 77 44 4C 8B 89")]
+    public partial bool IsMcGuffinUnlocked(uint mcGuffinId);
+
+    /// <summary>
+    /// Check if a particular Framer's Kit is unlocked and can be used.
+    /// </summary>
+    /// <remarks>
+    /// How IDs are located is a bit weird and not necessarily fully understood at time of writing. They appear on Framer
+    /// Kit items in the AdditionalData field, and at +0 in BannerCondition EXDs when +0xE == 9.
+    /// </remarks>
+    /// <param name="kitId">The kit ID to check for.</param>
+    /// <returns></returns>
+    [MemberFunction("4C 8B C9 66 83 FA 28")] // !!! Not happy about this
+    public partial bool IsFramersKitUnlocked(uint kitId);
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -102,7 +102,7 @@ public unsafe partial struct PlayerState
     /// revealed by that book.
     /// </summary>
     /// <param name="tomeId">The ID of the book to check for. Can be retrieved from GatheringSubCategory.Division</param>
-    /// <returns></returns>
+    /// <returns>Returns true if the book is unlocked.</returns>
     [MemberFunction("E9 ?? ?? ?? ?? 0F B7 57 70")]
     public partial bool IsFolkloreBookUnlocked(uint tomeId);
 
@@ -122,7 +122,7 @@ public unsafe partial struct PlayerState
     /// Kit items in the AdditionalData field, and at +0 in BannerCondition EXDs when +0xE == 9.
     /// </remarks>
     /// <param name="kitId">The kit ID to check for.</param>
-    /// <returns></returns>
+    /// <returns>Returns true if the framer's kit is unlocked.</returns>
     [MemberFunction("4C 8B C9 66 83 FA 28")] // !!! Not happy about this
     public partial bool IsFramersKitUnlocked(uint kitId);
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
@@ -1,12 +1,14 @@
-﻿using FFXIVClientStructs.FFXIV.Client.Game.Event;
+﻿using System;
+using FFXIVClientStructs.FFXIV.Client.Game.Event;
 using FFXIVClientStructs.FFXIV.Client.Game.Fate;
+using FFXIVClientStructs.FFXIV.Component.Exd;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 // this is a large object holding most of the other objects in the Client::Game::UI namespace
 // all data in here is used for UI display
 
 // ctor E8 ? ? ? ? 48 8D 0D ? ? ? ? 48 83 C4 28 E9 ? ? ? ? 48 83 EC 28 33 D2 
-[StructLayout(LayoutKind.Explicit, Size = 0x168D8)] // its at least this big, may be a few bytes bigger
+[StructLayout(LayoutKind.Explicit, Size = 0x16AE4)] // its at least this big, may be a few bytes bigger
 public unsafe partial struct UIState
 {
     [FieldOffset(0x00)] public Hotbar Hotbar;
@@ -16,6 +18,7 @@ public unsafe partial struct UIState
     [FieldOffset(0xA38)] public PlayerState PlayerState;
     [FieldOffset(0x11C8)] public Revive Revive;
     [FieldOffset(0x1498)] public Telepo Telepo;
+    [FieldOffset(0x14F0)] public Cabinet Cabinet;
     [FieldOffset(0x1A60)] public Buddy Buddy;
     [FieldOffset(0x2A70)] public RelicNote RelicNote;
 
@@ -24,12 +27,91 @@ public unsafe partial struct UIState
     [FieldOffset(0xA950)] public Map Map;
     
     [FieldOffset(0x11AF0)] public ContentsFinder ContentsFinder;
-
+    
+    // No idea why this isn't its own thing, but I can't find any trace of any member functions or anything worthy of
+    // making this its own struct. 
+    [FieldOffset(0x169C2)] public fixed byte UnlockedCompanionsBitmask[0x3A];
+    
     [StaticAddress("48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? 48 8B 01")]
     public static partial UIState* Instance();
 
     [MemberFunction("E8 ?? ?? ?? ?? 88 45 80")]
     public partial bool IsUnlockLinkUnlocked(uint unlockLink);
+
+    /// <summary>
+    /// Checks to see if an unlock link is unlocked, or if the passed value is greater than 0x10000, checks if the quest
+    /// is completed.
+    /// </summary>
+    /// <param name="unlockLinkOrQuestId">The unlock link or quest ID to check</param>
+    /// <param name="a3">Unknown, but appears to always be 1.</param>
+    /// <returns>Returns true if the unlock link is unlocked or if the quest is completed.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 A4")]
+    public partial bool IsUnlockLinkUnlockedOrQuestCompleted(uint unlockLinkOrQuestId, byte a3);
+    
+    /// <summary>
+    /// Check an item (by EXD row) to see if the action associated with the item is unlocked or "obtained/registered."
+    /// </summary>
+    /// <remarks>
+    /// This method populates offset 324 of *something*, which is then used in turn to display the "checked" flag on
+    /// unlockable items. It's used in a few other places, but this appears to be the primary use.
+    /// <br /><br />
+    /// This method **will** call EXD, so the usual caveats there apply. Where possible, use a by-ID check as they're
+    /// generally faster or rely less on EXD.
+    /// </remarks>
+    /// <param name="itemExdPtr">A pointer to an EXD row for an item, generally retrieved from <see cref="ExdModule.GetItemRowById"/>.</param>
+    /// <returns>Returns a number (byte?) based on the item's unlock status. For reasons unknown, this is a long but
+    /// no value above 4 has ever been noted.
+    /// <list type="table">
+    /// <listheader><term>Value</term><description>Meaning</description></listheader>
+    /// <item><term>1</term><description>The item is unlocked/registered.</description></item>
+    /// <item><term>2</term><description>The item is not unlocked/registered, but can be.</description></item>
+    /// <item><term>3</term><description>Can be returned, but not clear as to when.</description></item>
+    /// <item><term>4</term><description>The item has no unlock action, or an unlock action was not found.</description></item>
+    /// </list>
+    /// </returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 83 F8 01 75 03")]
+    public partial long IsItemActionUnlocked(void* itemExdPtr);
+
+    /// <summary>
+    /// Check if a Triple Triad card is obtained by the character.
+    /// </summary>
+    /// <param name="cardId">The ID of the card (technically, of TripleTriadCardResident) to check against.</param>
+    /// <returns>Returns true if the card is unlocked.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 8D 7B 78")]
+    public partial bool IsTripleTriadCardUnlocked(ushort cardId);
+
+    /// <summary>
+    /// Check if an emote (by ID) is unlocked.
+    /// </summary>
+    /// <remarks>
+    /// This method *will* perform an EXD get. If the unlock link is known it is better to call
+    /// <see cref="IsUnlockLinkUnlockedOrQuestCompleted"/> in order to prevent the extra call, as it performs
+    /// functionally the same checks.
+    /// </remarks>
+    /// <param name="emoteId">The ID of the emote to check for.</param>
+    /// <returns>Returns true if the emote is unlocked.</returns>
+    [MemberFunction("E9 ?? ?? ?? ?? 8B CB 48 8B C3")]
+    public partial bool IsEmoteUnlocked(ushort emoteId);
+
+    /// <summary>
+    /// Check if a companion (minion) is unlocked for the current character.
+    /// </summary>
+    /// <remarks>
+    /// WARNING: This method is NOT BOUNDED on IDs. While *one* function seems to set an upper bound on this, this
+    /// method is a pain in the neck to find *and*, frustratingly, cannot be sigged. 
+    /// </remarks>
+    /// <param name="companionId">The ID of the companion/minion to check for.</param>
+    /// <returns>Returns true if the specified minion is unlocked.</returns>
+    public bool IsCompanionUnlocked(uint companionId) {
+        // Logic borrowed from E8 ?? ?? ?? ?? 84 C0 75 A6 32 C0 and others.
+        
+        // This, for some reason, does not exist as a siggable method in the game code normally. Virtually everyone and
+        // everything that does minion checks will have this snippet (or one like it) in place. One does exist in the
+        // crossref for the bitmask, but it's over in what I suspect is in the UI module and is bounded. I don't want to
+        // replicate this upper bound here as that'll just be something we need to change with alarming regularity.
+        
+        return ((1 << ((int) companionId & 7)) & this.UnlockedCompanionsBitmask[companionId >> 3]) > 0;
+    }
 
     [MemberFunction("E8 ?? ?? ?? ?? 44 22 F0", IsStatic = true)]
     public static partial bool IsInstanceContentCompleted(uint instanceContentId);

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -32,6 +32,7 @@ globals:
   0x141FA2644: g_Client::Game::UI::ContentsFinder::ExplorerMode
   0x141FA2645: g_Client::Game::UI::ContentsFinder::LevelSync
   0x141FA2646: g_Client::Game::UI::ContentsFinder::LimitedLevelingRoulette
+  0x141FA7502: g_Client::Game::UI::UnlockedCompanionsMask  # not a pointer
   0x141FB2128: g_FateTablePtr
   0x141F43040: g_SomeOtherRenderingState
   0x141F55314: g_InvSqrt3
@@ -530,13 +531,25 @@ classes:
       0x14094A940: Initialize
       0x14095A4E0: ctor
       0x1409481C0: IsUnlockLinkUnlocked
+      0x1409481F0: IsUnlockLinkUnlockedOrQuestCompleted
+      0x14094A420: IsEmoteUnlocked
       0x1412970E0: IsInstanceContentCompleted
   Client::Game::UI::PlayerState:
+    instances:
+      - ea: 0x141F91578
+        pointer: False
     funcs:
       0x1408EA880: SetCharacterName
       0x1408EBF50: GetBeastTribeRank
       0x1408EBFD0: GetBeastTribeCurrentRep
       0x1408EC010: GetBeastTribeNeededRep
+      0x1408EBA40: IsMountUnlocked
+      0x1408EE740: IsOrnamentUnlocked
+      0x1408ED1B0: IsOrchestrionRollUnlocked
+      0x1408EC370: IsSecretRecipeBookUnlocked # DoH unlockable books
+      0x1408ED0F0: IsFolkloreTomeUnlocked     # DoL unlockable books
+      0x1408EE530: IsMcGuffinUnlocked
+      0x1408EE840: IsFramersKitUnlocked
       0x1408EE930: Initialize
       0x140959CC0: ctor
   Client::Game::UI::Revive:
@@ -555,6 +568,12 @@ classes:
         pointer: False
     funcs:
       0x140925560: IsBuddyEquipUnlocked
+  Client::Game::UI::Cabinet:
+    instances:
+      - ea: 0x141F92030
+        pointer: False
+    funcs:
+      0x140921980: IsItemInCabinet        # item is a cabinet-specific ID, not generic Item.
   Client::Game::UI::RelicNote:
     vtbls:
       - ea: 0x1418796A0


### PR DESCRIPTION
This pull request seeks to add a bit of research done regarding various unlock systems in the game. The vast majority of these methods (and supporting information) was found from `IsItemActionUnlocked` and spreads from there. With this pull request, I think most (all?) unlockable item types now have associated ClientStruct entries.

Of particular note that may need closer review:
- I added a struct for `Cabinet` (the in-game Armoire). Because there appear to be a number of member functions for dealing with the armoire, it seemed prudent to combine all of these together. The size 0x45 is a best guess, but it may be 0x44 instead.
- I added a new field to `UIState` for `UnlockedCompanionsBitmask`. Unlike `Cabinet`, I was not able to find anything specific to this mask, so I decided to keep it as a field rather than split into a struct.
- As a result of adding the minion bitmask, I had to increase the struct size to `0x16AE4` for `UIState`.
- I do have some concerns that the added bitfields (especially `Cabinet`) may expand over time, and cause issues if all the following offsets change. I'm not particularly sure how to fix this gracefully, or if (as I suspect), this is just something we'll have to deal with if/when the time comes.

As usual, I have attempted to add appropriate comments/documentation to cover the critical points of the methods as well as any potential gotchas that may come up.