### PR TITLE
Add weird missing agent.

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
@@ -318,6 +318,7 @@ public enum AgentId : uint {
     DeepDungeonMenu = 254,
     ItemAppraisal = 257, //DeepDungeon Appraisal
     ItemInspection = 258, //Lockbox
+    RecipeItemContext = 259, // context menus for RecipeTree and RecipeList, constructor inlined
     ContactList = 260,
     Snipe = 265,
     MountSpeed = 266,

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4193,6 +4193,10 @@ classes:
         base: Client::UI::Agent::AgentInterface
     funcs:
       0x140A777C0: ctor
+  Client::UI::Agent::AgentRecipeItemContext:
+    vtbls:
+      - ea: 0x1418AE300
+        base: Client::UI::Agent::AgentInterface
   Client::UI::Agent::AgentTeleportHousingFriend:
     vtbls:
       - ea: 0x1419346D0


### PR DESCRIPTION
Encountered this agent when investigating item context menus on RecipeTree and RecipeList. Both seem to use it. The item id for the current context menu is at +0x28 of this agent. The constructor is inlined in AgentModule.ctor.
Feel free to investigate its actual purpose further, I haven't checked what it does otherwise. :D