### PR TITLE
Move GetBeastTribeAllowance to QuestManager

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
@@ -57,6 +57,9 @@ public unsafe partial struct QuestManager
      */
     public bool IsQuestAccepted(uint questId) => this.IsQuestAccepted((ushort) (questId & 0xFFFF));
 
+    [MemberFunction("45 33 C9 48 81 C1 ?? ?? ?? ?? 45 8D 51 02")]
+    public partial uint GetBeastTribeAllowance();
+
     public bool IsDailyQuestCompleted(ushort questId) {
 	    var quest = GetDailyQuestById(questId);
 	    return quest != null && (quest->Flags & 1) != 0;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -76,14 +76,9 @@ public unsafe partial struct PlayerState
     [MemberFunction("E8 ?? ?? ?? ?? BE ?? ?? ?? ?? 84 C0 75 0C")]
     public partial byte GetBeastTribeRank(byte beastTribeIndex);
 
-    [MemberFunction("45 33 C9 48 81 C1 ?? ?? ?? ?? 45 8D 51 02")]
-    private static partial ulong GetBeastTribeAllowance(void* ptr);
-
-    [MemberFunction("E8 ?? ?? ?? ?? 4C 8B E8 BB")]
-    private static partial void* GetBeastTribeAllowancePointer();
-
+    [Obsolete("Use QuestManager.Instance()->GetBeastTribeAllowance() instead.", true)]
     public static ulong GetBeastTribeAllowance() {
-        return GetBeastTribeAllowance(GetBeastTribeAllowancePointer());
+        return QuestManager.Instance()->GetBeastTribeAllowance();
     }
 
     /// <summary>

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -81,7 +81,6 @@ functions:
   0x14065C8C0: ConvertLogMessageIdToCharaLogKind
   0x140742CA0: ExecuteCommand
   0x140C78710: CreateSelectYesno
-  0x14082CDA0: GetBeastTribeAllowance
   0x141184CB0: Client::UI::AddonHudLayoutScreen::MoveableAddonInfoStruct_UpdateAddonPosition
   0x14125C1A0: Client::Graphics::Kernel::CreateShader # static function
   0x1412686A0: NormalizeCustomizeData
@@ -507,6 +506,7 @@ classes:
       0x14082C450: GetQuestIndex
       0x14082CBE0: GetQuestClassJob
       0x14082C910: IsQuestAccepted
+      0x14082CDA0: GetBeastTribeAllowance
   InventoryManager:
     instances:
       - ea: 0x1420F6370


### PR DESCRIPTION
The static function `PlayerState.GetBeastTribeAllowance()` is misplaced because the passed private `GetBeastTribeAllowancePointer()` is actually `QuestManager_GetSingleton()`.

I have added it as a member function to QuestManager and marked `PlayerState.GetBeastTribeAllowance()` as obsolete.