### PR TITLE
Fix Wrong Attribute for MobHunt

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/MobHunt.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/MobHunt.cs
@@ -32,7 +32,7 @@ public unsafe partial struct MobHunt
     [FieldOffset(0x8)] public fixed byte unkArray[18];
     [FieldOffset(0x1A)] public fixed byte MarkID[18];
     
-    [FixedArray(typeof(KillCounts), 18)]
+    [FixedSizeArray<KillCounts>(18)]
     [FieldOffset(0x2C)] public fixed int CurrentKills[18 * 5];
     
     [FieldOffset(0x194)] public int ObtainedFlags;


### PR DESCRIPTION
Mistakenly used `FixedArray` instead of `FixedSizeArray` property.

Is the field okay to be a `fixed int[]` or does it need to be a `fixed byte[]`?