### PR TITLE
Add TerritoryInfo

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/TerritoryInfo.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/TerritoryInfo.cs
@@ -1,0 +1,17 @@
+﻿namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
+
+/// <summary>
+/// Contains the PlaceName values of where the player is currently located.
+/// </summary>
+[StructLayout(LayoutKind.Explicit, Size = 0x60)]
+public unsafe partial struct TerritoryInfo
+{
+    [FieldOffset(0x1C)] public int InSanctuary;
+    [FieldOffset(0x20)] public uint AreaPlaceNameID;
+    [FieldOffset(0x24)] public uint SubAreaPlaceNameID;
+
+    [StaticAddress("48 8D 0D ?? ?? ?? ?? BA ?? ?? ?? ?? F3 0F 5C 05", 3)]
+    public static partial TerritoryInfo* Instance();
+
+    public bool IsInSanctuary() => InSanctuary != 0;
+}


### PR DESCRIPTION
`off_14207B5B0`

This struct is created in GameMain_Initialize, it has a size of 0x60 in memory, though most of it seems to always be zero.
I use this struct in `Where Am I Again?` it contains two PlaceName values for area, and sub area.
It seems the Map Agent references these values in a few places.

I'm not sold on the name, if anyone has a better idea for the name let me know.

It's not a manager of anything, so I don't think it's appropriate to be in FFXIV.Client.Game, so I tossed it into FFXIV.Client.Game.UI as it does relate to things like display names and toasts.

![image](https://user-images.githubusercontent.com/9083275/213939563-9dc890f6-6125-48a5-8a69-ddecdf89148f.png)
