### PR TITLE
Fix InfoProxyCommonList size offset

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCommonList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCommonList.cs
@@ -8,8 +8,7 @@ public unsafe partial struct InfoProxyCommonList
 {
     [FieldOffset(0x0)] public InfoProxyPageInterface InfoProxyPageInterface;
     [FieldOffset(0x20)] public Utf8String Unk20;
-    //0x88
-    [FieldOffset(0x90)] public ushort Size; //??
+    [FieldOffset(0x8a)] public ushort Size;
     [FieldOffset(0x98)] public CharacterArray* Data;
     [FieldOffset(0xA0)] public CharacterDict* Dict;
 


### PR DESCRIPTION
CharacterArray isn't actually a fixed size 200 list, it's variable based on the size value (which is how many entry structs are present, not bytes). I'm not sure how to handle that so I'm just leaving it for now.

Verified with ghidra on InfoProxyCommonList ctor:
![](https://user-images.githubusercontent.com/1273787/224390669-d254eb70-0157-462b-a77e-725bb876d6e8.png)
