### PR TITLE
Improve AgentContentsFinder & AddonContentsFinder

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonContentsFinder.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonContentsFinder.cs
@@ -24,6 +24,32 @@ public unsafe struct AddonContentsFinder
     [FieldOffset(0x308)] public AtkComponentRadioButton* PvpRadioButton;
     [FieldOffset(0x310)] public AtkComponentRadioButton* GoldSaucerRadioButton;
 
+    [FixedSizeArray<Pointer<AtkTextNode>>(5)]
+    [FieldOffset(0x318)] public fixed byte SelectedDutyTextNode[0x8 * 5];
+
+    // Top bar buttons/icons indicating what duty finder settings are active, ie Unsync, LootMaster
+    [FixedSizeArray<Pointer<AtkComponentButton>>(8)]
+    [FieldOffset(0x3C8)] public fixed byte SettingsButton[0x8 * 8];
+
+    [FieldOffset(0x340)] public AtkComponentTreeList* DutyList; // Does not contain a pointer to the rendered list =(
+    [FieldOffset(0x348)] public AtkComponentDropDownList* OrderByButton;
+    [FieldOffset(0x350)] public AtkComponentButton* RefreshButton;
+    [FieldOffset(0x358)] public AtkComponentButton* DutyTypeButton; // "Regular Duty" / "High End duty" toggle button
+
+    [FieldOffset(0x360)] public AtkTextNode* JobNameTextNode;
+    [FieldOffset(0x368)] public AtkTextNode* UnkTextNode;
+    [FieldOffset(0x370)] public AtkTextNode* LevelTextNode;
+    [FieldOffset(0x378)] public AtkTextNode* ItemLevelTextNode;
+    [FieldOffset(0x380)] public AtkTextNode* RoleTextNode;
+    [FieldOffset(0x388)] public AtkTextNode* NumberSelectedTextNode;
+    [FieldOffset(0x390)] public AtkTextNode* ObtainingDataTextNode;
+    [FieldOffset(0x398)] public AtkTextNode* NumOtherPartiesRecruitingTextNode;
+    
+    [FieldOffset(0x3A8)] public AtkImageNode* StarImageNode; // Image node next to ItemLevelTextNode
+    [FieldOffset(0x3B0)] public AtkResNode* RoleIconResNode;
+    [FieldOffset(0x3B8)] public AtkImageNode* RoleIconImageNode;
+    [FieldOffset(0x3C0)] public AtkResNode* NumOtherPartiesRecruitingResNode;
+
     [FieldOffset(0x16A8)] public uint SelectedRadioButton; // Index of the selected radio button
     [FieldOffset(0x16B4)] public uint SelectedRow; // Index of the currently highlighted row, index does include headers that can't be clicked on, and collapsible headers
     [FieldOffset(0x16B8)] public uint NumEntries; // Number of entries the selected tab has, includes headers such as "High-end Trials (Endwalker)"

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
@@ -61,6 +61,7 @@ public struct ItemReward
     [FieldOffset(0x44)] public int ItemId;
     [FieldOffset(0x48)] public int Quantity;
     [FieldOffset(0x58)] public Utf8String TooltipString;
+    [FieldOffset(0x78)] public Utf8String UnkString;
 }
 
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
@@ -1,4 +1,4 @@
-﻿using FFXIVClientStructs.FFXIV.Client.System.Framework;
+﻿using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
@@ -10,19 +10,31 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 [StructLayout(LayoutKind.Explicit, Size = 0x2068)]
 public unsafe partial struct AgentContentsFinder
 {
-    public static AgentContentsFinder* Instance() => (AgentContentsFinder*)Framework.Instance()->GetUiModule()->GetAgentModule()->GetAgentByInternalId(AgentId.ContentsFinder);
+    public static AgentContentsFinder* Instance() => (AgentContentsFinder*)AgentModule.Instance()->GetAgentByInternalId(AgentId.ContentsFinder);
 
     [FieldOffset(0x0)] public AgentInterface AgentInterface;
+
+    [FieldOffset(0x86)] public byte* DescriptionString; // null-terminated cstring representing the currently displayed duty description
+
+    // Reward values for the currently selected duty
+    // Will be -1 or 0xFFFFFFFF if the UI displays an "up arrow" icon instead of a value
+    [FieldOffset(0x1B8)] public int ExpReward;
+    [FieldOffset(0x1BC)] public int GilReward;
+    [FieldOffset(0x1C0)] public int SealReward;
+    [FieldOffset(0x1C4)] public int PoeticReward;
+    [FieldOffset(0x1C8)] public int NonLimitedTomestoneReward; // As of 6.3 this is Astronomy
+    [FieldOffset(0x1CC)] public int LimitedTomestoneRward; // As of 6.3 this is Causality
+    [FieldOffset(0x1D0)] public int PvPExpReward;
+    [FieldOffset(0x1D4)] public int WolfMarkReward;
+
+    [FieldOffset(0x1B4C)] public int SelectedDutyId; // ContentFinderCondition rowId for duties, ContentRoulette rowId for roulette
+    [FieldOffset(0x1B58)] public byte NumCollectedRewards; // Value used for "Reward already received"
+
+    [FixedSizeArray<Utf8String>(10)] 
+    [FieldOffset(0x1BA8)] public fixed byte Strings[0x68 * 10]; // Tooltips and Category headers, ie "Gil", "Trials (Endwalker)"
     
-    /// <summary>
-    /// The ContentFinderCondition row index for the currently selected row in the ContentsFinder
-    /// </summary>
-    [FieldOffset(0x1B4C)] public int SelectedContentFinderCondition;
-    
-    /// <summary>
-    /// Contains the value used to display "Weekly Reward Received" or "Rewards Received 2/3"
-    /// </summary>
-    [FieldOffset(0x1B58)] public byte NumCollectedRewards;
+    [FieldOffset(0x204C)] public int CurrentTimestamp;
+    [FieldOffset(0x2058)] public byte SelectedTab;
 
     [MemberFunction("48 89 6C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B F9 41 0F B6 E8")]
     public partial void* OpenRegularDuty(uint contentsFinderCondition, byte a2 = 0);

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
@@ -20,8 +20,8 @@ public unsafe partial struct AgentContentsFinder
     [FieldOffset(0x408)] public ContentsFinderRewards BonusReward;
     
     // These seem to be duplicates of the above reward structs
-    // [FieldOffset(0x5C8)] public ContentsFinderRewards Reward2;
-    // [FieldOffset(0x810)] public ContentsFinderRewards BonusReward2;
+    [FieldOffset(0x5C8)] public ContentsFinderRewards Reward2;
+    [FieldOffset(0x810)] public ContentsFinderRewards BonusReward2;
 
     [FixedSizeArray<ItemReward>(35)] 
     [FieldOffset(0x890)] public fixed byte ItemRewardArray[0x130 * 35];
@@ -61,7 +61,7 @@ public struct ItemReward
     [FieldOffset(0x44)] public int ItemId;
     [FieldOffset(0x48)] public int Quantity;
     [FieldOffset(0x58)] public Utf8String TooltipString;
-    [FieldOffset(0x78)] public Utf8String UnkString;
+    [FieldOffset(0x78)] public Utf8String UnkString; // This string seems to be unused?
 }
 
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
@@ -15,18 +15,17 @@ public unsafe partial struct AgentContentsFinder
     [FieldOffset(0x0)] public AgentInterface AgentInterface;
 
     [FieldOffset(0x86)] public byte* DescriptionString; // null-terminated cstring representing the currently displayed duty description
+    
+    [FieldOffset(0x1B8)] public ContentsFinderRewards Reward;
+    [FieldOffset(0x408)] public ContentsFinderRewards BonusReward;
+    
+    // These seem to be duplicates of the above reward structs
+    // [FieldOffset(0x5C8)] public ContentsFinderRewards Reward2;
+    // [FieldOffset(0x810)] public ContentsFinderRewards BonusReward2;
 
-    // Reward values for the currently selected duty
-    // Will be -1 or 0xFFFFFFFF if the UI displays an "up arrow" icon instead of a value
-    [FieldOffset(0x1B8)] public int ExpReward;
-    [FieldOffset(0x1BC)] public int GilReward;
-    [FieldOffset(0x1C0)] public int SealReward;
-    [FieldOffset(0x1C4)] public int PoeticReward;
-    [FieldOffset(0x1C8)] public int NonLimitedTomestoneReward; // As of 6.3 this is Astronomy
-    [FieldOffset(0x1CC)] public int LimitedTomestoneRward; // As of 6.3 this is Causality
-    [FieldOffset(0x1D0)] public int PvPExpReward;
-    [FieldOffset(0x1D4)] public int WolfMarkReward;
-
+    [FixedSizeArray<ItemReward>(35)] 
+    [FieldOffset(0x890)] public fixed byte ItemRewardArray[0x130 * 35];
+    
     [FieldOffset(0x1B4C)] public int SelectedDutyId; // ContentFinderCondition rowId for duties, ContentRoulette rowId for roulette
     [FieldOffset(0x1B58)] public byte NumCollectedRewards; // Value used for "Reward already received"
 
@@ -42,3 +41,26 @@ public unsafe partial struct AgentContentsFinder
     [MemberFunction("E9 ?? ?? ?? ?? 8B 93 ?? ?? ?? ?? 48 83 C4 20")]
     public partial void* OpenRouletteDuty(byte roulette, byte a2 = 0);
 }
+
+[StructLayout(LayoutKind.Explicit, Size = 0x20)]
+public struct ContentsFinderRewards
+{
+    [FieldOffset(0x00)] public int ExpReward;
+    [FieldOffset(0x00)] public int GilReward;
+    [FieldOffset(0x00)] public int SealReward;
+    [FieldOffset(0x00)] public int PoeticReward;
+    [FieldOffset(0x00)] public int NonLimitedTomestoneReward;
+    [FieldOffset(0x00)] public int LimitedTomestoneRward;
+    [FieldOffset(0x00)] public int PvPExpReward;
+    [FieldOffset(0x00)] public int WolfMarkReward;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x130)]
+public struct ItemReward
+{
+    [FieldOffset(0x44)] public int ItemId;
+    [FieldOffset(0x48)] public int Quantity;
+    [FieldOffset(0x58)] public Utf8String TooltipString;
+}
+
+


### PR DESCRIPTION
This does rename `SelectedContentFinderCondition` to `SelectedDutyId`, as this hasn't been merged into dalamud yet, this is probably fine.