### PR TITLE
MJIManager Building Fields

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/MJIManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/MJIManager.cs
@@ -134,7 +134,7 @@ public struct MJIBuildingPlacement
 	[FieldOffset(0x0)] public uint PlaceId;
 
 	/// <summary>
-	///     Matches a distinct value in the 2nd column of the MJIBuild sheet.
+	///     Matches a distinct value in the 2nd column of the MJIBuilding sheet.
 	/// </summary>
 	[FieldOffset(0x4)] public ushort BuildingTypeId;
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/MJIManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/MJIManager.cs
@@ -40,6 +40,27 @@ public unsafe partial struct MJIManager {
 	[FieldOffset(0x3A)] public fixed byte LockedPouchItems[66];
 
 	/// <summary>
+	///     Compare MJIBuilding sheet's 2nd column to <see cref="MJIManagerBuilding.BuildinTypeId" />, to find the
+	///     building definition.
+	/// </summary>
+	[FieldOffset(0x1A4)] public MJIManagerBuilding Facility1;
+
+	/// <inheritdoc cref="Facility1"/>
+	[FieldOffset(0x1B4)] public MJIManagerBuilding Facility2;
+
+	/// <inheritdoc cref="Facility1"/>
+	[FieldOffset(0x1C4)] public MJIManagerBuilding Facility3;
+
+	/// <inheritdoc cref="Facility1"/>
+	[FieldOffset(0x1D4)] public MJIManagerBuilding Facility4;
+
+	/// <inheritdoc cref="Facility1"/>
+	[FieldOffset(0x1E4)] public MJIManagerBuilding Facility5;
+
+	/// <inheritdoc cref="Facility1"/>
+	[FieldOffset(0x1F4)] public MJIManagerBuilding Cabin;
+
+	/// <summary>
 	///     A reference to the current set of popularity scores given to craftworks on the player's island. The actual
 	///     popularity scores can be pulled from the MJICraftworksPopularity sheet using this value as a Row ID.
 	/// </summary>
@@ -102,6 +123,15 @@ public unsafe partial struct MJIManager {
 	public CraftworkDemandShift GetDemandShiftForCraftwork(uint itemId) {
 		return (CraftworkDemandShift)(SupplyAndDemandShifts[itemId] & 0x0F);
 	}
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x10)]
+public struct MJIManagerBuilding
+{
+	/// <summary>
+	///     Matches a distinct value in the 2nd column of the MJIBuild sheet.
+	/// </summary>
+	[FieldOffset(0x0)] public ushort BuildinTypeId;
 }
 
 public enum CraftworkSupply {

--- a/FFXIVClientStructs/FFXIV/Client/Game/MJIManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/MJIManager.cs
@@ -40,25 +40,25 @@ public unsafe partial struct MJIManager {
 	[FieldOffset(0x3A)] public fixed byte LockedPouchItems[66];
 
 	/// <summary>
-	///     Compare MJIBuilding sheet's 2nd column to <see cref="MJIManagerBuilding.BuildinTypeId" />, to find the
+	///     Compare MJIBuilding sheet's 2nd column to <see cref="MJIBuildingPlacement.BuildingTypeId" />, to find the
 	///     building definition.
 	/// </summary>
-	[FieldOffset(0x1A4)] public MJIManagerBuilding Facility1;
+	[FieldOffset(0x1A0)] public MJIBuildingPlacement Facility1;
 
 	/// <inheritdoc cref="Facility1"/>
-	[FieldOffset(0x1B4)] public MJIManagerBuilding Facility2;
+	[FieldOffset(0x1B0)] public MJIBuildingPlacement Facility2;
 
 	/// <inheritdoc cref="Facility1"/>
-	[FieldOffset(0x1C4)] public MJIManagerBuilding Facility3;
+	[FieldOffset(0x1C0)] public MJIBuildingPlacement Facility3;
 
 	/// <inheritdoc cref="Facility1"/>
-	[FieldOffset(0x1D4)] public MJIManagerBuilding Facility4;
+	[FieldOffset(0x1D0)] public MJIBuildingPlacement Facility4;
 
 	/// <inheritdoc cref="Facility1"/>
-	[FieldOffset(0x1E4)] public MJIManagerBuilding Facility5;
+	[FieldOffset(0x1E0)] public MJIBuildingPlacement Facility5;
 
 	/// <inheritdoc cref="Facility1"/>
-	[FieldOffset(0x1F4)] public MJIManagerBuilding Cabin;
+	[FieldOffset(0x1F0)] public MJIBuildingPlacement Cabin;
 
 	/// <summary>
 	///     A reference to the current set of popularity scores given to craftworks on the player's island. The actual
@@ -126,12 +126,17 @@ public unsafe partial struct MJIManager {
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x10)]
-public struct MJIManagerBuilding
+public struct MJIBuildingPlacement
 {
+	/// <summary>
+	///     Should line up with the row ids of the MJIBuildingPlace sheet.
+	/// </summary>
+	[FieldOffset(0x0)] public uint PlaceId;
+
 	/// <summary>
 	///     Matches a distinct value in the 2nd column of the MJIBuild sheet.
 	/// </summary>
-	[FieldOffset(0x0)] public ushort BuildinTypeId;
+	[FieldOffset(0x4)] public ushort BuildingTypeId;
 }
 
 public enum CraftworkSupply {


### PR DESCRIPTION
(Was going to keep this as a draft until more fields were resolved, but the added `PlaceId` field probably gives it enough utility to open the PR at this point)

Additional details:

 - Filled in by calls to `ffxiv_dx11.exe+C99000` in a few different events. (Opening workshop agenda, etc)
 - `MJIBuildingPlacement+8` values match for the same building types.
 - There appears to be landmark-related values following `Cabin`, but the structure seems off.

