### PR TITLE
Add ArrayData getters

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkArrayDataHolder.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkArrayDataHolder.cs
@@ -2,7 +2,7 @@
 
 // ctor E8 ?? ?? ?? ?? 48 8D 8E ?? ?? ?? ?? 48 89 BE ?? ?? ?? ?? 48 8B C7 
 [StructLayout(LayoutKind.Explicit, Size = 0x50)]
-public unsafe struct AtkArrayDataHolder
+public unsafe partial struct AtkArrayDataHolder
 {
     [FieldOffset(0x0)]
     public short NumberArrayCount; // these are total counts - some of the slots can be (and are) empty
@@ -23,4 +23,13 @@ public unsafe struct AtkArrayDataHolder
     [FieldOffset(0x38)] public short* ExtendArrayKeys;
     [FieldOffset(0x40)] public ExtendArrayData** _ExtendArrays;
     [FieldOffset(0x48)] public ExtendArrayData** ExtendArrays;
+
+    [MemberFunction("E8 ?? ?? ?? ?? EB 47 33 F6 8B CE 48 8B 47 18")]
+    public partial NumberArrayData* GetNumberArrayData(int index);
+
+    [MemberFunction("E8 ?? ?? ?? ?? EB 47 33 F6 8B CE 48 8B 47 30")]
+    public partial StringArrayData* GetStringArrayData(int index);
+
+    [MemberFunction("E8 ?? ?? ?? ?? EB 3C 33 FF")]
+    public partial ExtendArrayData* GetExtendArrayData(int index);
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkModule.cs
@@ -8,6 +8,15 @@ public unsafe partial struct AtkModule
     [FieldOffset(0x0)] public void* vtbl;
     [FieldOffset(0x1B48)] public AtkArrayDataHolder AtkArrayDataHolder;
 
+    [VirtualFunction(9)]
+    public partial NumberArrayData* GetNumberArrayData(int index);
+
+    [VirtualFunction(10)]
+    public partial StringArrayData* GetStringArrayData(int index);
+
+    [VirtualFunction(11)]
+    public partial ExtendArrayData* GetExtendArrayData(int index);
+
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 BA 40 84 FF")]
     public partial bool IsTextInputActive();
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -620,6 +620,9 @@ classes:
   Component::GUI::AtkArrayDataHolder:
     funcs:
       0x1404EE0F0: ctor
+      0x1404EE890: GetNumberArrayData
+      0x1404EE930: GetStringArrayData
+      0x1404EE9D0: GetExtendArrayData
   Component::GUI::AtkRenderer:
     funcs:
       0x1404EF2D0: Initialize
@@ -2623,6 +2626,9 @@ classes:
       - ea: 0x141931FC0
         base: Component::GUI::AtkModuleInterface
     vfuncs:
+      9: GetNumberArrayData
+      10: GetStringArrayData
+      11: GetExtendArrayData
       17: SetHandlerFunction
       39: SetUIVisibility
       58: OnUpdate


### PR DESCRIPTION
Adds native getters to AtkArrayDataHolder and AtkModule to get NumberArrayData*, StringArrayData* and ExtendArrayData* by index. If the requested ArrayData is empty, it will allocate it before returning.

The AtkModule virtual functions simply forward the call to the respective AtkArrayDataHolder member function.