### PR TITLE
More PlayerState research

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -83,9 +83,9 @@ public unsafe partial struct PlayerState
     /// 6 = Accessorie Pose: Glasses, Wings
     /// </remarks>
     [FieldOffset(0x47A)] public fixed byte SelectedPoses[7];
-    [FieldOffset(0x481)] public byte NoviceNetworkFlags1;
-    [FieldOffset(0x482)] public byte NoviceNetworkFlags2;
-    [FieldOffset(0x483)] public byte NoviceNetworkFlags3;
+    [FieldOffset(0x481)] public byte PlayerStateFlags1;
+    [FieldOffset(0x482)] public byte PlayerStateFlags2;
+    [FieldOffset(0x483)] public byte PlayerStateFlags3;
 
     [FieldOffset(0x501)] public fixed byte UnlockFlags[44];
 
@@ -344,16 +344,16 @@ public unsafe partial struct PlayerState
     public partial bool IsReturner();
 
     /// <summary>
-    /// Returns whether the specified NoviceNetworkFlag is set for the player.
+    /// Returns whether the specified PlayerStateFlag is set.
     /// </summary>
-    /// <param name="flag">The NoviceNetworkFlag to check.</param>
+    /// <param name="flag">The PlayerStateFlag to check.</param>
     [MemberFunction("E8 ?? ?? ?? ?? 3A D8 75 2E")]
-    public partial bool IsNoviceNetworkFlagSet(NoviceNetworkFlag flag);
+    public partial bool IsPlayerStateFlagSet(PlayerStateFlag flag);
 
     #endregion
 }
 
-public enum NoviceNetworkFlag : uint
+public enum PlayerStateFlag : uint
 {
     IsLoginSecurityToken = 1,
     IsBuddyInStable = 2,

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -83,7 +83,9 @@ public unsafe partial struct PlayerState
     /// 6 = Accessorie Pose: Glasses, Wings
     /// </remarks>
     [FieldOffset(0x47A)] public fixed byte SelectedPoses[7];
-    [FieldOffset(0x481)] public fixed byte NoviceNetworkFlags[3];
+    [FieldOffset(0x481)] public byte NoviceNetworkFlags1;
+    [FieldOffset(0x482)] public byte NoviceNetworkFlags2;
+    [FieldOffset(0x483)] public byte NoviceNetworkFlags3;
 
     [FieldOffset(0x501)] public fixed byte UnlockFlags[44];
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/RouletteController.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/RouletteController.cs
@@ -1,14 +1,22 @@
 namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 
-// This name may be wrong,
-// the only known member function that uses this struct returns the completion status of the input roulette
-[StructLayout(LayoutKind.Explicit, Size = 0xC0)]
+// Client::Game::UI::RouletteController
+// ctor inlined in UIState_ctor
+[StructLayout(LayoutKind.Explicit, Size = 0x70)]
 public unsafe partial struct RouletteController
 {
     public static RouletteController* Instance() => &UIState.Instance()->RouletteController;
+
+    /// <summary>
+    /// Provides the number of minutes remaining on the penalty.
+    /// </summary>
+    /// <param name="index">0 = Duty penalty<br/>1 = Unknown</param>
+    /// <returns>Number of minutes left</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 8B 0E 3B C8")]
+    public partial uint GetPenaltyRemainingInMinutes(byte index);
     
     [MemberFunction("48 83 EC 28 84 D2 75 07 32 C0")]
-    private partial bool IsRouletteIncomplete(byte roulette);
+    public partial bool IsRouletteIncomplete(byte roulette);
 
     public bool IsRouletteComplete(byte roulette) => !IsRouletteIncomplete(roulette);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
@@ -35,6 +35,9 @@ public unsafe partial struct AgentContentsFinder
     [FixedSizeArray<ContentsRouletteRole>(11)]
     [FieldOffset(0x2007)] public fixed byte ContentRouletteRoleBonus[11];
     
+    [FieldOffset(0x2014)] public uint DutyPenaltyMinutes;
+    [FieldOffset(0x2018)] public uint UnkPenaltyMinutes;
+
     [FieldOffset(0x204C)] public int CurrentTimestamp;
     [FieldOffset(0x2058)] public byte SelectedTab;
 
@@ -73,4 +76,3 @@ public enum ContentsRouletteRole : byte {
     DPS = 2,
     None = 3,
 }
-

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -702,6 +702,17 @@ classes:
       0x1409113B0: IsWeeklyBingoStickerPlaced
       0x1409113D0: GetWeeklyBingoTaskStatus
       0x140911610: GetWeeklyBingoExpMultiplier
+      0x14090FFD0: IsNoviceNetworkFlagSet
+      0x140910010: IsNovice
+      0x140910030: IsReturner
+      0x140910090: IsMentor
+      0x1409100B0: IsBattleMentor
+      0x1409100D0: IsTradeMentor
+      0x1409107C0: IsAetherCurrentZoneComplete
+      0x140910900: IsMeisterFlagAndHasSoulStoneEquipped
+      0x1409109A0: IsMeisterFlag
+      0x140910A10: IsMeisterFlagMaxCount
+      0x140912440: GetDesynthesisLevelForClassJob
       0x140912740: Initialize
       0x14097DD20: ctor
   Client::Game::UI::Revive:
@@ -783,6 +794,9 @@ classes:
     instances:
       - ea: 0x1420FB038
         pointer: False
+    funcs:
+      0x140950470: GetPenaltyRemainingInMinutes
+      0x140952A80: IsRouletteIncomplete
   Client::Game::UI::ContentsFinder:
     vtbls:
       - ea: 0x14198F670


### PR DESCRIPTION
Some notes:

The length of `PSNOnlineID` was taken from Sapphire's [ServerZoneDef.h](https://github.com/SapphireServer/Sapphire/blob/ffdbed7/src/common/Network/PacketDef/Zone/ServerZoneDef.h#L908). Apparently the ID is a maximum of 16 characters long, so I guess the 17th byte is for the null terminator.

`PlayerState.PenaltyTimestamps` is used by `RouletteController.GetPenaltyRemainingInMinutes`, which I also have added. It's used by `AgentContentsFinder`, so I added the fields there too. Don't know what the second penalty timestamp is used for.

`FishingBait` was at the wrong offset.

Also I couldn't figure out index 1 for `SelectedPoses` or what `NoviceNetworkFlag.Unknown14` checks. Maybe someone else knows more.

`NumOwnedMounts` is incremented at `0x14090DD5F` while reading in the mount unlock flags. Not sure if this gets updated after acquiring a new mount later on.

Names for `DeliveryLevel`, `IsMeisterFlag`, `IsMeisterFlagMaxCount`, `NoviceNetworkFlag.IsLoginSecurityToken` and `NoviceNetworkFlag.IsBuddyInStable` taken from lua functions. /shrug