### PR TITLE
Fix not resolving same sig with different offsets

### DIFF
--- a/FFXIVClientStructs/Interop/Address.cs
+++ b/FFXIVClientStructs/Interop/Address.cs
@@ -9,6 +9,8 @@ public class Address
         this.Bytes = bytes;
         this.Mask = mask;
         this.Value = value;
+
+        this.CacheKey = this.String;
     }
 
     public readonly string Name;
@@ -16,6 +18,7 @@ public class Address
     public readonly ulong[] Bytes;
     public readonly ulong[] Mask;
     public nuint Value;
+    public string CacheKey;
 }
 
 public sealed class StaticAddress : Address
@@ -23,6 +26,8 @@ public sealed class StaticAddress : Address
     public StaticAddress(string name, string @string, ulong[] bytes, ulong[] mask, nuint value, int offset) : base(name, @string, bytes, mask, value)
     {
         this.Offset = offset;
+
+        this.CacheKey = $"{this.String}+0x{this.Offset:X}";
     }
 
     public int Offset;


### PR DESCRIPTION
I came across an edge case where the resolver only resolved a signature once, even though it was present multiple times with different offsets.

I have identified two reasons behind this issue:

1) The key used in the `_textCache` dictionary did not account for the offset of a `StaticAddress`.
2) The loop was prematurely broken when an `Address` had been resolved at the given location, disregarding any other Addresses.

This would happen for the following example, in which the VTableAddress has the same sig (with an offset) as the Ctor method (without offset):

```cs
[VTableAddress("E8 ?? ?? ?? ?? 48 8B F0 48 89 45 0F", 0x1C)]
[StructLayout(LayoutKind.Explicit, Size = 0x90)]
public unsafe partial struct LuaCutsceneState
{
    [FieldOffset(0x10)] public Utf8String Path;
    [FieldOffset(0x78)] public uint Id;
    
    [MemberFunction("E8 ?? ?? ?? ?? 48 8B F0 48 89 45 0F")]
    public partial void Ctor();
}
```

To resolve this issue, I have made the following changes:

1) Added a `CacheKey` field to the `Address` class that takes the offset into account when it's a `StaticAddress`.
2) Removed the break statement from the loop to ensure all Addresses are processed.
3) Additionally, without the break statement, we are unable to remove elements from a List while iterating over it. To address this, I have used `.ToArray()` to make a temporary copy of the list of addresses.

By making these changes, both addresses are now cached correctly:

```json
  "E8 ?? ?? ?? ?? 48 8B F0 48 89 45 0F ?? ?? ?? ??": 8268432,
  "E8 ?? ?? ?? ?? 48 8B F0 48 89 45 0F ?? ?? ?? ??\u002B0x1C": 27045104,
```

(Well, the JsonEncoder escapes the "+" symbol, but it doesn't really matter. 🙄)