### PR TITLE
Wrap ActionTimelineManager in Container

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -46,7 +46,7 @@ public unsafe partial struct Character
     [FieldOffset(0x818)] public fixed byte EquipSlotData[4 * 10];
     [FieldOffset(0x840)] public fixed byte CustomizeData[0x1A];
 
-    [FieldOffset(0x8E0)] public ActionTimelineManager ActionTimelineManager;
+    [FieldOffset(0x8F0)] public ActionTimelinesContainer ActionTimelines;
 
     [FieldOffset(0xC60)] public uint PlayerTargetObjectID;
 
@@ -166,6 +166,12 @@ public unsafe partial struct Character
 	    [FieldOffset(0x08)] public BattleChara* OwnerObject;
 	    [FieldOffset(0x10)] public Ornament* OrnamentObject;
 	    [FieldOffset(0x18)] public ushort OrnamentId;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x340)]
+    public struct ActionTimelinesContainer
+    {
+        [FieldOffset(0x10)] public ActionTimelineManager ActionTimelineManager;
     }
 
     public enum EurekaElement : byte


### PR DESCRIPTION
I'm still not sure if this is entirely correct as it appears `ActionTimelineManager` struct I introduced is actually at least 2 different structs that live within this new container struct (or some of the fields currently in ATM belong here in the container).

However, this at least aligns things on the Character side so this is at the correct address as referenced in the constructor. 

I'll revisit this in future and see how it's best to break it up. 

(Addresses here are updated for 6.3 so should cleanly merge with any other changes to addresses in here).