### PR TITLE
Add MobHunt to EventHandlerType

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
@@ -58,6 +58,7 @@ public enum EventHandlerType : ushort {
 	InstanceContentGuide = 0x001D,
 	HousingAethernet = 0x001E,
 	FcTalk = 0x001F,
+	MobHunt = 0x0020,
 	Adventure = 0x0021,
 	DailyQuestSupply = 0x0022,
 	TripleTriad = 0x0023,


### PR DESCRIPTION
Found on events attached to B, A and S Rank monsters.