### PR TITLE
Add AtkArrayDataHolder to AtkStage

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkStage.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkStage.cs
@@ -1,17 +1,17 @@
-﻿using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Client.UI;
 
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
+
 // Component::GUI::AtkStage
 //   Component::GUI::AtkEventTarget
-
-// size = 0x75DF8
-// ctor E8 ?? ?? ?? ?? 48 8B F8 48 89 BE ?? ?? ?? ?? 48 8B 43 10
+// ctor "E8 ?? ?? ?? ?? 48 8B F8 48 89 BE ?? ?? ?? ?? 48 8B 43 10"
 [StructLayout(LayoutKind.Explicit, Size = 0x75DF8)]
 public unsafe partial struct AtkStage
 {
     [FieldOffset(0x0)] public AtkEventTarget AtkEventTarget;
     [FieldOffset(0x20)] public RaptureAtkUnitManager* RaptureAtkUnitManager;
     [FieldOffset(0x20)] public nint AtkInputManager;
+    [FieldOffset(0x38)] public AtkArrayDataHolder* AtkArrayDataHolder;
     [FieldOffset(0x78)] public AtkDragDropManager DragDropManager;
     [FieldOffset(0x168)] public AtkTooltipManager TooltipManager;
     [FieldOffset(0x338)] public AtkCursor AtkCursor;
@@ -26,4 +26,13 @@ public unsafe partial struct AtkStage
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 6C 24 ?? 80 BB")]
     public partial void ClearFocus();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B CB 4C 8B 70 50")]
+    public partial NumberArrayData** GetNumberArrayData();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 4C 8B 37")]
+    public partial StringArrayData** GetStringArrayData();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 4C 8B 70 10")]
+    public partial ExtendArrayData** GetExtendArrayData();
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2769,10 +2769,13 @@ classes:
       0x1404FFC30: GetFocus
       0x1404FFC60: SetFocus
       0x1404FFCC0: ClearFocus
+      0x140500AC0: RemoveAllEvents # (this, AtkComponentBase)
       0x140500BF0: GetNumberArrayData
+      0x140500C00: GetStringArrayData
+      0x140500C10: GetExtendArrayData
       0x140500D20: ctor
-      0x140523170: GetSingleton1  # dalamud GetBaseUIObject
-      0x140500ac0: RemoveAllEvents # (this, AtkComponentBase)
+      0x140523170: GetSingleton
+      0x140523180: GetSingleton2
   Component::GUI::AtkDragDropManager:
     vtbls:
       - ea: 0x141933658


### PR DESCRIPTION
Since `AtkStage_GetNumberArrayData` exists in data.yml, I thought I'd look around and see what I could find.

- Added:
  - GetStringArrayData
  - GetExtendArrayData and
  - a pointer to the whole AtkArrayDataHolder.
- Renamed the existing `GetSingleton1` to just `GetSingleton` and found a second one which I called `GetSingleton2`.
- Capitalized the address of `RemoveAllEvents` and sorted the functions by address.