### PR TITLE
Update AtkModule

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkModule.cs
@@ -6,6 +6,10 @@
 public unsafe partial struct AtkModule
 {
     [FieldOffset(0x0)] public void* vtbl;
+
+    [FieldOffset(0x1B10)] public AtkUnitBase* IntersectingAddon;
+    [FieldOffset(0x1B18)] public AtkCollisionNode* IntersectingCollisionNode;
+
     [FieldOffset(0x1B48)] public AtkArrayDataHolder AtkArrayDataHolder;
 
     [VirtualFunction(9)]
@@ -16,6 +20,9 @@ public unsafe partial struct AtkModule
 
     [VirtualFunction(11)]
     public partial ExtendArrayData* GetExtendArrayData(int index);
+
+    [VirtualFunction(26)]
+    public partial bool IsAddonReady(uint addonId);
 
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 BA 40 84 FF")]
     public partial bool IsTextInputActive();

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2969,6 +2969,7 @@ classes:
       10: GetStringArrayData
       11: GetExtendArrayData
       17: SetHandlerFunction
+      26: IsAddonReady
       39: SetUIVisibility
       58: OnUpdate
       63: OpenMapWithMapLink


### PR DESCRIPTION
- Added pointers to the currently hovered CollisionNode and its Addon.
- Added vf26 as `IsAddonReady(uint addonId)`.
  I found that it is used by agents to check if an addon has completed its OnSetup call.
  The flag is set right after the OnSetup call at either 0x1405238D2 or 0x140523916 with `atkUnitBase->byte189 |= 1u`.