### PR TITLE
UI::Map Add New Data

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -5,21 +5,24 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 [StructLayout(LayoutKind.Explicit)]
 public unsafe partial struct Map
 {
+    [StaticAddress("48 8D 0D ?? ?? ?? ?? 41 8B D4 66 89 44 24", 3)]
+    public static partial Map* Instance();
+    
     [Obsolete("Use QuestDataSpan instead", false)]
     [FieldOffset(0x90)] public QuestMarkerArray QuestMarkers;
 
-    [FixedSizeArray<MapMarkerInfo>(30)]
+    [FixedSizeArray<QuestInfo>(30)]
     [FieldOffset(0x90)] public fixed byte QuestData[0x90 * 30];
     
-    [FixedSizeArray<MapMarkerInfo>(16)]
+    [FixedSizeArray<QuestInfo>(16)]
     [FieldOffset(0x1170)] public fixed byte LevequestData[0x90 * 16];
     
-    [FieldOffset(0x1AE8)] public StdVector<QuestMarkerInfo> LevequestMarkerData;
-    [FieldOffset(0x1B20)] public MapMarkerDataContainer QuestMarkerData;
-    [FieldOffset(0x1BA0)] public SpecialMarkerContainer GuildOrderGuideMarkerData;
-    [FieldOffset(0x1B68)] public MapMarkerDataContainer GuildLeveAssignmentMarkerData;
-    [FieldOffset(0x3EB0)] public MapMarkerDataContainer CustomTalkMarkerData;
-    [FieldOffset(0x3E90)] public SpecialMarkerContainer TripleTriadMarkerData;
+    [FieldOffset(0x1AE8)] public StdVector<QuestMarkerInfo> ActiveLevequestMarkerData; // Only valid when a levequest is in progress
+    [FieldOffset(0x1B18)] public MapDataContainer<StandardMapMarkerData> QuestMarkerData;
+    [FieldOffset(0x1BA0)] public NonstandardMapMarkerContainer GuildOrderGuideMarkerData;
+    [FieldOffset(0x1B60)] public MapDataContainer<StandardMapMarkerData> GuildLeveAssignmentMarkerData;
+    [FieldOffset(0x3EA8)] public MapDataContainer<StandardMapMarkerData> CustomTalkMarkerData;
+    [FieldOffset(0x3E90)] public NonstandardMapMarkerContainer TripleTriadMarkerData;
     
     [Obsolete("Use QuestDataSpan instead", false)]
     [StructLayout(LayoutKind.Sequential, Size = 0x10E0)]
@@ -41,6 +44,7 @@ public unsafe partial struct Map
         }
     }
     
+    [Obsolete("Use QuestInfo structure instead", false)]
     [StructLayout(LayoutKind.Explicit, Size = 0x90)]
     public struct MapMarkerInfo
     {
@@ -50,52 +54,62 @@ public unsafe partial struct Map
         [FieldOffset(0x8B)] public byte ShouldRender;
         [FieldOffset(0x88)] public ushort RecommendedLevel;
     }
-
-    [StaticAddress("48 8D 0D ?? ?? ?? ?? 41 8B D4 66 89 44 24", 3)]
-    public static partial Map* Instance();
 }
 
-[StructLayout(LayoutKind.Explicit)]
-public unsafe partial struct MapMarkerDataContainer
+// This data structure is similar to Deque but slightly different
+[StructLayout(LayoutKind.Sequential)]
+public unsafe partial struct MapDataContainer<T> where T : unmanaged
 {
-    [FieldOffset(0x08)] public MapMarkerData** MarkerData;
-    [FieldOffset(0x10)] public int MarkerCount;
+    public ulong CurrentSize;
+    public nint Unused;
+    public T** DataMap;
+    public ulong MaxSize;
 
-    public Span<Pointer<MapMarkerData>> MarkerDataSpan => new(MarkerData, MarkerCount);
+    public Span<Pointer<T>> DataSpan => new(DataMap, (int)CurrentSize);
 }
-    
+
 [StructLayout(LayoutKind.Explicit, Size = 0x10)]
-public unsafe partial struct MapMarkerData
+public unsafe partial struct StandardMapMarkerData
 {
     [FieldOffset(0x00)] public uint IconId;
     [FieldOffset(0x04)] public uint LevelId; // RowId into the 'Level' sheet
     [FieldOffset(0x08)] public uint ObjectiveId; // RowId for whichever type of data this specific marker is representing, QuestId in the case of quests
     [FieldOffset(0x0C)] public int Flags;
 }
-
+    
 [StructLayout(LayoutKind.Explicit)]
-public unsafe partial struct SpecialMarkerContainer
+public unsafe partial struct NonstandardMapMarkerContainer
 {
-    [FieldOffset(0x00)] public SpecialMarker** SpecialMarkerData;
+    [FieldOffset(0x00)] public NonstandardMarker** GuildOrderGuideData;
     [FieldOffset(0x08)] public int DataCount;
         
-    public Span<Pointer<SpecialMarker>> DataSpan => new(SpecialMarkerData, DataCount);
+    public Span<Pointer<NonstandardMarker>> DataSpan => new(GuildOrderGuideData, DataCount);
 }
 
 [StructLayout(LayoutKind.Explicit)]
-public unsafe partial struct SpecialMarker
+public unsafe partial struct NonstandardMarker
 {
     [FieldOffset(0x14)] public uint ObjectiveId;
     [FieldOffset(0x18)] public Utf8String Tooltip;
-    [FieldOffset(0x80)] public SpecialMarkerData* MarkerData;
+    [FieldOffset(0x80)] public NonstandardMarkerData* MarkerData;
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x48)]
-public unsafe partial struct SpecialMarkerData
+public unsafe partial struct NonstandardMarkerData
 {
     [FieldOffset(0x00)] public uint LevelId;
     [FieldOffset(0x04)] public uint ObjectiveId;
     [FieldOffset(0x10)] public uint IconId;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x90)]
+public struct QuestInfo
+{
+    [FieldOffset(0x04)] public uint QuestID;
+    [FieldOffset(0x08)] public Utf8String Name;
+    [FieldOffset(0x70)] public StdVector<QuestMarkerInfo> MarkerData;
+    [FieldOffset(0x8B)] public byte ShouldRender;
+    [FieldOffset(0x88)] public ushort RecommendedLevel;
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x48)]

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -12,7 +12,7 @@ public unsafe partial struct Map
     [FieldOffset(0x90)] public fixed byte QuestData[0x90 * 30];
     
     [FixedSizeArray<MapMarkerInfo>(16)]
-    [FieldOffset(0x1170)] public fixed byte LevequestData[0x90 * 30];
+    [FieldOffset(0x1170)] public fixed byte LevequestData[0x90 * 16];
     
     [FieldOffset(0x1AE8)] public StdVector<QuestMarkerInfo> LevequestMarkerData;
     [FieldOffset(0x1B20)] public MapMarkerDataContainer QuestMarkerData;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -8,8 +8,12 @@ public unsafe partial struct Map
     [Obsolete("Use QuestDataSpan instead", false)]
     [FieldOffset(0x90)] public QuestMarkerArray QuestMarkers;
 
-    [FieldOffset(0x90)] public MapMarkerInfo QuestData;
-    [FieldOffset(0x1170)] public MapMarkerInfo LevequestData;
+    [FixedSizeArray<MapMarkerInfo>(30)]
+    [FieldOffset(0x90)] public fixed byte QuestData[0x90 * 30];
+    
+    [FixedSizeArray<MapMarkerInfo>(16)]
+    [FieldOffset(0x1170)] public fixed byte LevequestData[0x90 * 30];
+    
     [FieldOffset(0x1AE8)] public StdVector<QuestMarkerInfo> LevequestMarkerData;
     [FieldOffset(0x1B20)] public MapMarkerDataContainer QuestMarkerData;
     [FieldOffset(0x1BA0)] public SpecialMarkerContainer GuildOrderGuideMarkerData;
@@ -33,28 +37,6 @@ public unsafe partial struct Map
                 {
                     return (MapMarkerInfo*) (pointer + sizeof(MapMarkerInfo) * index);
                 }
-            }
-        }
-    }
-    
-    public Span<MapMarkerInfo> QuestDataSpan
-    {
-        get
-        {
-            fixed (MapMarkerInfo* pointer = &QuestData)
-            {
-                return new Span<MapMarkerInfo>(pointer, 30);
-            }
-        }
-    }
-
-    public Span<MapMarkerInfo> LevequestDataSpan
-    {
-        get
-        {
-            fixed (MapMarkerInfo* pointer = &LevequestData)
-            {
-                return new Span<MapMarkerInfo>(pointer, 30);
             }
         }
     }

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -23,7 +23,8 @@ public unsafe partial struct Map
     [FieldOffset(0x1B60)] public MapDataContainer<StandardMapMarkerData> GuildLeveAssignmentMarkerData;
     [FieldOffset(0x3EA8)] public MapDataContainer<StandardMapMarkerData> CustomTalkMarkerData;
     [FieldOffset(0x3E90)] public NonstandardMapMarkerContainer TripleTriadMarkerData;
-    
+    [FieldOffset(0x3F50)] public MapDataContainer<StandardMapMarkerData> BicolorGemstoneVendorMarkerData;
+
     [Obsolete("Use QuestDataSpan instead", false)]
     [StructLayout(LayoutKind.Sequential, Size = 0x10E0)]
     public struct QuestMarkerArray

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -5,8 +5,19 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 [StructLayout(LayoutKind.Explicit)]
 public unsafe partial struct Map
 {
+    [Obsolete("Use QuestDataSpan instead", false)]
     [FieldOffset(0x90)] public QuestMarkerArray QuestMarkers;
 
+    [FieldOffset(0x90)] public MapMarkerInfo QuestData;
+    [FieldOffset(0x1170)] public MapMarkerInfo LevequestData;
+    [FieldOffset(0x1AE8)] public StdVector<QuestMarkerInfo> LevequestMarkerData;
+    [FieldOffset(0x1B20)] public MapMarkerDataContainer QuestMarkerData;
+    [FieldOffset(0x1BA0)] public SpecialMarkerContainer GuildOrderGuideMarkerData;
+    [FieldOffset(0x1B68)] public MapMarkerDataContainer GuildLeveAssignmentMarkerData;
+    [FieldOffset(0x3EB0)] public MapMarkerDataContainer CustomTalkMarkerData;
+    [FieldOffset(0x3E90)] public SpecialMarkerContainer TripleTriadMarkerData;
+    
+    [Obsolete("Use QuestDataSpan instead", false)]
     [StructLayout(LayoutKind.Sequential, Size = 0x10E0)]
     public struct QuestMarkerArray
     {
@@ -25,16 +36,90 @@ public unsafe partial struct Map
             }
         }
     }
+    
+    public Span<MapMarkerInfo> QuestDataSpan
+    {
+        get
+        {
+            fixed (MapMarkerInfo* pointer = &QuestData)
+            {
+                return new Span<MapMarkerInfo>(pointer, 30);
+            }
+        }
+    }
 
+    public Span<MapMarkerInfo> LevequestDataSpan
+    {
+        get
+        {
+            fixed (MapMarkerInfo* pointer = &LevequestData)
+            {
+                return new Span<MapMarkerInfo>(pointer, 30);
+            }
+        }
+    }
+    
     [StructLayout(LayoutKind.Explicit, Size = 0x90)]
     public struct MapMarkerInfo
     {
         [FieldOffset(0x04)] public uint QuestID;
         [FieldOffset(0x08)] public Utf8String Name;
+        [FieldOffset(0x70)] public StdVector<QuestMarkerInfo> MarkerData;
         [FieldOffset(0x8B)] public byte ShouldRender;
         [FieldOffset(0x88)] public ushort RecommendedLevel;
     }
 
     [StaticAddress("48 8D 0D ?? ?? ?? ?? 41 8B D4 66 89 44 24", 3)]
     public static partial Map* Instance();
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public unsafe partial struct MapMarkerDataContainer
+{
+    [FieldOffset(0x08)] public MapMarkerData** MarkerData;
+    [FieldOffset(0x10)] public int MarkerCount;
+
+    public Span<Pointer<MapMarkerData>> MarkerDataSpan => new(MarkerData, MarkerCount);
+}
+    
+[StructLayout(LayoutKind.Explicit, Size = 0x10)]
+public unsafe partial struct MapMarkerData
+{
+    [FieldOffset(0x00)] public uint IconId;
+    [FieldOffset(0x04)] public uint LevelId; // RowId into the 'Level' sheet
+    [FieldOffset(0x08)] public uint ObjectiveId; // RowId for whichever type of data this specific marker is representing, QuestId in the case of quests
+    [FieldOffset(0x0C)] public int Flags;
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public unsafe partial struct SpecialMarkerContainer
+{
+    [FieldOffset(0x00)] public SpecialMarker** SpecialMarkerData;
+    [FieldOffset(0x08)] public int DataCount;
+        
+    public Span<Pointer<SpecialMarker>> DataSpan => new(SpecialMarkerData, DataCount);
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public unsafe partial struct SpecialMarker
+{
+    [FieldOffset(0x14)] public uint ObjectiveId;
+    [FieldOffset(0x18)] public Utf8String Tooltip;
+    [FieldOffset(0x80)] public SpecialMarkerData* MarkerData;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x48)]
+public unsafe partial struct SpecialMarkerData
+{
+    [FieldOffset(0x00)] public uint LevelId;
+    [FieldOffset(0x04)] public uint ObjectiveId;
+    [FieldOffset(0x10)] public uint IconId;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x48)]
+public unsafe partial struct QuestMarkerInfo
+{
+    [FieldOffset(0x00)] public uint LevelId;
+    [FieldOffset(0x08)] public Utf8String* Tooltip;
+    [FieldOffset(0x10)] public uint IconId;
 }


### PR DESCRIPTION
So yeah, that's a thing.

So these data structures contain all the necessary information to display the quests on the map.

Generally speaking there are two kinds of structures uses here, one that contains 4 integer values, and another that contains various other data including a pointer to the parent's tooltip.

These all work, as I am currently using them in Mappy, if any of yall wanna take a crack at simplifying this be my guest.
I have no time urgency to merge this as I have my own copy local to my plugin Mappy.

If you have any better ideas for the names be my guest.