### PR TITLE
Fix UnlockedCompanionsBitmask in UIState

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
@@ -31,7 +31,10 @@ public unsafe partial struct UIState
     
     // No idea why this isn't its own thing, but I can't find any trace of any member functions or anything worthy of
     // making this its own struct. 
-    [FieldOffset(0x169C2)] public fixed byte UnlockedCompanionsBitmask[0x3A]; //??
+    // Ref: g_Client::Game::UI::UnlockedCompanionsMask
+    //      direct ref: 48 8D 0D ?? ?? ?? ?? 0F B6 04 08 84 D0 75 10 B8 ?? ?? ?? ?? 48 8B 5C 24
+    //      relative to uistate: E8 ?? ?? ?? ?? 84 C0 75 A6 32 C0 (case for 0x355)
+    [FieldOffset(0x16A62)] public fixed byte UnlockedCompanionsBitmask[0x3A];
     
     [StaticAddress("48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? 48 8B 01")]
     public static partial UIState* Instance();


### PR DESCRIPTION
- New offset, documented the name and stable-sig

Please double-check my math before merging, the math checks out but I'm unable at present to test this on live code.

```
g_Client::Game::UI::UnlockedCompanionsMask - 0x14207CDC2
g_Client::Game::UI::UIState_Instance       - 0x142066360
--------------------------------------------------------
                                             0x000016A62
```

If there's a way I can use our sig for this, that would be awesome, but honestly not sure how.