### PR TITLE
[Breaking Change] Add native ArrayData SetValue methods

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkArrayData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkArrayData.cs
@@ -7,6 +7,6 @@ public unsafe struct AtkArrayData
     [FieldOffset(0x8)] public int Size;
     [FieldOffset(0x1C)] public byte Unk1C;
     [FieldOffset(0x1D)] public byte Unk1D;
-    [FieldOffset(0x1E)] public byte HasModifiedData;
+    [FieldOffset(0x1E)] public bool HasModifiedData;
     [FieldOffset(0x1F)] public byte Unk1F; // initialized to -1
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/NumberArrayData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/NumberArrayData.cs
@@ -1,18 +1,16 @@
 ﻿namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x28)]
-public unsafe struct NumberArrayData
+public unsafe partial struct NumberArrayData
 {
     [FieldOffset(0x0)] public AtkArrayData AtkArrayData;
     [FieldOffset(0x20)] public int* IntArray;
 
-    public void SetValue(int index, int value)
-    {
-        if (index < AtkArrayData.Size)
-            if (IntArray[index] != value)
-            {
-                IntArray[index] = value;
-                AtkArrayData.HasModifiedData = 1;
-            }
-    }
+    /// <summary>Set a value at the specified index of the IntArray.</summary>
+    /// <param name="index">The index in the array.</param>
+    /// <param name="value">The integer value.</param>
+    /// <param name="force">If <c>true</c> it bypasses the check if the value is different from what is stored (read before write).</param>
+    /// <param name="silent">If <c>false</c> and the value was changed, HasModifiedData will be set to <c>true</c>.</param>
+    [MemberFunction("3B 51 08 7D 28")]
+    public partial void SetValue(int index, int value, bool force = false, bool silent = false);
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/StringArrayData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/StringArrayData.cs
@@ -1,28 +1,30 @@
-﻿using System.Text;
-
-namespace FFXIVClientStructs.FFXIV.Component.GUI;
+﻿namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x30)]
 public unsafe partial struct StringArrayData
 {
     [FieldOffset(0x0)] public AtkArrayData AtkArrayData;
-    [FieldOffset(0x20)] public byte** StringArray; // char * *
-    [FieldOffset(0x28)] public byte* UnkString; // char *
+    [FieldOffset(0x20)] public byte** StringArray;
+    [FieldOffset(0x28)] public byte** ManagedStringArray;
 
-    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 4F 10 41 0F B6 9F")]
-    public partial void SetValue(int index, byte* value, bool notify);
-
-    public void SetValue(int index, string value, bool notify)
-    {
-        SetValue(index, Encoding.UTF8.GetBytes(value), notify);
-    }
-
-    public void SetValue(int index, byte[] value, bool notify)
-    {
-        var alloc = Marshal.AllocHGlobal(value.Length + 1);
-        Marshal.Copy(value, 0, alloc, value.Length);
-        Marshal.WriteByte(alloc, value.Length, 0);
-        SetValue(index, (byte*) alloc, notify);
-        Marshal.FreeHGlobal(alloc);
-    }
+    /// <summary>Set a value at the specified index of the StringArray.</summary>
+    /// <param name="index">The index in the array.</param>
+    /// <param name="value">
+    /// A pointer to a null terminated string.<br/>
+    /// <b>Note:</b> When passing a C# string (made possible by the generator overload), make sure managed is set to <c>true</c>.
+    /// </param>
+    /// <param name="readBeforeWrite">
+    /// If <c>true</c>, it compares the stored pointer with the passed pointer (not the text it points to) before setting it (read before write).<br/>
+    /// If <c>false</c>, the stored pointer will always be replaced with the passed pointer.<br/><br/>
+    /// In any way, it only has an effect if managed is <c>false</c>.
+    /// </param>
+    /// <param name="managed">
+    /// Recommended to be set to <c>true</c> when using a temporary pointer.<br/>
+    /// The game will allocate memory in the UI space and copy the text. The passed pointer can then be freed right after the SetValue call.<br/>
+    /// Internally, the pointer to the allocated memory is (also) stored in ManagedStringArray to allow SetValue to reuse or reallocate the space as needed.
+    /// </param>
+    /// <param name="silent">If <c>false</c> and the value was changed, HasModifiedData will be set to <c>true</c>.</param>
+    [MemberFunction("E8 ?? ?? ?? ?? F6 47 14 08")]
+    [GenerateCStrOverloads]
+    public partial void SetValue(int index, byte* value, bool readBeforeWrite = true, bool managed = true, bool silent = false);
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2651,7 +2651,8 @@ classes:
       - ea: 0x141930EE0
         base: Component::GUI::AtkArrayData
     funcs:
-      0x1404ECFF0: SetValueIfDifferentAndNotify
+      0x1404ED050: SetValue
+      0x1404ECFF0: SetValueIfDifferent
       0x1404ED090: SetValueForced
   Component::GUI::StringArrayData:
     vtbls:
@@ -2660,8 +2661,8 @@ classes:
     funcs:
       0x1404ED300: SetValue
       0x1404ED4E0: SetValueUtf8
-      0x1404ED540: SetValueIfDifferentAndNotify
-      0x1404ED570: SetValueIfDifferentAndNotifyUtf8
+      0x1404ED540: SetValueIfDifferent
+      0x1404ED570: SetValueIfDifferentUtf8
       0x1404ED5B0: SetValueForced
       0x1404ED5F0: SetValueForcedUtf8
   Component::GUI::ExtendArrayData:


### PR DESCRIPTION
This PR adds a native SetValue method for NumberArrayData and changes the one for StringArrayData.

The SetValue function for StringArrayData we used was actually the one called SetValueForced in data.yml.
I replaced it with the one that's actually SetValue, which has a convenient feature:
If the `managed` parameter is set to true, the game will allocate it's own memory for the text of the passed byte* to make a copy of it. It's then fully managed by SetValue itself, since it stores a copy of the new pointer in a ManagedStringArray and will reuse or reallocate it as needed. This allows us to use `[GenerateCStrOverloads]` to simply call SetValue with a C# string.

Since the arguments have changed I marked this as a breaking change. Maybe this is something for the next API level increase.