### PR TITLE
Add Map Marker Data to UI::Map

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -5,21 +5,24 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 [StructLayout(LayoutKind.Explicit)]
 public unsafe partial struct Map
 {
+    [StaticAddress("48 8D 0D ?? ?? ?? ?? 41 8B D4 66 89 44 24", 3)]
+    public static partial Map* Instance();
+    
     [Obsolete("Use QuestDataSpan instead", false)]
     [FieldOffset(0x90)] public QuestMarkerArray QuestMarkers;
 
-    [FixedSizeArray<MapMarkerInfo>(30)]
+    [FixedSizeArray<QuestInfo>(30)]
     [FieldOffset(0x90)] public fixed byte QuestData[0x90 * 30];
     
-    [FixedSizeArray<MapMarkerInfo>(16)]
+    [FixedSizeArray<QuestInfo>(16)]
     [FieldOffset(0x1170)] public fixed byte LevequestData[0x90 * 16];
     
-    [FieldOffset(0x1AE8)] public StdVector<QuestMarkerInfo> LevequestMarkerData;
-    [FieldOffset(0x1B20)] public MapMarkerDataContainer QuestMarkerData;
-    [FieldOffset(0x1BA0)] public SpecialMarkerContainer GuildOrderGuideMarkerData;
-    [FieldOffset(0x1B68)] public MapMarkerDataContainer GuildLeveAssignmentMarkerData;
-    [FieldOffset(0x3EB0)] public MapMarkerDataContainer CustomTalkMarkerData;
-    [FieldOffset(0x3E90)] public SpecialMarkerContainer TripleTriadMarkerData;
+    [FieldOffset(0x1AE8)] public StdVector<QuestMarkerInfo> ActiveLevequestMarkerData; // Only valid when a levequest is in progress
+    [FieldOffset(0x1B18)] public MapDataContainer<StandardMapMarkerData> QuestMarkerData;
+    [FieldOffset(0x1BA0)] public NonstandardMapMarkerContainer GuildOrderGuideMarkerData;
+    [FieldOffset(0x1B60)] public MapDataContainer<StandardMapMarkerData> GuildLeveAssignmentMarkerData;
+    [FieldOffset(0x3EA8)] public MapDataContainer<StandardMapMarkerData> CustomTalkMarkerData;
+    [FieldOffset(0x3E90)] public NonstandardMapMarkerContainer TripleTriadMarkerData;
     
     [Obsolete("Use QuestDataSpan instead", false)]
     [StructLayout(LayoutKind.Sequential, Size = 0x10E0)]
@@ -41,6 +44,7 @@ public unsafe partial struct Map
         }
     }
     
+    [Obsolete("Use QuestInfo structure instead", false)]
     [StructLayout(LayoutKind.Explicit, Size = 0x90)]
     public struct MapMarkerInfo
     {
@@ -50,52 +54,62 @@ public unsafe partial struct Map
         [FieldOffset(0x8B)] public byte ShouldRender;
         [FieldOffset(0x88)] public ushort RecommendedLevel;
     }
-
-    [StaticAddress("48 8D 0D ?? ?? ?? ?? 41 8B D4 66 89 44 24", 3)]
-    public static partial Map* Instance();
 }
 
-[StructLayout(LayoutKind.Explicit)]
-public unsafe partial struct MapMarkerDataContainer
+// This data structure is similar to Deque but slightly different
+[StructLayout(LayoutKind.Sequential)]
+public unsafe partial struct MapDataContainer<T> where T : unmanaged
 {
-    [FieldOffset(0x08)] public MapMarkerData** MarkerData;
-    [FieldOffset(0x10)] public int MarkerCount;
+    public ulong CurrentSize;
+    public nint Unused;
+    public T** DataMap;
+    public ulong MaxSize;
 
-    public Span<Pointer<MapMarkerData>> MarkerDataSpan => new(MarkerData, MarkerCount);
+    public Span<Pointer<T>> DataSpan => new(DataMap, (int)CurrentSize);
 }
-    
+
 [StructLayout(LayoutKind.Explicit, Size = 0x10)]
-public unsafe partial struct MapMarkerData
+public unsafe partial struct StandardMapMarkerData
 {
     [FieldOffset(0x00)] public uint IconId;
     [FieldOffset(0x04)] public uint LevelId; // RowId into the 'Level' sheet
     [FieldOffset(0x08)] public uint ObjectiveId; // RowId for whichever type of data this specific marker is representing, QuestId in the case of quests
     [FieldOffset(0x0C)] public int Flags;
 }
-
+    
 [StructLayout(LayoutKind.Explicit)]
-public unsafe partial struct SpecialMarkerContainer
+public unsafe partial struct NonstandardMapMarkerContainer
 {
-    [FieldOffset(0x00)] public SpecialMarker** SpecialMarkerData;
+    [FieldOffset(0x00)] public NonstandardMarker** GuildOrderGuideData;
     [FieldOffset(0x08)] public int DataCount;
         
-    public Span<Pointer<SpecialMarker>> DataSpan => new(SpecialMarkerData, DataCount);
+    public Span<Pointer<NonstandardMarker>> DataSpan => new(GuildOrderGuideData, DataCount);
 }
 
 [StructLayout(LayoutKind.Explicit)]
-public unsafe partial struct SpecialMarker
+public unsafe partial struct NonstandardMarker
 {
     [FieldOffset(0x14)] public uint ObjectiveId;
     [FieldOffset(0x18)] public Utf8String Tooltip;
-    [FieldOffset(0x80)] public SpecialMarkerData* MarkerData;
+    [FieldOffset(0x80)] public NonstandardMarkerData* MarkerData;
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x48)]
-public unsafe partial struct SpecialMarkerData
+public unsafe partial struct NonstandardMarkerData
 {
     [FieldOffset(0x00)] public uint LevelId;
     [FieldOffset(0x04)] public uint ObjectiveId;
     [FieldOffset(0x10)] public uint IconId;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x90)]
+public struct QuestInfo
+{
+    [FieldOffset(0x04)] public uint QuestID;
+    [FieldOffset(0x08)] public Utf8String Name;
+    [FieldOffset(0x70)] public StdVector<QuestMarkerInfo> MarkerData;
+    [FieldOffset(0x8B)] public byte ShouldRender;
+    [FieldOffset(0x88)] public ushort RecommendedLevel;
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x48)]

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -1,6 +1,4 @@
-﻿
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
@@ -96,6 +94,10 @@ public unsafe partial struct MapMarkerData
     [FieldOffset(0x04)] public uint ObjectiveId;
     [FieldOffset(0x08)] public Utf8String* TooltipString;
     [FieldOffset(0x10)] public uint IconId;
+    [FieldOffset(0x18)] public float X;
+    [FieldOffset(0x1C)] public float Y;
+    [FieldOffset(0x20)] public float Z;
+    [FieldOffset(0x24)] public float Radius;
     [FieldOffset(0x3C)] public ushort RecommendedLevel;
 }
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -12,7 +12,7 @@ public unsafe partial struct Map
     [FieldOffset(0x90)] public fixed byte QuestData[0x90 * 30];
     
     [FixedSizeArray<MapMarkerInfo>(16)]
-    [FieldOffset(0x1170)] public fixed byte LevequestData[0x90 * 30];
+    [FieldOffset(0x1170)] public fixed byte LevequestData[0x90 * 16];
     
     [FieldOffset(0x1AE8)] public StdVector<QuestMarkerInfo> LevequestMarkerData;
     [FieldOffset(0x1B20)] public MapMarkerDataContainer QuestMarkerData;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -8,8 +8,12 @@ public unsafe partial struct Map
     [Obsolete("Use QuestDataSpan instead", false)]
     [FieldOffset(0x90)] public QuestMarkerArray QuestMarkers;
 
-    [FieldOffset(0x90)] public MapMarkerInfo QuestData;
-    [FieldOffset(0x1170)] public MapMarkerInfo LevequestData;
+    [FixedSizeArray<MapMarkerInfo>(30)]
+    [FieldOffset(0x90)] public fixed byte QuestData[0x90 * 30];
+    
+    [FixedSizeArray<MapMarkerInfo>(16)]
+    [FieldOffset(0x1170)] public fixed byte LevequestData[0x90 * 30];
+    
     [FieldOffset(0x1AE8)] public StdVector<QuestMarkerInfo> LevequestMarkerData;
     [FieldOffset(0x1B20)] public MapMarkerDataContainer QuestMarkerData;
     [FieldOffset(0x1BA0)] public SpecialMarkerContainer GuildOrderGuideMarkerData;
@@ -33,28 +37,6 @@ public unsafe partial struct Map
                 {
                     return (MapMarkerInfo*) (pointer + sizeof(MapMarkerInfo) * index);
                 }
-            }
-        }
-    }
-    
-    public Span<MapMarkerInfo> QuestDataSpan
-    {
-        get
-        {
-            fixed (MapMarkerInfo* pointer = &QuestData)
-            {
-                return new Span<MapMarkerInfo>(pointer, 30);
-            }
-        }
-    }
-
-    public Span<MapMarkerInfo> LevequestDataSpan
-    {
-        get
-        {
-            fixed (MapMarkerInfo* pointer = &LevequestData)
-            {
-                return new Span<MapMarkerInfo>(pointer, 30);
             }
         }
     }

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -23,7 +23,8 @@ public unsafe partial struct Map
     [FieldOffset(0x1B60)] public MapDataContainer<StandardMapMarkerData> GuildLeveAssignmentMarkerData;
     [FieldOffset(0x3EA8)] public MapDataContainer<StandardMapMarkerData> CustomTalkMarkerData;
     [FieldOffset(0x3E90)] public NonstandardMapMarkerContainer TripleTriadMarkerData;
-    
+    [FieldOffset(0x3F50)] public MapDataContainer<StandardMapMarkerData> BicolorGemstoneVendorMarkerData;
+
     [Obsolete("Use QuestDataSpan instead", false)]
     [StructLayout(LayoutKind.Sequential, Size = 0x10E0)]
     public struct QuestMarkerArray

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -5,8 +5,19 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 [StructLayout(LayoutKind.Explicit)]
 public unsafe partial struct Map
 {
+    [Obsolete("Use QuestDataSpan instead", false)]
     [FieldOffset(0x90)] public QuestMarkerArray QuestMarkers;
 
+    [FieldOffset(0x90)] public MapMarkerInfo QuestData;
+    [FieldOffset(0x1170)] public MapMarkerInfo LevequestData;
+    [FieldOffset(0x1AE8)] public StdVector<QuestMarkerInfo> LevequestMarkerData;
+    [FieldOffset(0x1B20)] public MapMarkerDataContainer QuestMarkerData;
+    [FieldOffset(0x1BA0)] public SpecialMarkerContainer GuildOrderGuideMarkerData;
+    [FieldOffset(0x1B68)] public MapMarkerDataContainer GuildLeveAssignmentMarkerData;
+    [FieldOffset(0x3EB0)] public MapMarkerDataContainer CustomTalkMarkerData;
+    [FieldOffset(0x3E90)] public SpecialMarkerContainer TripleTriadMarkerData;
+    
+    [Obsolete("Use QuestDataSpan instead", false)]
     [StructLayout(LayoutKind.Sequential, Size = 0x10E0)]
     public struct QuestMarkerArray
     {
@@ -25,16 +36,90 @@ public unsafe partial struct Map
             }
         }
     }
+    
+    public Span<MapMarkerInfo> QuestDataSpan
+    {
+        get
+        {
+            fixed (MapMarkerInfo* pointer = &QuestData)
+            {
+                return new Span<MapMarkerInfo>(pointer, 30);
+            }
+        }
+    }
 
+    public Span<MapMarkerInfo> LevequestDataSpan
+    {
+        get
+        {
+            fixed (MapMarkerInfo* pointer = &LevequestData)
+            {
+                return new Span<MapMarkerInfo>(pointer, 30);
+            }
+        }
+    }
+    
     [StructLayout(LayoutKind.Explicit, Size = 0x90)]
     public struct MapMarkerInfo
     {
         [FieldOffset(0x04)] public uint QuestID;
         [FieldOffset(0x08)] public Utf8String Name;
+        [FieldOffset(0x70)] public StdVector<QuestMarkerInfo> MarkerData;
         [FieldOffset(0x8B)] public byte ShouldRender;
         [FieldOffset(0x88)] public ushort RecommendedLevel;
     }
 
     [StaticAddress("48 8D 0D ?? ?? ?? ?? 41 8B D4 66 89 44 24", 3)]
     public static partial Map* Instance();
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public unsafe partial struct MapMarkerDataContainer
+{
+    [FieldOffset(0x08)] public MapMarkerData** MarkerData;
+    [FieldOffset(0x10)] public int MarkerCount;
+
+    public Span<Pointer<MapMarkerData>> MarkerDataSpan => new(MarkerData, MarkerCount);
+}
+    
+[StructLayout(LayoutKind.Explicit, Size = 0x10)]
+public unsafe partial struct MapMarkerData
+{
+    [FieldOffset(0x00)] public uint IconId;
+    [FieldOffset(0x04)] public uint LevelId; // RowId into the 'Level' sheet
+    [FieldOffset(0x08)] public uint ObjectiveId; // RowId for whichever type of data this specific marker is representing, QuestId in the case of quests
+    [FieldOffset(0x0C)] public int Flags;
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public unsafe partial struct SpecialMarkerContainer
+{
+    [FieldOffset(0x00)] public SpecialMarker** SpecialMarkerData;
+    [FieldOffset(0x08)] public int DataCount;
+        
+    public Span<Pointer<SpecialMarker>> DataSpan => new(SpecialMarkerData, DataCount);
+}
+
+[StructLayout(LayoutKind.Explicit)]
+public unsafe partial struct SpecialMarker
+{
+    [FieldOffset(0x14)] public uint ObjectiveId;
+    [FieldOffset(0x18)] public Utf8String Tooltip;
+    [FieldOffset(0x80)] public SpecialMarkerData* MarkerData;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x48)]
+public unsafe partial struct SpecialMarkerData
+{
+    [FieldOffset(0x00)] public uint LevelId;
+    [FieldOffset(0x04)] public uint ObjectiveId;
+    [FieldOffset(0x10)] public uint IconId;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x48)]
+public unsafe partial struct QuestMarkerInfo
+{
+    [FieldOffset(0x00)] public uint LevelId;
+    [FieldOffset(0x08)] public Utf8String* Tooltip;
+    [FieldOffset(0x10)] public uint IconId;
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -28,17 +28,7 @@ public unsafe partial struct Map
     [FieldOffset(0x3EA8)] public SimpleMapMarkerContainer SimpleCustomTalkMarkerData;
     [FieldOffset(0x3F48)] public MapMarkerContainer GemstoneTraderMarkerData;
     [FieldOffset(0x3F50)] public SimpleMapMarkerContainer SimpleGemstoneTraderMarkerData;
-
-    /// <summary>
-    /// Returns a span that only includes the number of quests that are actually accepted.
-    /// </summary>
-    public Span<MarkerInfo> SizedQuestData => new(Unsafe.AsPointer(ref QuestData[0]), QuestManager.Instance()->NumAcceptedQuests);
     
-    /// <summary>
-    /// Returns a span that only includes the number of levequests that are actually accepted.
-    /// </summary>
-    public Span<MarkerInfo> SizedLevequestData => new(Unsafe.AsPointer(ref LevequestData[0]), QuestManager.Instance()->NumAcceptedLeveQuests);
-
     [Obsolete("Use QuestDataSpan instead", false)]
     [StructLayout(LayoutKind.Sequential, Size = 0x10E0)]
     public struct QuestMarkerArray

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -1,4 +1,7 @@
-﻿using FFXIVClientStructs.FFXIV.Client.System.String;
+﻿
+
+using System.Runtime.CompilerServices;
+using FFXIVClientStructs.FFXIV.Client.System.String;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 
@@ -11,19 +14,32 @@ public unsafe partial struct Map
     [Obsolete("Use QuestDataSpan instead", false)]
     [FieldOffset(0x90)] public QuestMarkerArray QuestMarkers;
 
-    [FixedSizeArray<QuestInfo>(30)]
+    [FixedSizeArray<MarkerInfo>(30)]
     [FieldOffset(0x90)] public fixed byte QuestData[0x90 * 30];
     
-    [FixedSizeArray<QuestInfo>(16)]
+    [FixedSizeArray<MarkerInfo>(16)]
     [FieldOffset(0x1170)] public fixed byte LevequestData[0x90 * 16];
     
-    [FieldOffset(0x1AE8)] public StdVector<QuestMarkerInfo> ActiveLevequestMarkerData; // Only valid when a levequest is in progress
-    [FieldOffset(0x1B18)] public MapDataContainer<StandardMapMarkerData> QuestMarkerData;
-    [FieldOffset(0x1BA0)] public NonstandardMapMarkerContainer GuildOrderGuideMarkerData;
-    [FieldOffset(0x1B60)] public MapDataContainer<StandardMapMarkerData> GuildLeveAssignmentMarkerData;
-    [FieldOffset(0x3EA8)] public MapDataContainer<StandardMapMarkerData> CustomTalkMarkerData;
-    [FieldOffset(0x3E90)] public NonstandardMapMarkerContainer TripleTriadMarkerData;
-    [FieldOffset(0x3F50)] public MapDataContainer<StandardMapMarkerData> BicolorGemstoneVendorMarkerData;
+    [FieldOffset(0x1AE8)] public StdVector<MapMarkerData> ActiveLevequestMarkerData;
+    [FieldOffset(0x1B10)] public MapMarkerContainer QuestMarkerData;
+    [FieldOffset(0x1B18)] public SimpleMapMarkerContainer SimpleQuestMarkerData;
+    [FieldOffset(0x1B58)] public MapMarkerContainer GuildLeveAssignmentMapMarkerData;
+    [FieldOffset(0x1BA0)] public MapMarkerContainer GuildOrderGuideMarkerData;
+    [FieldOffset(0x3E90)] public MapMarkerContainer TripleTriadMarkerData;
+    [FieldOffset(0x3EA0)] public MapMarkerContainer CustomTalkMarkerData;
+    [FieldOffset(0x3EA8)] public SimpleMapMarkerContainer SimpleCustomTalkMarkerData;
+    [FieldOffset(0x3F48)] public MapMarkerContainer GemstoneTraderMarkerData;
+    [FieldOffset(0x3F50)] public SimpleMapMarkerContainer SimpleGemstoneTraderMarkerData;
+
+    /// <summary>
+    /// Returns a span that only includes the number of quests that are actually accepted.
+    /// </summary>
+    public Span<MarkerInfo> SizedQuestData => new(Unsafe.AsPointer(ref QuestData[0]), QuestManager.Instance()->NumAcceptedQuests);
+    
+    /// <summary>
+    /// Returns a span that only includes the number of levequests that are actually accepted.
+    /// </summary>
+    public Span<MarkerInfo> SizedLevequestData => new(Unsafe.AsPointer(ref LevequestData[0]), QuestManager.Instance()->NumAcceptedLeveQuests);
 
     [Obsolete("Use QuestDataSpan instead", false)]
     [StructLayout(LayoutKind.Sequential, Size = 0x10E0)]
@@ -45,78 +61,107 @@ public unsafe partial struct Map
         }
     }
     
-    [Obsolete("Use QuestInfo structure instead", false)]
+    [Obsolete("Use MarkerInfo structure instead", false)]
     [StructLayout(LayoutKind.Explicit, Size = 0x90)]
     public struct MapMarkerInfo
     {
         [FieldOffset(0x04)] public uint QuestID;
         [FieldOffset(0x08)] public Utf8String Name;
-        [FieldOffset(0x70)] public StdVector<QuestMarkerInfo> MarkerData;
         [FieldOffset(0x8B)] public byte ShouldRender;
         [FieldOffset(0x88)] public ushort RecommendedLevel;
     }
 }
 
-// This data structure is similar to Deque but slightly different
-[StructLayout(LayoutKind.Sequential)]
-public unsafe partial struct MapDataContainer<T> where T : unmanaged
-{
-    public ulong CurrentSize;
-    public nint Unused;
-    public T** DataMap;
-    public ulong MaxSize;
-
-    public Span<Pointer<T>> DataSpan => new(DataMap, (int)CurrentSize);
-}
-
 [StructLayout(LayoutKind.Explicit, Size = 0x10)]
-public unsafe partial struct StandardMapMarkerData
+public unsafe partial struct SimpleMapMarkerData
 {
     [FieldOffset(0x00)] public uint IconId;
     [FieldOffset(0x04)] public uint LevelId; // RowId into the 'Level' sheet
     [FieldOffset(0x08)] public uint ObjectiveId; // RowId for whichever type of data this specific marker is representing, QuestId in the case of quests
     [FieldOffset(0x0C)] public int Flags;
 }
-    
-[StructLayout(LayoutKind.Explicit)]
-public unsafe partial struct NonstandardMapMarkerContainer
-{
-    [FieldOffset(0x00)] public NonstandardMarker** GuildOrderGuideData;
-    [FieldOffset(0x08)] public int DataCount;
-        
-    public Span<Pointer<NonstandardMarker>> DataSpan => new(GuildOrderGuideData, DataCount);
-}
 
-[StructLayout(LayoutKind.Explicit)]
-public unsafe partial struct NonstandardMarker
+[StructLayout(LayoutKind.Explicit, Size = 0x90)]
+public unsafe partial struct MarkerInfo
 {
-    [FieldOffset(0x14)] public uint ObjectiveId;
-    [FieldOffset(0x18)] public Utf8String Tooltip;
-    [FieldOffset(0x80)] public NonstandardMarkerData* MarkerData;
+    [FieldOffset(0x04)] public uint ObjectiveId;
+    [FieldOffset(0x08)] public Utf8String Label;
+    [FieldOffset(0x70)] public StdVector<MapMarkerData> MarkerData;
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x48)]
-public unsafe partial struct NonstandardMarkerData
+public unsafe partial struct MapMarkerData
 {
     [FieldOffset(0x00)] public uint LevelId;
     [FieldOffset(0x04)] public uint ObjectiveId;
+    [FieldOffset(0x08)] public Utf8String* TooltipString;
     [FieldOffset(0x10)] public uint IconId;
+    [FieldOffset(0x3C)] public ushort RecommendedLevel;
 }
 
-[StructLayout(LayoutKind.Explicit, Size = 0x90)]
-public struct QuestInfo
+/// <summary>
+/// This container uses a 2-dimensional array to contain Map Markers that contain basic information.
+/// If you need more advanced information, use the MapMarkerContainer fields instead if applicable.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public unsafe partial struct SimpleMapMarkerContainer
 {
-    [FieldOffset(0x04)] public uint QuestID;
-    [FieldOffset(0x08)] public Utf8String Name;
-    [FieldOffset(0x70)] public StdVector<QuestMarkerInfo> MarkerData;
-    [FieldOffset(0x8B)] public byte ShouldRender;
-    [FieldOffset(0x88)] public ushort RecommendedLevel;
+    public ulong CurrentSize;
+    public nint InternalPointer;
+    public SimpleMapMarkerData** DataArray;
+    public ulong MaxSize;
+
+    public Span<Pointer<SimpleMapMarkerData>> DataSpan => new(DataArray, (int)CurrentSize);
+    
+    public IEnumerable<SimpleMapMarkerData> GetEnumerable()
+    {
+        var results = new List<SimpleMapMarkerData>();
+
+        foreach (var index in Enumerable.Range(0, (int) CurrentSize))
+        {
+            results.Add(*DataArray[index]);
+        }
+
+        return results;
+    }
 }
 
-[StructLayout(LayoutKind.Explicit, Size = 0x48)]
-public unsafe partial struct QuestMarkerInfo
+/// <summary>
+/// This container uses a linked list internally to contain Map Markers that contain tooltip information.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public unsafe partial struct MapMarkerContainer
 {
-    [FieldOffset(0x00)] public uint LevelId;
-    [FieldOffset(0x08)] public Utf8String* Tooltip;
-    [FieldOffset(0x10)] public uint IconId;
+    public LinkedList* List;
+    public int Size;
+
+    public IEnumerable<MarkerInfo> GetAllMarkers()
+    {
+        var result = new List<MarkerInfo>();
+        var current = List->First;
+        
+        foreach(var _ in Enumerable.Range(0, Size))
+        {
+            result.Add(current->Data);
+            current = current->Next;
+        }
+
+        return result;
+    }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public unsafe partial struct LinkedList
+{
+    public MapMarkerNode* First;
+    public MapMarkerNode* Last;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public unsafe partial struct MapMarkerNode
+{
+    public MapMarkerNode* Next;
+    public MapMarkerNode* Previous;
+
+    public MarkerInfo Data;
 }


### PR DESCRIPTION
There are two new data structures used and implemented here, one is based on a LinkedList, the other is based on a Map, neither a AtkLinkedListnor a StdMap properly fit here, as the "CurrentSize" field of a map is always zero for these, and the list implementation used here doesn't include size information once you are at the Start and End pointers.

### SimpleMapMarkerContainer 
SimpleMapMarkerContainer only contains basic information about the map marker, icon id, location, and lumina row id for whatever kind of entry it is.

For example: 
![image](https://github.com/aers/FFXIVClientStructs/assets/9083275/2431c78f-8355-42a3-9fbf-849ea3565add)

In this image there are 2 entries for CustomTalk, these are the "The Smith" markers near Bentbranch.

### MapMarkerContainer 
MapMarkerContainer contains the very useful data, locations, tooltips, and much more.

Each marker in the map has a vector of additional markers. The markers contained in that vector contain the specific location information.

![image](https://github.com/aers/FFXIVClientStructs/assets/9083275/e25ed55b-da3b-4d26-b2ad-d4a13a8b9d54)

### Disclaimer
The SimpleMapMarkerContainer overlaps with the MapMarkerContainer to share the "Current Size" value. This likely means that its a bigger composite type, however it becomes much more difficult to use in that form so I decided to keep them separate.
