### PR TITLE
Nest LinkedList

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -127,6 +127,13 @@ public unsafe partial struct MapMarkerContainer
     public LinkedList* List;
     public int Size;
 
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe partial struct LinkedList
+    {
+        public MapMarkerNode* First;
+        public MapMarkerNode* Last;
+    }
+
     public IEnumerable<MarkerInfo> GetAllMarkers()
     {
         var result = new List<MarkerInfo>();
@@ -140,13 +147,6 @@ public unsafe partial struct MapMarkerContainer
 
         return result;
     }
-}
-
-[StructLayout(LayoutKind.Sequential)]
-public unsafe partial struct LinkedList
-{
-    public MapMarkerNode* First;
-    public MapMarkerNode* Last;
 }
 
 [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
PR #500 added a `LinkedList` struct to the `FFXIVClientStructs.FFXIV.Client.Game.UI` namespace.
I think this could cause some confusion and would rather see it being nested inside the `MapMarkerContainer` struct.