### PR TITLE
Fix AgentMap offsets

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMap.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMap.cs
@@ -52,10 +52,10 @@ public unsafe partial struct AgentMap
 
     [FieldOffset(0x59B0)] public byte MapMarkerCount;
     [FieldOffset(0x59B1)] public byte TempMapMarkerCount;
-    [FieldOffset(0x59B3)] public byte IsFlagMarkerSet;
-    [FieldOffset(0x59B5)] public byte MiniMapMarkerCount;
-    [FieldOffset(0x59BD)] public byte IsPlayerMoving;
-    [FieldOffset(0x59C5)] public byte IsControlKeyPressed;
+    [FieldOffset(0x59B5)] public byte IsFlagMarkerSet;
+    [FieldOffset(0x59B7)] public byte MiniMapMarkerCount;
+    [FieldOffset(0x59BF)] public byte IsPlayerMoving;
+    [FieldOffset(0x59C7)] public byte IsControlKeyPressed;
 
     public static AgentMap* Instance() => Framework.Instance()->GetUiModule()->GetAgentModule()->GetAgentMap();
 


### PR DESCRIPTION
It seems the offsets at the end of the struct moved by 2 bytes.