### PR TITLE
Update JobGuage data.yml vf_3 name

### DIFF
--- a/ida/data.yml
+++ b/ida/data.yml
@@ -908,6 +908,7 @@ classes:
     vfuncs:
       0: dtor
       1: Init
+      3: RecievePacketValues
       4: SetValues
   Client::Game::Gauge::PaladinGauge:
     vtbls:


### PR DESCRIPTION
Partly named due to find under `Client::Game::JobGaugeManager_Update` which calls `**a1 + 24` and all `vf_3` does almost the same as `Init` but only for setting from the packet