### PR TITLE
Even More Island Sanctuary Findings

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/MJI/IslandState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/MJI/IslandState.cs
@@ -2,6 +2,10 @@
 
 [StructLayout(LayoutKind.Explicit, Size = 0xB0)]
 public unsafe struct IslandState {
+    // Unknown!! This flag *appears* to control island state for quite a few things and is read *a lot* by Lua, but I
+    // haven't been able to tack this down quite yet. 
+    [FieldOffset(0x00)] public bool CanEditIsland;
+    
     /// <summary>
     /// The current Sanctuary Rank of the player's island. Controls what buildings/items/recipes are or aren't
     /// available to the player, and represented by MJIRank.
@@ -80,6 +84,24 @@ public unsafe struct IslandState {
     /// </summary>
     [FieldOffset(0x62)] public MJIFarmPasture Pasture;
 
+    /// <summary>
+    /// Appears to be set if the pasture in it has any animal currently under care.
+    /// </summary>
+    [FieldOffset(0x66)] public bool PastureUnderCare; // ??
+    
+    // Note: 0x68 to the game is treated as a single DWORD, but the actual values are only used in the context of
+    // LOWORD or HIWORD, so we'll split these fields.
+    
+    /// <summary>
+    /// The current daily care fee paid to the Creature Comforter for the pasture.
+    /// </summary>
+    [FieldOffset(0x68)] public ushort PastureDailyCareFee;
+    
+    /// <summary>
+    /// The current daily care fee paid to the Produce Producer for the farm.
+    /// </summary>
+    [FieldOffset(0x6A)] public ushort FarmDailyCareFee;
+    
     /// <summary>
     /// The current number of hours remaining until a specific Landmark has finished construction.
     /// 

--- a/FFXIVClientStructs/FFXIV/Client/Game/MJI/MJIManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/MJI/MJIManager.cs
@@ -168,12 +168,12 @@ public unsafe partial struct MJIManager {
     public partial bool IsItemLocked(uint itemId);
 
     /// <summary>
-    /// Checks if a specific MJIFunction is locked and therefore cannot be used.
+    /// Checks if a specific MJIFunction is unlocked and able to be used
     /// </summary>
     /// <param name="functionId">The RowID of the MJIFunction to check</param>
-    /// <returns>Returns <c>true</c> if the function is locked, <c>false</c> otherwise.</returns>
+    /// <returns>Returns <c>true</c> if the function is unlocked, <c>false</c> otherwise.</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 44 3A F0")]
-    public partial bool IsFunctionLocked(byte functionId);
+    public partial bool IsFunctionUnlocked(byte functionId);
 
     /// <summary>
     /// Get a bitfield representing the currently-displayed minimap icons.

--- a/FFXIVClientStructs/FFXIV/Client/Game/MJI/MJIPastureHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/MJI/MJIPastureHandler.cs
@@ -6,8 +6,32 @@
 public unsafe partial struct MJIPastureHandler {
     [FieldOffset(0x0)] public void* vtbl;
     
+    /// <summary>
+    /// An array representing all animals currently present in the pastures on the Island. 
+    /// </summary>
     [FixedSizeArray<MJIAnimal>(20)]
     [FieldOffset(0x2E8)] public fixed byte MJIAnimals[MJIAnimal.Size * 20];
+
+    /// <summary>
+    /// An array representing which minions are currently out roaming the Island. This array is indexed by row ID from
+    /// the Companion EXD sheet. See <see cref="MinionSlots"/> if information about minion locations is required.
+    /// </summary>
+    // Warning: This array will change size every time new minions are added!!
+    [FixedSizeArray<bool>(480)]
+    [FieldOffset(0x6F8)] public fixed byte RoamingMinions[480];
+
+    /// <summary>
+    /// An array containing information on all the minion slots present on the Island Sanctuary.
+    /// This array is indexed by an internal ID and does not appear to be grouped by location or similar.
+    /// </summary>
+    [FixedSizeArray<MJIMinionSlot>(40)] 
+    [FieldOffset(0x8B8)] public fixed byte MinionSlots[40 * MJIMinionSlot.Size];
+
+    /// <summary>
+    /// Gets the current number of minions roaming the Island Sanctuary.
+    /// </summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 3C 28 72 1E")]
+    public partial byte GetCurrentRoamingMinionCount();
 }
 
 [StructLayout(LayoutKind.Explicit, Size = Size)]
@@ -16,8 +40,36 @@ public struct MJIAnimal {
 
     [FieldOffset(0x0)] public byte SlotId;
     [FieldOffset(0x1C)] public uint BNPCNameId;
+    [FieldOffset(0x20)] public uint ObjectId;
     [FieldOffset(0x24)] public byte AnimalType;
     [FieldOffset(0x25)] public byte FoodLevel;
     [FieldOffset(0x26)] public byte Mood;
     [FieldOffset(0x27)] public ushort Leavings; // ??
+}
+
+[StructLayout(LayoutKind.Explicit, Size = Size)]
+public struct MJIMinionSlot {
+    public const int Size = 0xC;
+
+    /// <summary>
+    /// An internal ID used to track minion slots.
+    /// </summary>
+    /// <remarks>
+    /// May be set to 40 if the slot is currently empty or uninitialized.
+    /// </remarks>
+    [FieldOffset(0x0)] public byte SlotId;
+    
+    [FieldOffset(0x4)] public uint ObjectId;
+    [FieldOffset(0x8)] public ushort MinionId;
+    
+    /// <summary>
+    /// The MJIMinionPopAreaId that this minion currently resides in.
+    /// </summary>
+    [FieldOffset(0xA)] public byte PopAreaId;
+
+    /// <summary>
+    /// Check if this specific Minion Slot contains a minion or not.
+    /// </summary>
+    /// <returns>Returns <c>true</c> if a minion is present, <c>false</c> otherwise.</returns>
+    public bool IsSlotPopulated() => this.MinionId != 0;
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
@@ -74,21 +74,17 @@ public unsafe partial struct UIState
     /// Check an item (by EXD row) to see if the action associated with the item is unlocked or "obtained/registered."
     /// </summary>
     /// <remarks>
-    /// This method populates offset 324 of *something*, which is then used in turn to display the "checked" flag on
-    /// unlockable items. It's used in a few other places, but this appears to be the primary use.
-    /// <br /><br />
-    /// This method **will** call EXD, so the usual caveats there apply. Where possible, use a by-ID check as they're
-    /// generally faster or rely less on EXD.
+    /// This method <b>will</b> call EXD, so the usual caveats there apply. Where possible, use a by-ID check as
+    /// they're generally faster and/or rely less on EXD.
     /// </remarks>
     /// <param name="itemExdPtr">A pointer to an EXD row for an item, generally retrieved from <see cref="ExdModule.GetItemRowById"/>.</param>
-    /// <returns>Returns a number (byte?) based on the item's unlock status. For reasons unknown, this is a long but
-    /// no value above 4 has ever been noted.
+    /// <returns>Returns a value denoting this item's unlock status from the below table:
     /// <list type="table">
     /// <listheader><term>Value</term><description>Meaning</description></listheader>
     /// <item><term>1</term><description>The item is unlocked/registered.</description></item>
     /// <item><term>2</term><description>The item is not unlocked/registered, but can be.</description></item>
-    /// <item><term>3</term><description>Can be returned, but not clear as to when.</description></item>
-    /// <item><term>4</term><description>The item has no unlock action, or an unlock action was not found.</description></item>
+    /// <item><term>3</term><description>Unknown, possibly "information not loaded yet."</description></item>
+    /// <item><term>4</term><description>The item does not have an unlock status.</description></item>
     /// </list>
     /// </returns>
     [MemberFunction("E8 ?? ?? ?? ?? 83 F8 01 75 03")]

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -570,7 +570,7 @@ classes:
       0x140B71910: LoadDemandResearchPacket
       0x140B71E80: IsRecipeUnlocked # (this, recipeId)
       0x140B71EB0: IsPouchItemLocked # (this, pouchItemId)
-      0x140B70250: IsFunctionLocked # (this, functionId)
+      0x140B70250: IsFunctionUnlocked # (this, functionId)
       0x140B70480: HandleActorControlPacket
       0x140B70F60: HandleInboundPacket
       0x140B722F0: GetVisibleMinimapIcons
@@ -580,6 +580,12 @@ classes:
   Client::Game::MJI::IslandState:
     funcs:
       0x140B74FD0: ctor
+  Client::Game::MJI::MJIPastureHandler:
+    funcs:
+      0x1413ED140: GetCurrentRoamingMinionCount
+      0x1413ED2B0: SetMinionPlaceStatus  # (this, minionId, isPlaced)
+      0x1413ECE80: ExecuteReleaseMinion  # (this, minionId, areaId)
+      0x1413ECFC0: ExecuteRecallMinion   # (this, minionId)
   Client::System::String::Utf8String:
     funcs:
       0x140059F40: ctor  # empty string ctor
@@ -664,7 +670,11 @@ classes:
       0x14096BDF0: IsUnlockLinkUnlocked
       0x14096BE20: IsUnlockLinkUnlockedOrQuestCompleted
       0x14096E010: IsEmoteUnlocked
-      0x141380B20: IsInstanceContentCompleted
+      0x14096E180: IsItemActionUnlocked
+      0x14096C290: IsTripleTriadCardUnlocked
+      0x14096D890: GetNextMapAllowanceTimestamp
+      0x141380840: IsInstanceContentUnlocked   # static
+      0x141380B20: IsInstanceContentCompleted  # static
   Client::Game::UI::PlayerState:
     instances:
       - ea: 0x1420EA0B8


### PR DESCRIPTION
- Adds some extra `IslandState` data, specifically:
  - Whether the player has the ability to interact with the island (`CanEditIsland`)
  - Whether the Pasture is currently under mammet care (`PastureUnderCare`)
  - The daily fees for both pasture and farm care (`PastureDailyCareFee` and `FarmDailyCareFee`)
- Rename `IsFunctionLocked` to `IsFunctionUnlocked` as I got behavior backwards
- Add information about minions to `MJIPastureHandler` (this name may be a misnomer now?)
  - The `RoamingMinions` array tracks which minions are currently released and roaming the Sanctuary
  - The `MinionSlots` array tracks specific minions and other data (like position, ObjectId, etc.)
- Some other sneaky fixes