### PR TITLE
CExporter: Correctly handle generic types

### DIFF
--- a/ida/CExporter/Program.cs
+++ b/ida/CExporter/Program.cs
@@ -333,6 +333,10 @@ namespace CExporter
             {
                 var generic = type.GetGenericTypeDefinition();
                 fullName = generic.FullName.Split('`')[0];
+                if (type.IsNested)
+                {
+                    fullName += '+' + generic.FullName.Split('+')[1].Split('[')[0];
+                }
                 foreach (var argType in type.GenericTypeArguments)
                 {
                     var argTypeFullName = FixFullName(argType).Replace("::", "");

--- a/ida/CExporter/Program.cs
+++ b/ida/CExporter/Program.cs
@@ -1,4 +1,3 @@
-using FFXIVClientStructs.STD;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -329,19 +328,23 @@ namespace CExporter
                 throw new Exception($"Unknown EnvFormat: {EnvFormat}");
 
             string fullName;
-            if (type.IsGenericType)
+            if (type.IsGenericType || (type.IsPointer && type.GetElementType().IsGenericType))
             {
-                var generic = type.GetGenericTypeDefinition();
+                bool isPointer = type.IsPointer;
+                var dereferenced = isPointer ? type.GetElementType() : type;
+                var generic = dereferenced.GetGenericTypeDefinition();
                 fullName = generic.FullName.Split('`')[0];
-                if (type.IsNested)
+                if (dereferenced.IsNested)
                 {
                     fullName += '+' + generic.FullName.Split('+')[1].Split('[')[0];
                 }
-                foreach (var argType in type.GenericTypeArguments)
+                foreach (var argType in dereferenced.GenericTypeArguments)
                 {
                     var argTypeFullName = FixFullName(argType).Replace("::", "");
                     fullName += $"{separator}{argTypeFullName}";
                 }
+                if (isPointer)
+                    fullName += '*';
             }
             else
             {

--- a/ida/CExporter/Program.cs
+++ b/ida/CExporter/Program.cs
@@ -348,11 +348,11 @@ namespace CExporter
                 fullName = type.FullName;
             }
 
-            if (fullName.Contains(FFXIVNamespacePrefix))
+            if (fullName.StartsWith(FFXIVNamespacePrefix))
                 fullName = fullName.Remove(0, FFXIVNamespacePrefix.Length);
-            if (fullName.Contains(STDNamespacePrefix))
+            if (fullName.StartsWith(STDNamespacePrefix))
                 fullName = fullName.Remove(0, STDNamespacePrefix.Length);
-            if (fullName.Contains(InteropNamespacePrefix))
+            if (fullName.StartsWith(InteropNamespacePrefix))
                 fullName = fullName.Remove(0, InteropNamespacePrefix.Length);
 
             if (fullName.Contains("FFXIVClientStructs, Version"))


### PR DESCRIPTION
This adresses the following three problems:
* When a generic type was part of FFXIVClientstructs namespace, the type name was corrupted
* Nested types in generic types had the same name as their parent
* Pointers to generic types would be resolved to either void* or an invalid System type

I have tested these cahnges with Ghidra only, as I don't have IDA. If someone could test this with IDA it would be appreciated