### PR TITLE
Add HasPremiumSaddlebag to PlayerState

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -22,6 +22,7 @@ public unsafe partial struct PlayerState
 
     [FieldOffset(0x130)] public short SyncedLevel;
     [FieldOffset(0x132)] public byte IsLevelSynced;
+    [FieldOffset(0x133)] public bool HasPremiumSaddlebag;
 
     [FieldOffset(0x136)] public byte GuardianDeity;
     [FieldOffset(0x137)] public byte BirthMonth;


### PR DESCRIPTION
Not sure on the name, because it could also mean the player is subscribed to the Premium Service Plan as a whole.
As far as I can see it's only being used as a bool in combination with a check for InventoryType.PremiumSaddleBag1 (4100).
Setting it to true makes the right saddlebag appear. 😏

Currently located at 0x1420EA1EB (updated Feb. 9, still at +133 from PlayerState).