### PR TITLE
Improve QuestManager

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
@@ -4,7 +4,7 @@ using FFXIVClientStructs.FFXIV.Application.Network.WorkDefinitions;
 namespace FFXIVClientStructs.FFXIV.Client.Game;
 
 // idk if this is a manager, but I don't know what else to call it
-[StructLayout(LayoutKind.Explicit, Size = 0xEE8)]
+[StructLayout(LayoutKind.Explicit, Size = 0xF10)]
 public unsafe partial struct QuestManager
 {
 	[FieldOffset(0x10)] public QuestListArray Quest;

--- a/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
@@ -4,7 +4,7 @@ using FFXIVClientStructs.FFXIV.Application.Network.WorkDefinitions;
 namespace FFXIVClientStructs.FFXIV.Client.Game;
 
 // idk if this is a manager, but I don't know what else to call it
-[StructLayout(LayoutKind.Explicit, Size = 0xF10)]
+[StructLayout(LayoutKind.Explicit, Size = 0xF00)]
 public unsafe partial struct QuestManager
 {
 	[FieldOffset(0x10)] public QuestListArray Quest;

--- a/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
@@ -4,7 +4,7 @@ using FFXIVClientStructs.FFXIV.Application.Network.WorkDefinitions;
 namespace FFXIVClientStructs.FFXIV.Client.Game;
 
 // idk if this is a manager, but I don't know what else to call it
-[StructLayout(LayoutKind.Explicit, Size = 0xF10)]
+[StructLayout(LayoutKind.Explicit, Size = 0xEE8)]
 public unsafe partial struct QuestManager
 {
 	[FieldOffset(0x10)] public QuestListArray Quest;
@@ -20,6 +20,8 @@ public unsafe partial struct QuestManager
 	[FixedSizeArray<LeveWork>(16)]
 	[FieldOffset(0xC80)] public fixed byte LeveQuests[0x18 * 16];
     [FieldOffset(0xE00)] public byte NumLeveAllowances;
+
+    [FieldOffset(0xEE8)] public byte NumAcceptedQuests;
     [FieldOffset(0xEF8)] public byte NumAcceptedLeveQuests;
 
 	[MemberFunction("E8 ?? ?? ?? ?? 66 BA 10 0C")]

--- a/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
@@ -4,7 +4,7 @@ using FFXIVClientStructs.FFXIV.Application.Network.WorkDefinitions;
 namespace FFXIVClientStructs.FFXIV.Client.Game;
 
 // idk if this is a manager, but I don't know what else to call it
-[StructLayout(LayoutKind.Explicit, Size = 0xEE8)]
+[StructLayout(LayoutKind.Explicit, Size = 0xF10)]
 public unsafe partial struct QuestManager
 {
 	[FieldOffset(0x10)] public QuestListArray Quest;
@@ -20,6 +20,7 @@ public unsafe partial struct QuestManager
 	[FixedSizeArray<LeveWork>(16)]
 	[FieldOffset(0xC80)] public fixed byte LeveQuests[0x18 * 16];
     [FieldOffset(0xE00)] public byte NumLeveAllowances;
+    [FieldOffset(0xEF8)] public byte NumAcceptedLeveQuests;
 
 	[MemberFunction("E8 ?? ?? ?? ?? 66 BA 10 0C")]
     public static partial QuestManager* Instance();


### PR DESCRIPTION
The constructor for QuestManager does allocate the last element at 0xEE0 size of 0x8, the next sequential struct is allocated at 0xF10 from QuestManager start.

I've been using the value at 0xEF8 in DailyDuty for quite some time, it's the number of currently accepted levequests.