### PR TITLE
Update unlock bitmasks in UIState

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
@@ -41,15 +41,26 @@ public unsafe partial struct UIState
     [FieldOffset(0x11C10)] public MobHunt MobHunt;
 
     // Ref: UIState#IsUnlockLinkUnlocked (relative to uistate)
-    [FieldOffset(0x16AF4)] public fixed byte UnlockLinkBitmask[0x7E];
+    // Size: Offset of UnlockedAetherytesBitmask - Offset of UnlockLinkBitmask
+    [FieldOffset(0x16AF4)] public fixed byte UnlockLinkBitmask[0x40];
+
+    // Ref: Telepo#UpdateAetheryteList (in the Aetheryte sheet loop)
+    // Size: Number of rows in Aetheryte sheet >> 3
+    [FieldOffset(0x16B34)] public fixed byte UnlockedAetherytesBitmask[200 >> 3];
     
+    // Ref: E8 ?? ?? ?? ?? 48 83 6F ?? ?? 75 06 48 89 77 68
+    // Size: Number of rows in HowTo sheet >> 3
+    [FieldOffset(0x16B4E)] public fixed byte UnlockedHowtoBitmask[288 >> 3];
+
     // Ref: g_Client::Game::UI::UnlockedCompanionsMask
     //      direct ref: 48 8D 0D ?? ?? ?? ?? 0F B6 04 08 84 D0 75 10 B8 ?? ?? ?? ?? 48 8B 5C 24
     //      relative to uistate: E8 ?? ?? ?? ?? 84 C0 75 A6 32 C0 (case for 0x355)
-    [FieldOffset(0x16B72)] public fixed byte UnlockedCompanionsBitmask[0x3A];
+    // Size: Number of rows in Companion sheet >> 3
+    [FieldOffset(0x16B72)] public fixed byte UnlockedCompanionsBitmask[496 >> 3];
     
     // 42 0F B6 04 30 44 84 C0
-    [FieldOffset(0x16BB0)] public fixed byte ChocoboTaxiStandsBitmask[0x26];
+    // Size: Number of rows in ChocoboTaxi sheet >> 3
+    [FieldOffset(0x16BB0)] public fixed byte ChocoboTaxiStandsBitmask[312 >> 3];
     
     [StaticAddress("48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? 48 8B 01", 3)]
     public static partial UIState* Instance();
@@ -112,6 +123,24 @@ public unsafe partial struct UIState
     /// <returns>Returns true if the emote is unlocked.</returns>
     [MemberFunction("E9 ?? ?? ?? ?? 8B 13 41 B8 ?? ?? ?? ?? 8B CA")]
     public partial bool IsEmoteUnlocked(ushort emoteId);
+
+    /// <summary>
+    /// Check if a aetheryte is unlocked for the current character.
+    /// </summary>
+    /// <param name="aetheryteId">The ID of the aetheryte to check for.</param>
+    /// <returns>Returns true if the specified aetheryte is unlocked.</returns>
+    public bool IsAetheryteUnlocked(uint aetheryteId) {
+        return ((1 << ((int) aetheryteId & 7)) & this.UnlockedAetherytesBitmask[aetheryteId >> 3]) > 0;
+    }
+
+    /// <summary>
+    /// Check if a HowTo is unlocked for the current character.
+    /// </summary>
+    /// <param name="howtoId">The ID of the HowTo to check for.</param>
+    /// <returns>Returns true if the specified HowTo is unlocked.</returns>
+    public bool IsHowToUnlocked(uint howtoId) {
+        return ((1 << ((int) howtoId & 7)) & this.UnlockedHowtoBitmask[howtoId >> 3]) > 0;
+    }
 
     /// <summary>
     /// Check if a companion (minion) is unlocked for the current character.

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -33,7 +33,11 @@ globals:
   0x142183B14: g_Client::Game::UI::ContentsFinder::ExplorerMode
   0x142183B15: g_Client::Game::UI::ContentsFinder::LevelSync
   0x142183B16: g_Client::Game::UI::ContentsFinder::LimitedLevelingRoulette
+  0x142188AF4: g_Client::Game::UI::UnlockLinkBitmask  # not a pointer
+  0x142188B34: g_Client::Game::UI::UnlockedAetherytesBitmask  # not a pointer
   0x142188B72: g_Client::Game::UI::UnlockedCompanionsMask  # not a pointer
+  0x142188B4E: g_Client::Game::UI::UnlockedHowToBitmask  # not a pointer
+  0x142188BB0: g_Client::Game::UI::ChocoboTaxiStandsBitmask  # not a pointer
   0x14218ADD0: g_Conditions # bool array, size is Condition sheet row count
   0x142122E70: g_SomeOtherRenderingState
   0x142135194: g_InvSqrt3
@@ -4225,7 +4229,7 @@ classes:
     funcs:
       0x140958E80: ctor
       0x140958FE0: IsSelectUseTicketInactive
-      0x140959140: UpdatePlayerAetheryteList
+      0x140959140: UpdateAetheryteList
       0x140959CC0: Teleport
       0x14095AF10: TeleportWithTicket
       0x14095AFA0: InvokeSelectUseTicket


### PR DESCRIPTION
I saw commit daa76a0 (sorry for that btw) and thought the sizes might be old now too. So here's an updated with some more bitmasks. 🙂

- I reduced the size of `UnlockLinkBitmask`, so it fits until `UnlockedAetherytesBitmask` starts. I hope this doesn't cause any problems.
- It looks like there is 1 byte padding between `UnlockedAetherytesBitmask` and `UnlockedHowToBitmask`?! I'm not sure if `UnlockedAetherytesBitmask` is just 1 byte too short now or not, but I tested `IsAetheryteUnlocked` against the Aetheryte sheet and it works fine. 🤷‍♂️
- Fun fact: I also rented a Chocobo for the first time to check if `IsHowToUnlocked` works. It works. 😄👍

Oh yeah, and I renamed `UpdatePlayerAetheryteList` to `UpdateAetheryteList` in the data.yml, so it aligns with the method in Telepo.cs.