### PR TITLE
Add soft target to Character

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -83,7 +83,7 @@ public unsafe partial struct Character
 
     /// <summary>
     /// The GameObjectID of the entity that currently has the combat tag on this character. May be set to a party ID if
-    /// certain conditions are met (PVP/alliances?).
+    /// certain conditions are met (PVP?). See <see cref="CombatTagType"/> for information about the type of tagger.
     /// </summary>
     /// <remarks>
     /// A tagger is generally the first entity to deal damage to this character, and will persist until that entity
@@ -113,7 +113,9 @@ public unsafe partial struct Character
     [FieldOffset(0x1AC0)] public GameObjectID SoftTargetId;
 
     [FieldOffset(0x1B00)] public uint NameID;
-
+    
+    [FieldOffset(0x1B10)] public uint CompanionOwnerID;
+    
     [FieldOffset(0x1B1C)] public ushort CurrentWorld;
     [FieldOffset(0x1B1E)] public ushort HomeWorld;
 
@@ -122,7 +124,17 @@ public unsafe partial struct Character
     [FieldOffset(0x1B26)] public CharacterModes Mode;
     [FieldOffset(0x1B27)] public byte ModeParam; // Different purpose depending on mode. See CharacterModes for more info.
     [FieldOffset(0x1B29)] public byte Battalion; // used for determining friend/enemy state
-    [FieldOffset(0x1B10)] public uint CompanionOwnerID;
+
+    /// <summary>
+    /// The type of tagger, as represented in <see cref="CombatTaggerId"/>. Known values:
+    /// <list type="bullet">
+    /// <item>0 - Entity Not Tagged</item>
+    /// <item>1 - Character Tag (players, battle NPCs, etc.)</item>
+    /// <item>2 - Party Tag (PVP?)</item>
+    /// <item>4 - Observed, but unknown.</item>
+    /// </list>
+    /// </summary>
+    [FieldOffset(0x1B31)] public byte CombatTagType;
 
     // Note: These 2 status flags might be just an ushort instead of 2 separate bytes.
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -80,6 +80,16 @@ public unsafe partial struct Character
     [FieldOffset(0x1A4C)] public float Alpha;
     [FieldOffset(0x1A80)] public Companion* CompanionObject; // minion
     [FieldOffset(0x1A98)] public fixed byte FreeCompanyTag[6];
+
+    /// <summary>
+    /// The GameObjectID of the entity that currently has the combat tag on this character. May be set to a party ID if
+    /// certain conditions are met (PVP/alliances?).
+    /// </summary>
+    /// <remarks>
+    /// A tagger is generally the first entity to deal damage to this character, and will persist until that entity
+    /// has died, at which point it will reset.
+    /// </remarks>
+    [FieldOffset(0x1AB0)] public GameObjectID CombatTaggerId;
     
     [Obsolete($"Use {nameof(HardTargetId)} instead.")]
     [FieldOffset(0x1AB8)] public ulong TargetObjectID;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -64,7 +64,8 @@ public unsafe partial struct Character
 
     /// <summary>
     /// The current target for this character's gaze. Can be set independently of soft or hard targets, and may be set
-    /// by NPCs or minions. For players, an action cast will generally target the LookTarget.
+    /// by NPCs or minions. For players, an action cast will generally target the LookTarget (which generally will be
+    /// the soft target if set, then the hard target).
     /// </summary>
     /// <remarks>
     /// Unlike other GameObjectIDs, this one appears to be set to fully 0 if the player is not looking at anything.
@@ -91,17 +92,17 @@ public unsafe partial struct Character
     /// </remarks>
     [FieldOffset(0x1AB0)] public GameObjectID CombatTaggerId;
     
-    [Obsolete($"Use {nameof(HardTargetId)} instead.")]
+    [Obsolete($"Use {nameof(TargetId)} instead.")]
     [FieldOffset(0x1AB8)] public ulong TargetObjectID;
 
     /// <summary>
-    /// The current hard target for this Character. This will not be set for the LocalPlayer.
+    /// The current (hard) target for this Character. This will not be set for the LocalPlayer.
     /// </summary>
     /// <remarks>
-    /// Developers should generally use <see cref="GetHardTargetId"/> over reading this field directly, as it will
-    /// properly handle resolving the hard target for the local player.
+    /// Developers should generally use <see cref="GetTargetId"/> over reading this field directly, as it will
+    /// properly handle resolving the target for the local player.
     /// </remarks>
-    [FieldOffset(0x1AB8)] public GameObjectID HardTargetId;
+    [FieldOffset(0x1AB8)] public GameObjectID TargetId;
     
     /// <summary>
     /// The current soft target for this Character. This will not be set for the LocalPlayer.
@@ -171,20 +172,18 @@ public unsafe partial struct Character
         get => (StatusFlags4 & 0x20) == 0x20;
         set => StatusFlags4 = (byte) (value ? StatusFlags4 | 0x20 : StatusFlags4 & ~0x20);
     }
-
-    [Obsolete($"Use {nameof(GetHardTargetId)} instead.")]
-    public ulong GetTargetId() => this.GetHardTargetId();
     
     /// <summary>
-    /// Gets the hard target ID for this character. If this character is the LocalPlayer, this will instead read the
-    /// hard target ID from the <see cref="TargetSystem"/>. Used for calculating ToT via /assist.
+    /// Gets the (hard) target ID for this character. If this character is the LocalPlayer, this will instead read the
+    /// target ID from the <see cref="TargetSystem"/>. Used for calculating ToT via /assist.
     /// </summary>
     /// <returns>Returns the object ID of this character's target.</returns>
+    // TODO: Update this return type to GameObjectID with next API bump.
     [MemberFunction("E8 ?? ?? ?? ?? 49 3B C7 0F 84")]
-    public partial GameObjectID GetHardTargetId();
+    public partial ulong GetTargetId();
     
     [MemberFunction("E8 ?? ?? ?? ?? 48 3B FD 74 36")]
-    public partial void SetHardTargetId(GameObjectID id);
+    public partial void SetTargetId(GameObjectID id);
 
     /// <summary>
     /// Gets the soft target ID for this character. If this character is the LocalPlayer, this will instead read the

--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -81,19 +81,25 @@ public unsafe partial struct Character
     [FieldOffset(0x1A80)] public Companion* CompanionObject; // minion
     [FieldOffset(0x1A98)] public fixed byte FreeCompanyTag[6];
     
-    [Obsolete("Use HardTargetObjectId instead.")]
+    [Obsolete($"Use {nameof(HardTargetId)} instead.")]
     [FieldOffset(0x1AB8)] public ulong TargetObjectID;
 
     /// <summary>
-    /// The current hard target for this Character. This will not be set for the LocalPlayer. Developers should
-    /// generally use <see cref="GetHardTargetId"/> over reading this field directly.
+    /// The current hard target for this Character. This will not be set for the LocalPlayer.
     /// </summary>
+    /// <remarks>
+    /// Developers should generally use <see cref="GetHardTargetId"/> over reading this field directly, as it will
+    /// properly handle resolving the hard target for the local player.
+    /// </remarks>
     [FieldOffset(0x1AB8)] public GameObjectID HardTargetId;
     
     /// <summary>
-    /// The current soft target for this Character. This will not be set for the LocalPlayer. Developers should
-    /// generally use <see cref="GetSoftTargetId"/> over reading this field directly.
+    /// The current soft target for this Character. This will not be set for the LocalPlayer.
     /// </summary>
+    /// <remarks>
+    /// Developers should generally use <see cref="GetSoftTargetId"/> over reading this field directly, as it will
+    /// properly handle resolving the soft target for the local player.
+    /// </remarks>
     [FieldOffset(0x1AC0)] public GameObjectID SoftTargetId;
 
     [FieldOffset(0x1B00)] public uint NameID;
@@ -144,7 +150,7 @@ public unsafe partial struct Character
         set => StatusFlags4 = (byte) (value ? StatusFlags4 | 0x20 : StatusFlags4 & ~0x20);
     }
 
-    [Obsolete("Use GetHardTargetId instead.")]
+    [Obsolete($"Use {nameof(GetHardTargetId)} instead.")]
     public ulong GetTargetId() => this.GetHardTargetId();
     
     /// <summary>

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -10,8 +10,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Object;
 //   if (DataID != 0) ObjectID = DataID, Type = 1
 // else ObjectID = ObjectID, Type = 0
 [StructLayout(LayoutKind.Explicit, Size = 0x8)]
-public struct GameObjectID
-{
+public struct GameObjectID {
     [FieldOffset(0x0)] public uint ObjectID;
     [FieldOffset(0x4)] public byte Type;
 
@@ -20,8 +19,18 @@ public struct GameObjectID
         return *(long*)objid;
     }
 
+    public static unsafe implicit operator ulong(GameObjectID id) {
+        var objid = stackalloc GameObjectID[] {id};
+        return *(ulong*)objid;
+    }
+
     public static unsafe implicit operator GameObjectID(long id) {
         var objid = stackalloc long[] {id};
+        return *(GameObjectID*)objid;
+    }
+    
+    public static unsafe implicit operator GameObjectID(ulong id) {
+        var objid = stackalloc ulong[] {id};
         return *(GameObjectID*)objid;
     }
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3904,8 +3904,8 @@ classes:
       0x140733A00: IsCasting
       0x140742DF0: IsMounted
       0x140744640: GetCompanionOwnerID
-      0x140745570: SetHardTargetId
-      0x1407455E0: GetHardTargetId
+      0x140745570: SetTargetId
+      0x1407455E0: GetTargetId
       0x140745620: SetSoftTargetId
       0x1407456A0: GetSoftTargetId
       0x140746300: SetMode

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3904,7 +3904,10 @@ classes:
       0x140733A00: IsCasting
       0x140742DF0: IsMounted
       0x140744640: GetCompanionOwnerID
-      0x1407455E0: GetTargetId
+      0x140745570: SetHardTargetId
+      0x1407455E0: GetHardTargetId
+      0x140745620: SetSoftTargetId
+      0x1407456A0: GetSoftTargetId
       0x140746300: SetMode
       0x140748520: Finalize
       0x14074F6B0: SetupBNpc


### PR DESCRIPTION
- Corrects PlayerTargetObjectID to LookTargetId, add docs
- Corrects TargetObjectID to HardTargetId, add docs
- Adds SoftTargetId
- Corrects GetTargetId to GetHardTargetId, add docs
- Adds GetSoftTargetId
- Adds SetHardTargetId, SetSoftTargetId
- Allows implicit casting GameObjectID to/from a ulong