### PR TITLE
Fix LeveWork Sequence

### DIFF
--- a/FFXIVClientStructs/FFXIV/Application/Network/WorkDefinitions/LeveWork.cs
+++ b/FFXIVClientStructs/FFXIV/Application/Network/WorkDefinitions/LeveWork.cs
@@ -3,7 +3,7 @@
 [StructLayout(LayoutKind.Explicit, Size = 0x18)]
 public struct LeveWork {
 	[FieldOffset(0x08)] public ushort LeveId;
-	[FieldOffset(0x09)] public byte Sequence;
+	[FieldOffset(0x0A)] public byte Sequence;
 	[FieldOffset(0x0C)] public ushort Flags;
 	[FieldOffset(0x0E)] public ushort LeveSeed;
 	[FieldOffset(0x10)] public byte ClearClass;


### PR DESCRIPTION
Sequence is not the second byte of the LeveId. It comes after the LeveId. Just like in [QuestWork](https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Application/Network/WorkDefinitions/QuestWork.cs).

Happy little accidents.