### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,53 @@
+root = true
+
+# All files
+[*]
+end_of_line = crlf
+indent_style = space
+charset = utf-8
+
+# XML project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+[*.cs]
+indent_size = 4
+insert_final_newline = true
+
+###############################
+# .NET Coding Conventions     #
+###############################
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary
+
+###############################
+# C# Coding Conventions       #
+###############################
+
+# namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+
+# var preferences
+csharp_style_var_for_built_in_types = true
+csharp_style_var_when_type_is_apparent = true
+csharp_style_var_elsewhere = true
+
+# Expression-bodied members
+csharp_style_expression_bodied_operators = true
+
+# Expression-level preferences
+csharp_prefer_braces = false
+csharp_style_prefer_utf8_string_literals = false
+
+###############################
+# C# Formatting Rules         #
+###############################
+
+# Indentation preferences
+csharp_indent_labels = flush_left

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,9 @@ insert_final_newline = true
 # .NET Coding Conventions     #
 ###############################
 
+# Organize usings
+dotnet_sort_system_directives_first = true
+
 # Parentheses preferences
 dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary
 dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary

--- a/.editorconfig
+++ b/.editorconfig
@@ -54,3 +54,12 @@ csharp_style_prefer_utf8_string_literals = false
 
 # Indentation preferences
 csharp_indent_labels = flush_left
+
+# Braces
+csharp_prefer_braces = false
+
+# New-line options
+csharp_new_line_before_open_brace = none
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false


### PR DESCRIPTION
I'm not sure if this will help to get some consistency in here, but it's worth a try.
This obviously needs a `dotnet format` after merging.

In my opinion, .NET already has good defaults, which I have tweaked a bit. However, I'm not sure they're actually applied.
For example, according to the [docs](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/dotnet-formatting-options) `dotnet_sort_system_directives_first` defaults to true, but it didn't sort them correctly unless specified in the .editorconfig file. 🤷‍♂️

Also, since nobody runs `dotnet format` before comitting their changes, we might need a GitHub Action for this. Something similar to the [v9 rollup](https://github.com/goatcorp/Dalamud/blob/master/.github/workflows/rollup.yml) action in Dalamud, which automatically pushes format fixes via a PR that it creates.