### PR TITLE
AtkEventInterface2

### DIFF
--- a/ida/data.yml
+++ b/ida/data.yml
@@ -366,6 +366,12 @@ classes:
       - ea: 0x1418EBDA8
     vfuncs:
       0: ReceiveEvent
+  Component::GUI::AtkModuleInterface::AtkEventInterface2:
+    vtbls:
+      - ea: 0x1418eed90
+        base: Component::GUI::AtkModuleInterface::AtkEventInterface
+    vfuncs:
+      2: dtor
   Component::GUI::AtkTextInput::AtkTextInputEventInterface:
   Component::Text::TextChecker::ExecNonMacroFunc:
   Component::Text::TextModule:
@@ -744,7 +750,7 @@ classes:
   Client::Game::UI::Revive:
     vtbls:
       - ea: 0x141990AC0
-        base: Component::GUI::AtkModuleInterface::AtkEventInterface
+        base: Component::GUI::AtkModuleInterface::AtkEventInterface2
   Client::Game::UI::Buddy:
     instances:
       - ea: 0x1420FA590
@@ -800,7 +806,7 @@ classes:
   Client::Game::UI::AreaInstance:
     vtbls:
       - ea: 0x141991B70
-        base: Component::GUI::AtkModuleInterface::AtkEventInterface
+        base: Component::GUI::AtkModuleInterface::AtkEventInterface2
     instances:
       - ea: 0x1420FB5F8
         pointer: False
@@ -832,7 +838,7 @@ classes:
   Client::Game::UI::Loot:
     vtbls:
       - ea: 0x141991BB8
-        base: Component::GUI::AtkModuleInterface::AtkEventInterface
+        base: Component::GUI::AtkModuleInterface::AtkEventInterface2
     instances:
       - ea: 0x1420FBAC0
         pointer: False
@@ -1792,9 +1798,8 @@ classes:
   Client::UI::Agent::AgentInterface:
     vtbls:
       - ea: 0x14190B300
-        base: Component::GUI::AtkModuleInterface::AtkEventInterface
+        base: Component::GUI::AtkModuleInterface::AtkEventInterface2
     vfuncs:
-      2: dtor
       3: Show
       4: Hide
       5: IsAgentActive
@@ -3409,7 +3414,7 @@ classes:
   Client::UI::Misc::ConfigModule:
     vtbls:
       - ea: 0x141948E18
-        base: Component::GUI::AtkModuleInterface::AtkEventInterface
+        base: Component::GUI::AtkModuleInterface::AtkEventInterface2
       - ea: 0x141948E30
         base: Common::Configuration::ConfigBase::ChangeEventInterface
     funcs:
@@ -4141,18 +4146,14 @@ classes:
   Client::Game::UI::Telepo::SelectUseTicketInvoker:
     vtbls:
       - ea: 0x141990BC8
-        base: Component::GUI::AtkModuleInterface::AtkEventInterface
-    vfuncs:
-      2: dtor
+        base: Component::GUI::AtkModuleInterface::AtkEventInterface2
   Client::Game::UI::Telepo:
     instances:
       - ea: 0x1420F9FA0
         pointer: False
     vtbls:
       - ea: 0x141990BE0
-        base: Component::GUI::AtkModuleInterface::AtkEventInterface
-    vfuncs:
-      2: dtor
+        base: Component::GUI::AtkModuleInterface::AtkEventInterface2
     funcs:
       0x140943DB0: ctor
       0x140943F10: IsSelectUseTicketInactive
@@ -5538,7 +5539,7 @@ classes:
   Client::UI::Agent::AgentBannerInterface::Storage::CharacterData:
     vtbls:
       - ea: 0x141B92EF8
-        base: Component::GUI::AtkModuleInterface::AtkEventInterface
+        base: Component::GUI::AtkModuleInterface::AtkEventInterface2
     funcs:
       0x1414D55E0: dtor
   Client::UI::Agent::AgentBannerParty:
@@ -5587,7 +5588,7 @@ classes:
   Client::Game::Event::EventSceneModule::UISkipListener:
     vtbls:
       - ea: 0x14196D5A0
-        base: Component::GUI::AtkModuleInterface::AtkEventInterface
+        base: Component::GUI::AtkModuleInterface::AtkEventInterface2
   Client::Game::Event::Director:
     vtbls:
       - ea: 0x14196DEA0


### PR DESCRIPTION
There seems to be some interface between AtkEventInterface and AgentInterface that adds a "dtor" vfunc that a whole bunch of classes derive from (ghidra was complaining about renaming vf1 to AgentInterface.dtor).

I'm 98% certain of the vtable, though it's super hard to say with full confidence, though I suspect that's the least interesting part of this.