### PR TITLE
Add GPose, IdleCam Checks

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/ActionManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/ActionManager.cs
@@ -81,6 +81,14 @@ public unsafe partial struct ActionManager
     
     [MemberFunction("48 89 5C 24 ?? 57 48 83 EC 20 48 8B DA 8B F9 E8 ?? ?? ?? ?? 4C 8B C3")]
     public static partial bool CanUseActionOnTarget(uint actionId, GameObject* target);
+    
+    /// <summary>
+    /// Returns the ID of the action present at the specified Duty Action slot.
+    /// </summary>
+    /// <param name="dutyActionSlot">The Duty Action slot number (0 or 1) to look up.</param>
+    /// <returns>Returns an Action ID.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? EB 17 33 C9")]
+    public static partial uint GetDutyActionId(ushort dutyActionSlot);
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x14)]

--- a/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
@@ -30,6 +30,9 @@ public unsafe partial struct GameMain
 
 	[MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 21 48 8B 4F 10")]
 	public static partial bool IsInSanctuary();
+	
+	[MemberFunction("E8 ?? ?? ?? ?? 0F 28 74 24 ?? 0F B6 F0")]
+	public static partial bool IsInGPose();
 
 	[MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 8B 44 24 60 48 8D 8D")]
 	public partial void QueueActiveFestivals(uint festival1, uint festival2, uint festival3, uint festival4); // Applies once the current "event" is done (GPose, Cutscene etc)

--- a/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
@@ -34,6 +34,9 @@ public unsafe partial struct GameMain
 	[MemberFunction("E8 ?? ?? ?? ?? 0F 28 74 24 ?? 0F B6 F0")]
 	public static partial bool IsInGPose();
 
+	[MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 D7")]
+	public static partial bool IsInIdleCam();
+
 	[MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 8B 44 24 60 48 8D 8D")]
 	public partial void QueueActiveFestivals(uint festival1, uint festival2, uint festival3, uint festival4); // Applies once the current "event" is done (GPose, Cutscene etc)
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
@@ -134,6 +134,9 @@ public unsafe partial struct UIModule
     [VirtualFunction(76)]
     public partial void ExitGPose();
 
+    [VirtualFunction(77)]
+    public partial bool IsInGPose();
+
     [VirtualFunction(78)]
     public partial void EnterIdleCam(byte a1 = 0, ulong focusObject = 0xE0000000);
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
@@ -143,6 +143,9 @@ public unsafe partial struct UIModule
     [VirtualFunction(79)]
     public partial void ExitIdleCam();
 
+    [VirtualFunction(80)]
+    public partial bool IsInIdleCam();
+
     [VirtualFunction(141)]
     public partial void ToggleUi(UiFlags flags, bool enable, bool unknown = true);
     

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -294,6 +294,7 @@ classes:
       0x1404CBC70: Update
       0x1404CDDC0: ctor
       0x1404CD480: IsInGPose  # (probably) static
+      0x1404CD4C0: IsInIdleCam  # static
       0x1404CD6A0: IsInInstanceArea
       0x14091EF40: IsInPvPInstance
       0x14091F000: IsInPvPArea
@@ -3436,6 +3437,7 @@ classes:
       77: IsInGPose
       78: EnterIdleCam
       79: ExitIdleCam
+      80: IsInIdleCam
       89: ShowEurekaHud
       90: HideEurekaHud
       96: OpenMycInfo

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -293,6 +293,7 @@ classes:
       0x1404CB930: Terminate
       0x1404CBC70: Update
       0x1404CDDC0: ctor
+      0x1404CD480: IsInGPose  # (probably) static
       0x1404CD6A0: IsInInstanceArea
       0x14091EF40: IsInPvPInstance
       0x14091F000: IsInPvPArea
@@ -3432,6 +3433,7 @@ classes:
       70: DisableCutsceneInputMode
       75: EnterGPose
       76: ExitGPose
+      77: IsInGPose
       78: EnterIdleCam
       79: ExitIdleCam
       89: ShowEurekaHud

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -938,6 +938,7 @@ classes:
       0x1409B5210: SwapBlueMageActionSlots
       0x1409B5320: SetBlueMageActions
       0x1409B8DC0: GetMaxCharges
+      0x1409BA070: GetDutyActionId  # (byte dutyActionSlot) -> uint
       0x1409A8C30: GetRecastGroup
       0x1409AE120: GetRecastGroupDetail
       0x1409AE1F0: Update


### PR DESCRIPTION
- Adds `UIModule#IsInGPose` at UIModule vf77
  - Adds static (probably) method `GameMain.IsInGPose`
  - Adds relevant data.yml findings
- Adds `UIModule#IsInIdleCam` at UIModule vf80 (found by @Haselnussbomber)
  - Adds static method `GameMain.IsInIdleCam`
  - Adds relevant data.yml findings

And, as as bonus:

- Adds `ActionManager.GetDutyActionId`
  - Found as a static member of ActionManager (thanks @MidoriKami)
  - Adds relevant data.yml findings