### PR TITLE
[Breaking Change] Change AtkEventType type

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
@@ -2,7 +2,7 @@
 
 // max known: 79
 // seems to have generic events followed by component-specific events
-public enum AtkEventType
+public enum AtkEventType : byte
 {
     MouseDown = 3,
     MouseUp = 4,
@@ -44,14 +44,11 @@ public enum AtkEventType
 public unsafe struct AtkEvent
 {
     [FieldOffset(0x0)] public AtkResNode* Node; // extra node param, unused a lot
-
-    [FieldOffset(0x8)]
-    public AtkEventTarget* Target; // target of event (eg clicking a button, target is the button node)
-
+    [FieldOffset(0x8)] public AtkEventTarget* Target; // target of event (eg clicking a button, target is the button node)
     [FieldOffset(0x10)] public AtkEventListener* Listener; // listener of event
     [FieldOffset(0x18)] public uint Param; // arg3 of ReceiveEvent
     [FieldOffset(0x20)] public AtkEvent* NextEvent;
-    [FieldOffset(0x28)] public byte Type;
+    [FieldOffset(0x28)] public AtkEventType Type;
     [FieldOffset(0x29)] public byte Unk29;
     [FieldOffset(0x30)] public byte Flags; // 0: handled, 5: force handled (see AtkEvent::SetEventIsHandled)
 }


### PR DESCRIPTION
Changing the underlying type of the `AtkEventType` enum to byte allows us to use it directly as type for the field `Type`.