### PR TITLE
Add AgentFishGuide

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFishGuide.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFishGuide.cs
@@ -1,0 +1,13 @@
+﻿using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
+[Agent(AgentId.FishGuide)]
+[StructLayout(LayoutKind.Explicit, Size = 0x158)]
+public unsafe partial struct AgentFishGuide
+{
+    [FieldOffset(0x00)] public AgentInterface AgentInterface;
+
+    [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 0F B6 93 ?? ?? ?? ?? 48 8B CE")]
+    public partial void OpenForItemId(uint itemId, bool isSpearfishing);
+}

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3887,6 +3887,8 @@ classes:
     vtbls:
       - ea: 0x1419913B0
         base: Client::UI::Agent::AgentInterface
+    funcs:
+      0x1409DD680: OpenForItemId
   Client::UI::Agent::AgentFishRecord:
     vtbls:
       - ea: 0x1419A8968


### PR DESCRIPTION
This PR adds a function to open the Fish Guide for a given Item Id.

Since the Fish Guide is split into two lists, one for fishing and one for spearfishing (the toggle button is below the item list), the caller has to specify which list the item is listed in using the `isSpearfishing` parameter.
All it needs is a check against the SpearfishingItem sheet:
```cs
var isSpearfishing = Service.Data.GetExcelSheet<SpearfishingItem>().Any(row => row.Item.Row == itemId);
```