### PR TITLE
Update AtkArrayData

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
@@ -31,6 +31,18 @@ public unsafe partial struct RaptureAtkModule
     [MemberFunction("E8 ?? ?? ?? ?? 0F B6 44 24 ?? 48 89 9F")]
     public partial bool ChangeUiMode(uint uiMode);
 
+    [MemberFunction("E8 ?? ?? ?? ?? 48 39 77 28 0F 84")]
+    public partial bool IncRefNumberArrayData(int index);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 75 28")]
+    public partial bool DecRefNumberArrayData(int index);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 49 83 7E ?? ?? 74 0D")]
+    public partial bool IncRefStringArrayData(int index);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 46 58 48 85 C0")]
+    public partial bool DecRefStringArrayData(int index);
+
     [VirtualFunction(39)]
     public partial void SetUiVisibility(bool uiVisible);
 

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkArrayData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkArrayData.cs
@@ -1,12 +1,27 @@
-﻿namespace FFXIVClientStructs.FFXIV.Component.GUI;
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x20)]
 public unsafe struct AtkArrayData
 {
     [FieldOffset(0x0)] public void* vtbl;
     [FieldOffset(0x8)] public int Size;
+    [FieldOffset(0xC)] public fixed byte SubscribedAddons[16];
     [FieldOffset(0x1C)] public byte Unk1C;
+    [FieldOffset(0x1D)] public byte SubscribedAddonsCount;
+    /// <remarks>
+    /// 0 = No update pending<br/>
+    /// 1 = Update subscribed addons (specific flags are checked in AtkUnitManager.UpdateAddonByID)<br/>
+    /// 2 = Force update subscribed addons
+    /// </remarks>
+    [FieldOffset(0x1E)] public byte UpdateState;
+    [FieldOffset(0x1F)] public sbyte RefCount; // initialized to -1, used by Agents
+
+    [Obsolete("Use AtkArrayData.SubscribedAddonsCount")]
     [FieldOffset(0x1D)] public byte Unk1D;
+
+    [Obsolete("Use AtkArrayData.UpdateState")]
     [FieldOffset(0x1E)] public bool HasModifiedData;
-    [FieldOffset(0x1F)] public byte Unk1F; // initialized to -1
+
+    [Obsolete("Use AtkArrayData.RefCount")]
+    [FieldOffset(0x1F)] public byte Unk1F;
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -1,4 +1,4 @@
-﻿namespace FFXIVClientStructs.FFXIV.Component.GUI;
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
 // Component::GUI::AtkUnitBase
 //   Component::GUI::AtkEventListener
 
@@ -83,6 +83,17 @@ public unsafe partial struct AtkUnitBase
 
     [MemberFunction("E8 ?? ?? ?? ?? 8D 77 02")]
     public partial bool SetFocusNode(AtkResNode* node, bool a3 = false, uint a4 = 0);
+
+    /// <param name="arrayType">0 for StringArrayData or 1 for NumberArrayData</param>
+    /// <param name="arrayIndex">The index in AtkArrayDataHolder</param>
+    [MemberFunction("E8 ?? ?? ?? ?? 44 8D 43 79")]
+    public partial void SubscribeAtkArrayData(byte arrayType, byte arrayIndex);
+
+    /// <param name="arrayType">0 for StringArrayData or 1 for NumberArrayData</param>
+    /// <param name="arrayIndex">The index in AtkArrayDataHolder</param>
+    /// <param name="clean">Resets all values to default, also frees managed strings</param>
+    [MemberFunction("E8 ?? ?? ?? ?? 45 33 C9 8D 56 01")]
+    public partial void UnsubscribeAtkArrayData(byte arrayType, byte arrayIndex, bool clean = false);
 
     [VirtualFunction(3)]
     public partial bool Open(uint uknUint);

--- a/FFXIVClientStructs/FFXIV/Component/GUI/NumberArrayData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/NumberArrayData.cs
@@ -10,7 +10,7 @@ public unsafe partial struct NumberArrayData
     /// <param name="index">The index in the array.</param>
     /// <param name="value">The integer value.</param>
     /// <param name="force">If <c>true</c> it bypasses the check if the value is different from what is stored (read before write).</param>
-    /// <param name="silent">If <c>false</c> and the value was changed, HasModifiedData will be set to <c>true</c>.</param>
+    /// <param name="silent">If <c>false</c> and the value was changed, UpdateState will be set to <c>1</c> to request an update on subscribed addons.</param>
     [MemberFunction("3B 51 08 7D 28")]
     public partial void SetValue(int index, int value, bool force, bool silent);
 

--- a/FFXIVClientStructs/FFXIV/Component/GUI/StringArrayData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/StringArrayData.cs
@@ -1,4 +1,4 @@
-﻿namespace FFXIVClientStructs.FFXIV.Component.GUI;
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x30)]
 public unsafe partial struct StringArrayData
@@ -23,7 +23,7 @@ public unsafe partial struct StringArrayData
     /// The game will allocate memory in the UI space and copy the text. The passed pointer can then be freed right after the SetValue call.<br/>
     /// Internally, the pointer to the allocated memory is (also) stored in ManagedStringArray to allow SetValue to reuse or reallocate the space as needed.
     /// </param>
-    /// <param name="silent">If <c>false</c> and the value was changed, HasModifiedData will be set to <c>true</c>.</param>
+    /// <param name="silent">If <c>false</c> and the value was changed, UpdateState will be set to <c>1</c> to request an update on subscribed addons.</param>
     [MemberFunction("E8 ?? ?? ?? ?? F6 47 14 08")]
     [GenerateCStrOverloads]
     public partial void SetValue(int index, byte* value, bool readBeforeWrite, bool managed, bool silent);

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1411,12 +1411,17 @@ classes:
     funcs:
       0x1400B3EB0: ctor
       0x1400B4B40: dtor
+      0x1400B4EE0: ChangeUiMode
       0x1400B5EE0: OpenAddon
       0x1400B6660: OpenYesNo
       0x1400C9410: OnUpdate_Nameplates
+      0x1400CA8C0: IncRefNumberArrayData
+      0x1400CA910: IncRefStringArrayData
       0x1400D9860: UpdateNameplates_BattleChara
       0x1400DA6B0: UpdateNameplates_NPC
       0x1400DCA20: IsUIVisible
+      0x140558500: DecRefNumberArrayData
+      0x140558560: DecRefStringArrayData
   Client::UI::Info::InfoProxyInterface:
     vtbls:
       - ea: 0x14194E6B8
@@ -3076,6 +3081,8 @@ classes:
       0x140529BA0: CalculateBounds
       0x14052A370: SetFlag
       0x14052BEB0: Draw
+      0x14052C3D0: SubscribeAtkArrayData # handler: 4C 8B D2 48 8B D1 41 83 F9 04
+      0x14052C560: UnsubscribeAtkArrayData # handler: 48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 41 83 F9 04
       0x14052C810: SetFocusNode
       0x14052CD90: GetNodeById
       0x14052CEC0: GetButtonNodeById


### PR DESCRIPTION
I noticed that `HasModifiedData`, which I changed in 48bc59e9, can actually have a value of 2, so it's not a bool.

Investigation revealed that
- if set to 0, nothing happens,
- if set to 1, `OnRequestedUpdate` is called on the subscribed addons, but only if the flag checks in `AtkUnitManager.UpdateAddonByID` pass,
- if set to 2, it forces an `OnRequestedUpdate` call on the subscribed addons, bypassing the flag checks.

I renamed the field to `UpdateState` and changed it back to `byte`.

Other than that, I found out:
- Some Addons subscribe to an array in OnSetup and unsubscribe in the Finalize functions, I added the called functions as `SubscribeAtkArrayData`/`UnsubscribeAtkArrayData`. The ID of the addon is stored in `fixed byte SubscribedAddons[16]` at 0xC (length actually just a guess, but I found that StringArray#5 is subscribed by 15 addons).
- `Unk1C` is still unknown and I didn't check it, maybe a 17th addon.
- `Unk1D` is now `SubscribedAddonsCount`.
- `Unk1F` is now `RefCount` as it stores a count of how many Agents are using this array. This is incremented with `IncRefNumberArrayData`/`IncRefStringArrayData` in Show functions, or decremented with `DecRefNumberArrayData`/`DecRefStringArrayData` in Hide functions.

If `RefCount` is -1, the IncRef* functions will set it to 1. When decrementing the ref or unsubscribing from an array, it checks if `RefCount` and `SubscribedAddonsCount` are 0. If this is true, the array will self-destruct: it sets everything to zero, frees memory and removes itself from the AtkArrayDataHolder. Could be dangerous. Maybe just add these functions to data.yml, but not to the .cs files? I doubt anyone would need to call them anyway.

Also, I added the old field names with an Obsolete attribute for compatibility.