### PR TITLE
AgentGatheringNote add GatheringAreaInfo

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGatheringNote.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGatheringNote.cs
@@ -11,7 +11,7 @@ public unsafe partial struct AgentGatheringNote
 
     [FieldOffset(0x0)] public AgentInterface AgentInterface;
 
-    [FieldOffset(0xB8)] public GatheringAreaInfo GatheringAreaInfo; // Represents the currently set gathering area
+    [FieldOffset(0xB8)] public GatheringAreaInfo* GatheringAreaInfo; // Represents the currently set gathering area
 
     [MemberFunction("E8 ?? ?? ?? ?? EB 63 48 83 F8")]
     public partial void OpenGatherableByItemId(ushort itemID);

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGatheringNote.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGatheringNote.cs
@@ -11,6 +11,15 @@ public unsafe partial struct AgentGatheringNote
 
     [FieldOffset(0x0)] public AgentInterface AgentInterface;
 
+    [FieldOffset(0xB8)] public GatheringAreaInfo GatheringAreaInfo; // Represents the currently set gathering area
+
     [MemberFunction("E8 ?? ?? ?? ?? EB 63 48 83 F8")]
     public partial void OpenGatherableByItemId(ushort itemID);
+}
+
+// 0xC8 is the minimum size, total size is unknown, 0x10 + sizeof(OpenMapInfo) [0xB8]
+[StructLayout(LayoutKind.Explicit, Size = 0xC0)]
+public unsafe partial struct GatheringAreaInfo
+{
+    [FieldOffset(0x10)] public OpenMapInfo OpenMapInfo;
 }


### PR DESCRIPTION
![image](https://github.com/aers/FFXIVClientStructs/assets/9083275/3dda1ce5-9d14-4664-92aa-a48b1835095a)

Adds struct for getting gathering area information