### PR TITLE
Remove Obsolete from RaptureAtkModule.IsUiVisible

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
@@ -46,7 +46,6 @@ public unsafe partial struct RaptureAtkModule
     [VirtualFunction(39)]
     public partial void SetUiVisibility(bool uiVisible);
 
-    [Obsolete("Use RaptureAtkUnitManager.IsUiVisible")]
     public bool IsUiVisible {
         get => !RaptureAtkUnitManager.Flags.HasFlag(RaptureAtkModuleFlags.UiHidden);
         set => SetUiVisibility(value);


### PR DESCRIPTION
`RaptureAtkUnitManager.IsUiVisible` doesn't exist and the setter function `SetUiVisibility`, which does more than setting the flag, is a vf of `RaptureAtkModule`, so we can't easily move it into `RaptureAtkUnitManager` anyway.