### PR TITLE
Fix FateContext Offsets

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Fate/FateContext.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Fate/FateContext.cs
@@ -17,6 +17,7 @@ public struct FateContext
     [FieldOffset(0x3AC)] public byte State;
     [FieldOffset(0x3AF)] public byte HandInCount;
     [FieldOffset(0x3B8)] public byte Progress;
+    [FieldOffset(0x3C4)] public bool IsExpBonus;
     [FieldOffset(0x3D8)] public uint IconId;
     [FieldOffset(0x3F9)] public byte Level;
     [FieldOffset(0x3FA)] public byte MaxLevel;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Fate/FateContext.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Fate/FateContext.cs
@@ -23,6 +23,6 @@ public struct FateContext
     [FieldOffset(0x450)] public Vector3 Location;
     [FieldOffset(0x464)] public float Radius;
 
-    [FieldOffset(0x720)] public uint MapIconId;
-    [FieldOffset(0x74E)] public ushort TerritoryId;
+    [FieldOffset(0x760)] public uint MapIconId;
+    [FieldOffset(0x78E)] public ushort TerritoryId;
 }


### PR DESCRIPTION
These fields shifted by 64 bytes since someone checked them last.

Also adds `IsExpBonus` field