### PR TITLE
Partial StaticAddressPointers

### DIFF
--- a/FFXIVClientStructs.InteropSourceGenerators/StaticAddressGenerator.cs
+++ b/FFXIVClientStructs.InteropSourceGenerators/StaticAddressGenerator.cs
@@ -180,7 +180,7 @@ internal sealed class StaticAddressGenerator : IIncrementalGenerator
             builder.AppendLine("}");
             builder.AppendLine();
             
-            builder.AppendLine("public unsafe static class StaticAddressPointers");
+            builder.AppendLine("public unsafe static partial class StaticAddressPointers");
             builder.AppendLine("{");
             builder.Indent();
             StaticAddressInfos.Iter(sai => sai.RenderPointer(builder, StructInfo));

--- a/FFXIVClientStructs.InteropSourceGenerators/VTableAddressGenerator.cs
+++ b/FFXIVClientStructs.InteropSourceGenerators/VTableAddressGenerator.cs
@@ -162,7 +162,7 @@ internal sealed class VTableAddressGenerator : IIncrementalGenerator
             builder.AppendLine("{");
             builder.AppendLine("}");
             builder.AppendLine();
-            builder.AppendLine("public unsafe static class StaticAddressPointers");
+            builder.AppendLine("public unsafe static partial class StaticAddressPointers");
             builder.AppendLine("{");
             builder.Indent();
             StaticAddressInfos.Iter(sai => sai.RenderPointer(builder, StructInfo));


### PR DESCRIPTION
This PR makes `StaticAddressPointers` a partial class.
Otherwise we can't have both the `StaticAddress()` attribute on functions inside the struct and the `VTableAddress()` attribute on the struct.