### PR TITLE
Various offset updates

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -31,11 +31,16 @@ public unsafe partial struct Character
     [FieldOffset(0x1D6)] public ushort MaxGatheringPoints;
     [FieldOffset(0x1D8)] public ushort CraftingPoints;
     [FieldOffset(0x1DA)] public ushort MaxCraftingPoints;
-
     [FieldOffset(0x1DC)] public short TransformationId;
-    [FieldOffset(0x1DE)] public short StatusEffectVFXId;
+    [FieldOffset(0x1DE)] public short StatusEffectVFXId; // outdated since TitleID moved here
+    [FieldOffset(0x1DE)] public ushort TitleID;
+
     [FieldOffset(0x1E2)] public byte ClassJob;
     [FieldOffset(0x1E3)] public byte Level;
+
+    [FieldOffset(0x1ED)] public byte ShieldValue;
+
+    [FieldOffset(0x1EF)] public byte OnlineStatus;
 
     #endregion
 
@@ -65,13 +70,10 @@ public unsafe partial struct Character
 
     [FieldOffset(0x1B1C)] public ushort CurrentWorld;
     [FieldOffset(0x1B1E)] public ushort HomeWorld;
-    [FieldOffset(0x1DE)] public ushort TitleID;
     [FieldOffset(0x1B26)] public byte EventState; // Leave for backwards compat. See Mode.
     [FieldOffset(0x1B26)] public CharacterModes Mode;
     [FieldOffset(0x1B27)] public byte ModeParam; // Different purpose depending on mode. See CharacterModes for more info.
-    [FieldOffset(0x1B28)] public byte OnlineStatus;
     [FieldOffset(0x1B29)] public byte Battalion; // used for determining friend/enemy state
-    [FieldOffset(0x1ED)] public byte ShieldValue;
     [FieldOffset(0x1B1B)] public byte StatusFlags;
     [FieldOffset(0x1B1F)] public byte StatusFlags4; // 0x80 flagged when permanent wetness in GPose is toggled.
     [FieldOffset(0x1AE8)] public uint CompanionOwnerID;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
@@ -1,4 +1,4 @@
-﻿using FFXIVClientStructs.FFXIV.Client.Game.Character;
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game.Control; 
 
@@ -7,9 +7,9 @@ public unsafe partial struct Control
 {
     [FieldOffset(0x00)] public CameraManager CameraManager;
     [FieldOffset(0x180)] public TargetSystem TargetSystem;
-    
-    [FieldOffset(0x5A48)] public uint LocalPlayerObjectId;
-    [FieldOffset(0x5A50)] public BattleChara* LocalPlayer;
+
+    [FieldOffset(0x5AE8)] public uint LocalPlayerObjectId;
+    [FieldOffset(0x5AF0)] public BattleChara* LocalPlayer;
 
     [StaticAddress("4C 8D 35 ?? ?? ?? ?? 85 D2", 3)]
     public static partial Control* Instance();

--- a/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
@@ -1,10 +1,10 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using FFXIVClientStructs.FFXIV.Application.Network.WorkDefinitions;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game;
 
 // idk if this is a manager, but I don't know what else to call it
-[StructLayout(LayoutKind.Explicit, Size = 0xF00)]
+[StructLayout(LayoutKind.Explicit, Size = 0xF40)]
 public unsafe partial struct QuestManager
 {
 	[FieldOffset(0x10)] public QuestListArray Quest;
@@ -12,17 +12,17 @@ public unsafe partial struct QuestManager
 	[FixedSizeArray<QuestWork>(30)]
 	[FieldOffset(0x10)] public fixed byte NormalQuests[0x18 * 30];
 	[FixedSizeArray<DailyQuestWork>(12)]
-	[FieldOffset(0x568)] public fixed byte DailyQuests[0x10 * 12];
+	[FieldOffset(0x5B8)] public fixed byte DailyQuests[0x10 * 12];
 	[FixedSizeArray<TrackingWork>(5)]
-	[FieldOffset(0x658)] public fixed byte TrackedQuests[0x10 * 5];
+	[FieldOffset(0x6A8)] public fixed byte TrackedQuests[0x10 * 5];
 	[FixedSizeArray<BeastReputationWork>(17)]
-	[FieldOffset(0xB70)] public fixed byte BeastReputation[0x10 * 17];
+	[FieldOffset(0xBC8)] public fixed byte BeastReputation[0x10 * 17];
 	[FixedSizeArray<LeveWork>(16)]
-	[FieldOffset(0xC80)] public fixed byte LeveQuests[0x18 * 16];
-    [FieldOffset(0xE00)] public byte NumLeveAllowances;
+	[FieldOffset(0xCD8)] public fixed byte LeveQuests[0x18 * 16];
+    [FieldOffset(0xE58)] public byte NumLeveAllowances;
 
-    [FieldOffset(0xEE8)] public byte NumAcceptedQuests;
-    [FieldOffset(0xEF8)] public byte NumAcceptedLeveQuests;
+    [FieldOffset(0xF40)] public byte NumAcceptedQuests;
+    [FieldOffset(0xF50)] public byte NumAcceptedLeveQuests;
 
 	[MemberFunction("E8 ?? ?? ?? ?? 66 BA 10 0C")]
     public static partial QuestManager* Instance();

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -124,7 +124,7 @@ public unsafe partial struct PlayerState
     [FieldOffset(0x678)] public byte WeeklyBingoRequestOpenBingoNo;
 
     [FieldOffset(0x6B4)] public byte WeeklyBingoExpMultiplier;
-    [FieldOffset(0x69D)] public bool WeeklyBingoUnk63;
+    [FieldOffset(0x6B5)] public bool WeeklyBingoUnk63;
 
     #endregion
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
@@ -1,4 +1,4 @@
-﻿using FFXIVClientStructs.FFXIV.Client.Game.Event;
+using FFXIVClientStructs.FFXIV.Client.Game.Event;
 using FFXIVClientStructs.FFXIV.Client.Game.Fate;
 using FFXIVClientStructs.FFXIV.Component.Exd;
 
@@ -19,12 +19,11 @@ public unsafe partial struct UIState
     [FieldOffset(0x1250)] public Inspect Inspect;
     [FieldOffset(0x14B8)] public Telepo Telepo;
     [FieldOffset(0x14F8)] public Cabinet Cabinet;
-    [FieldOffset(0x1A90)] public Buddy Buddy;
-    [FieldOffset(0x296C)] public PvPProfile PvPProfile;
+    [FieldOffset(0x1AB0)] public Buddy Buddy;
+    [FieldOffset(0x298C)] public PvPProfile PvPProfile;
     [FieldOffset(0x2A10)] public ContentsNote ContentsNote;
     [FieldOffset(0x2AB8)] public RelicNote RelicNote;
-    [FieldOffset(0x2B28)] public AreaInstance AreaInstance;
-    [FieldOffset(0x2B34)] public MobHunt MobHunt;
+    [FieldOffset(0x2B18)] public AreaInstance AreaInstance; // at vtbl - 0x10
     [FieldOffset(0x2FE0)] public Loot Loot;
 
     [FieldOffset(0x3C60)] public RecipeNote RecipeNote;
@@ -34,22 +33,23 @@ public unsafe partial struct UIState
 
     [FieldOffset(0xAA90)] public Map Map;
 
-    [FieldOffset(0xEA40)] public MarkingController MarkingController;
-    [FieldOffset(0xECF0)] public LimitBreakController LimitBreakController;
+    [FieldOffset(0xEA80)] public MarkingController MarkingController;
+    [FieldOffset(0xED60)] public LimitBreakController LimitBreakController;
 
-    [FieldOffset(0x119B8)] public RouletteController RouletteController;
-    [FieldOffset(0x11A88)] public ContentsFinder ContentsFinder;
+    [FieldOffset(0x11A28)] public RouletteController RouletteController;
+    [FieldOffset(0x11AF8)] public ContentsFinder ContentsFinder;
+    [FieldOffset(0x11C10)] public MobHunt MobHunt;
 
     // Ref: UIState#IsUnlockLinkUnlocked (relative to uistate)
-    [FieldOffset(0x169FC)] public fixed byte UnlockLinkBitmask[0x7E];
+    [FieldOffset(0x16AF4)] public fixed byte UnlockLinkBitmask[0x7E];
     
     // Ref: g_Client::Game::UI::UnlockedCompanionsMask
     //      direct ref: 48 8D 0D ?? ?? ?? ?? 0F B6 04 08 84 D0 75 10 B8 ?? ?? ?? ?? 48 8B 5C 24
     //      relative to uistate: E8 ?? ?? ?? ?? 84 C0 75 A6 32 C0 (case for 0x355)
-    [FieldOffset(0x16A7A)] public fixed byte UnlockedCompanionsBitmask[0x3A];
+    [FieldOffset(0x16B70)] public fixed byte UnlockedCompanionsBitmask[0x3A];
     
     // 42 0F B6 04 30 44 84 C0
-    [FieldOffset(0x16AB6)] public fixed byte ChocoboTaxiStandsBitmask[0x26];
+    [FieldOffset(0x16BB0)] public fixed byte ChocoboTaxiStandsBitmask[0x26];
     
     [StaticAddress("48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? 48 8B 01", 3)]
     public static partial UIState* Instance();

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -88,7 +88,6 @@ functions:
   0x1400A7FB0: IsRolePlaying
   0x140988600: GetTeleportCost
   0x140B04D10: SetCondition
-  0x140B05050: SetConditionByPermissionAndLog
   0x140B05520: IsLocalPlayerLalafell
   0x140C28780: CreateSelectYesno
   0x141166EA0: Client::UI::AddonHudLayoutScreen::MoveableAddonInfoStruct_UpdateAddonPosition
@@ -244,8 +243,8 @@ functions:
   0x140B049A0: IsInMordionGaol # if this returns true, i'm sorry for you
   0x140B580D0: WorldToScreenPoint
   0x1416A0AE0: OodleNew # oodle code starts here
-  0x1416A0B50: OodleDelete 
-  0x1416A0B80: rrPrintf_v1 
+  0x1416A0B50: OodleDelete
+  0x1416A0B80: rrPrintf_v1
   0x1416A2B20: OodleNetwork1UDP_CountingState::Count
   0x1416A33E0: OodleNetwork1UDP_State::Decode
   0x1416A40A0: OodleNetwork1UDP_State::Encode
@@ -259,7 +258,7 @@ functions:
   0x1416AA420: OodleNetwork1UDP_Encode
   0x1416AAA70: OodleNetwork1UDP_State_Size
   0x1416AAF20: OodleNetwork1UDP_Train
-  0x1416AC2C0: OodleNetwork1_Shared_SetWindow  
+  0x1416AC2C0: OodleNetwork1_Shared_SetWindow
   0x1416AC3F0: OodleNetwork1_Shared_Size
   0x1416AF730: rrArithDecodeInit
   0x1416AF7D0: rrArithEncodeFlush
@@ -673,7 +672,7 @@ classes:
       0x140527560: ExpandNodeListSize
       0x140527BC0: DuplicateComponentNode
       0x140527700: SeardNodeById
-      0x140527760: SearchNodeByIndex 
+      0x140527760: SearchNodeByIndex
       0x1405277D0: GetDuplicatedNode
   Component::GUI::AtkArrayDataHolder:
     funcs:
@@ -2937,7 +2936,7 @@ classes:
       15: GetSizeScaled
       16: Hide2
       17: SetScaleToHudLayoutScale
-      18: ShouldCollideWithWindow 
+      18: ShouldCollideWithWindow
       39: Initialize
       40: Finalize
       41: Update
@@ -3562,7 +3561,7 @@ classes:
       0x1406900F0: EquipGearsetInternal
       0x140690780: CreateGearset
       0x140690810: DeleteGearset
-      0x1406909E0: UpdateGearset # (this, gearsetIndext)
+      0x1406909E0: UpdateGearset # (this, gearsetIndex)
       0x140690E20: LinkGlamourPlate
       0x140690F40: RemoveGlamourPlateLink
       0x140690F50: HasLinkedGlamourPlate
@@ -5576,7 +5575,7 @@ classes:
     funcs:
       0x140CDADF0: ctor
       0x140CDAE20: dtor2
-      0x140CDAE80: ViewArchiveItem  
+      0x140CDAE80: ViewArchiveItem
   Client::UI::Agent::AgentVVDNotebook:
     vtbls:
       - ea: 0x141AC2970
@@ -7014,7 +7013,7 @@ classes:
     funcs:
       0x1418410C0: load1 # hkStreamReader, hkClass, hkTypeInfoRegistry
       0x141840F80: load2 # hkStreamReader, hkTypeInfoRegistry
-      0x141840F20: load3 # hkStreamReader    
+      0x141840F20: load3 # hkStreamReader
   hkMatrix4f:
     funcs:
       0x1417B2080: ?set4x4ColumnMajor@hkMatrix4f@@QEAAXPEBM@Z


### PR DESCRIPTION
Updated offsets for:
- UIState.cs
- Character.cs (partial)
  - I just wanted to fix OnlineStatus and rearranged the offsets while doing so. Not sure what StatusEffectVFXId is, but at that offset is now TitleID. Maybe it moved to 0x1E0?
- Control.cs
  - I guess TargetSystem grew (didn't check).
- QuestManager.cs
- PlayerState.cs (missed one)

Updated data.yml:
- Removed SetConditionByPermissionAndLog
  - I added this a while ago, but it doesn't set the condition at all. I think it checks them against the permissions and prints the error, if it doesn't match. Anyway, I didn't look much into it, just wanted it to be removed since it has a wrong name.
- Fixed a typo in a comment (gearsetIndext -> gearsetIndex)
- Trimmed whitespaces