### PR TITLE
Add EorzeaTimeOverride to Framework.

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
@@ -21,6 +21,8 @@ public unsafe partial struct Framework
     [FieldOffset(0x1680)] public long ServerTime;
     [FieldOffset(0x16B8)] public float FrameDeltaTime;
     [FieldOffset(0x1770)] public long EorzeaTime;
+    [FieldOffset(0x1798)] public long EorzeaTimeOverride;
+    [FieldOffset(0x17A0)] public bool IsEorzeaTimeOverridden;
     [FieldOffset(0x17C4)] public float FrameRate;
     [FieldOffset(0x17D0)] public bool WindowInactive;
 


### PR DESCRIPTION
This is used in cutscenes and GPose to override EorzeaTime. When the flag is true, it effects the time absolutely, when false it appears to be some kind of offset to real EorzeaTime.