### PR TITLE
Add "ActiveCraftRecipeId" field to AgentRecipeNote.

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRecipeNote.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRecipeNote.cs
@@ -13,6 +13,7 @@ public unsafe partial struct AgentRecipeNote
     [FieldOffset(0x0)] public AgentInterface AgentInterface;
 
     [FieldOffset(0x3BC)] public int SelectedRecipeIndex;
+    [FieldOffset(0x3D4)] public uint ActiveCraftRecipeId; // 0 when not actively crafting, does not include 0x10_000
 
     // Add 0x10_000, differentiate duplicate recipes by the CraftType value + 8
     // Name           CraftType ClassJob


### PR DESCRIPTION
This field is just a uint on AgentRecipeNote I found that contains the recipe id of whichever recipe the player has started actively crafting. Contains 0 when not crafting or just looking at the recipe list (RecipeNote). Surprisingly does not contain the `0x10_000` that the "internal" APIs otherwise do.