### PR TITLE
Update RaptureGearsetModule

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
@@ -101,9 +101,9 @@ public unsafe partial struct RaptureGearsetModule {
     /// Get the Banner index of a Gearset.
     /// </summary>
     /// <param name="gearsetId">The ID of the gearset.</param>
-    /// <returns>The actual BannerIndex (gearset->BannerIndex - 1).</returns>
+    /// <returns>The Banner index, or -1 if it was not linked.</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 0F B6 C0 41 3B C7")]
-    public partial byte GetBannerIndex(byte gearsetId);
+    public partial sbyte GetBannerIndex(byte gearsetId);
 
     /// <summary>
     /// Set the Banner index of a Gearset.

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
@@ -1,4 +1,3 @@
-using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc.UserFileManager;
 
@@ -10,7 +9,7 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 [VTableAddress("48 8D 05 ?? ?? ?? ?? 48 89 5F 40 48 8D 77 48", 3)]
 [StructLayout(LayoutKind.Explicit, Size = 0xB670)]
 public unsafe partial struct RaptureGearsetModule {
-    public static RaptureGearsetModule* Instance() => Framework.Instance()->GetUiModule()->GetRaptureGearsetModule();
+    public static RaptureGearsetModule* Instance() => UIModule.Instance()->GetRaptureGearsetModule();
 
     [FieldOffset(0)] public UserFileEvent UserFileEvent;
     [FixedSizeArray<GearsetEntry>(100)]
@@ -41,7 +40,7 @@ public unsafe partial struct RaptureGearsetModule {
     /// Check if a gearset at a specific index is valid.
     /// </summary>
     /// <remarks>
-    /// Will return 0 if the gearset index is higher than the player's max allowed gearset number.
+    /// Will return <c>false</c> if the gearset index is higher than the player's max allowed gearset number.
     /// </remarks>
     /// <param name="gearsetId">The index of the gearset to look up.</param>
     /// <returns>Returns <c>true</c> if the gearset is valid, <c>false</c> otherwise.</returns>
@@ -54,7 +53,7 @@ public unsafe partial struct RaptureGearsetModule {
     /// <param name="gearsetId">The gearset ID to attempt to equip.</param>
     /// <param name="glamourPlateId">The glamour plate to attempt to equip alongside this gearset. Passing 0 will use the
     /// linked gearset (if any).</param>
-    /// <returns>Returns 0 if the equip succeeded, -1 otherwise (???).</returns>
+    /// <returns>Returns 0 if the equip succeeded, -1 otherwise.</returns>
     [MemberFunction("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F9 41 0F B6 F0 48 8D 0D")]
     public partial int EquipGearset(int gearsetId, byte glamourPlateId = 0);
 
@@ -91,21 +90,37 @@ public unsafe partial struct RaptureGearsetModule {
     /// Check if a specific gearset has a linked glamour plate.
     /// </summary>
     /// <param name="gearsetId">The ID of the gearset to check.</param>
-    /// <returns>Returns 0 if a gearset is invalid or does not have a linked plate, 1 otherwise.</returns>
+    /// <returns>Returns <c>false</c> if a gearset is invalid or does not have a linked plate, <c>true</c> otherwise.</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 0E 8B D3")]
-    public partial byte HasLinkedGlamourPlate(int gearsetId);
+    public partial bool HasLinkedGlamourPlate(int gearsetId);
 
     [MemberFunction("45 33 C0 83 FA 64")]
     public partial int GetClassJobIconForGearset(int gearsetId);
 
+    /// <summary>
+    /// Get the Banner index of a Gearset.
+    /// </summary>
+    /// <param name="gearsetId">The ID of the gearset.</param>
+    /// <returns>The actual BannerIndex (gearset->BannerIndex - 1).</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 0F B6 C0 41 3B C7")]
-    public partial byte GetBannerIndexByGearsetIndex(byte gearsetIndex); // returns the actual BannerIndex (gearset->BannerIndex - 1)
+    public partial byte GetBannerIndex(byte gearsetId);
 
+    /// <summary>
+    /// Set the Banner index of a Gearset.
+    /// </summary>
+    /// <param name="gearsetId">The ID of the gearset.</param>
+    /// <param name="bannerIndex">The Banner index, or -1 to unlink the Banner.</param>
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 7C 24 ?? 40 FE C6")]
-    public partial void SetBannerIndexForGearsetIndex(byte gearsetIndex, sbyte bannerIndex); // actual BannerIndex, -1 = unlink banner
+    public partial void SetBannerIndex(byte gearsetId, sbyte bannerIndex);
 
+    /// <summary>
+    /// Check if a specified gearset has a Banner linked to it.
+    /// </summary>
+    /// <param name="gearsetId">The ID of the gearset.</param>
+    /// <returns>Returns <c>true</c> if the gearset has a Banner linked to it, <c>false</c> otherwise.</returns>
+    /// <remarks>Equivalent to Flags.HasFlag(GearsetFlag.Exists) &amp;&amp; BannerIndex != 0.</remarks>
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 3F 48 8B 03")]
-    public partial bool IsGearsetLinkedWithBanner(byte gearsetIndex); // equivalent to Flags.HasFlag(GearsetFlag.Exists) && BannerIndex != 0
+    public partial bool HasLinkedBanner(byte gearsetId);
 
     [StructLayout(LayoutKind.Sequential, Size = 0xAF2C)]
     public struct Gearsets {

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
@@ -247,6 +247,20 @@ public unsafe partial struct RaptureGearsetModule {
         [FieldOffset(0x37)] public GearsetFlag Flags;
         [FixedSizeArray<GearsetItem>(14)]
         [FieldOffset(0x38)] public fixed byte Items[0x1C * 14];
+        [FieldOffset(0x38 + GearsetItem.Size * 00)] public GearsetItem MainHand;
+        [FieldOffset(0x38 + GearsetItem.Size * 01)] public GearsetItem OffHand;
+        [FieldOffset(0x38 + GearsetItem.Size * 02)] public GearsetItem Head;
+        [FieldOffset(0x38 + GearsetItem.Size * 03)] public GearsetItem Body;
+        [FieldOffset(0x38 + GearsetItem.Size * 04)] public GearsetItem Hands;
+        [FieldOffset(0x38 + GearsetItem.Size * 05)] public GearsetItem Belt;
+        [FieldOffset(0x38 + GearsetItem.Size * 06)] public GearsetItem Legs;
+        [FieldOffset(0x38 + GearsetItem.Size * 07)] public GearsetItem Feet;
+        [FieldOffset(0x38 + GearsetItem.Size * 08)] public GearsetItem Ears;
+        [FieldOffset(0x38 + GearsetItem.Size * 09)] public GearsetItem Neck;
+        [FieldOffset(0x38 + GearsetItem.Size * 10)] public GearsetItem Wrists;
+        [FieldOffset(0x38 + GearsetItem.Size * 11)] public GearsetItem RingRight;
+        [FieldOffset(0x38 + GearsetItem.Size * 12)] public GearsetItem RingLeft; // aka RightLeft
+        [FieldOffset(0x38 + GearsetItem.Size * 13)] public GearsetItem SoulStone;
 
         /// <returns>Returns a pointer to the BannerModuleEntry* or null if the gearset is not linked to a banner.</returns>
         public BannerModuleEntry* GetBanner() {

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
@@ -1,4 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
+using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc.UserFileManager;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
@@ -6,15 +7,14 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 // Client::UI::Misc::RaptureGearsetModule
 //   Client::UI::Misc::UserFileManager::UserFileEvent
 // ctor "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 83 EC 20 45 33 F6 48 89 51 10 48 8D 05 ?? ?? ?? ?? 4C 89 71 08 49 8B D8"
+[VTableAddress("48 8D 05 ?? ?? ?? ?? 48 89 5F 40 48 8D 77 48", 3)]
 [StructLayout(LayoutKind.Explicit, Size = 0xB670)]
 public unsafe partial struct RaptureGearsetModule {
     public static RaptureGearsetModule* Instance() => Framework.Instance()->GetUiModule()->GetRaptureGearsetModule();
 
     [FieldOffset(0)] public UserFileEvent UserFileEvent;
-    [FieldOffset(0x0000)] public void* vtbl;
-    [Obsolete("Use UserFileEvent.FileName instead", true)]
-    [FieldOffset(0x0030)] public fixed byte ModuleName[16];
-    [FieldOffset(0x0048)] public Gearsets Gearset;
+    [FixedSizeArray<GearsetEntry>(100)]
+    [FieldOffset(0x48)] public fixed byte Entries[0x1C0 * 100];
 
     [FieldOffset(0xB434)] public int CurrentGearsetIndex;
 
@@ -27,15 +27,26 @@ public unsafe partial struct RaptureGearsetModule {
     public partial GearsetEntry* GetGearset(int gearsetId);
 
     /// <summary>
+    /// Find a <see cref="GearsetEntry"/> by name and return its ID.<br/>
+    /// </summary>
+    /// <remarks>
+    /// The search is case-sensitive and returns the first gearset with a name beginning with the specified gearsetName.
+    /// </remarks>
+    /// <param name="gearsetName">The name of the gearset to look up.</param>
+    /// <returns>Returns the index/ID of a GearsetEntry</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 8B D8 81 FB")]
+    public partial int FindGearsetIDByName(Utf8String* gearsetName);
+
+    /// <summary>
     /// Check if a gearset at a specific index is valid.
     /// </summary>
     /// <remarks>
     /// Will return 0 if the gearset index is higher than the player's max allowed gearset number.
     /// </remarks>
     /// <param name="gearsetId">The index of the gearset to look up.</param>
-    /// <returns>Returns 1 if the gearset is valid, 0 otherwise.</returns>
+    /// <returns>Returns <c>true</c> if the gearset is valid, <c>false</c> otherwise.</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 4C 8D 0D ?? ?? ?? ?? 84 C0")]
-    public partial byte IsValidGearset(int gearsetId);
+    public partial bool IsValidGearset(int gearsetId);
 
     /// <summary>
     /// Attempt to equip a gearset, with certain safety checks in place.
@@ -50,9 +61,9 @@ public unsafe partial struct RaptureGearsetModule {
     /// <summary>
     /// Save the player's current inventory to a new gearset at the next possible ID.
     /// </summary>
-    /// <returns>Returns the ID of the created gearset, or 255 if the creation attempt fails.</returns>
+    /// <returns>Returns the ID of the created gearset, or -1 if the creation attempt fails.</returns>
     [MemberFunction("E8 ?? ?? ?? ?? EB 07 8B D5 E8 ?? ?? ?? ?? 8B E8")]
-    public partial uint CreateGearset();
+    public partial sbyte CreateGearset();
 
     /// <summary>
     /// Delete the gearset at the specified ID.
@@ -112,56 +123,115 @@ public unsafe partial struct RaptureGearsetModule {
 
     [Flags]
     public enum GearsetFlag : byte {
-        None = 0x00,
+        None = 0,
+
+        /// <summary>
+        /// Is set when this gearset entry has been created.
+        /// </summary>
         Exists = 0x01,
+
         Unknown02 = 0x02,
-        Unknown04 = 0x04,
+
+        /// <summary>
+        /// Shows a red exclamation mark with message "The specified main arm was missing from your Armoury Chest."
+        /// </summary>
+        MainHandMissing = 0x04,
+
+        /// <summary>
+        /// Is set when "Display Headgear" is ticked.
+        /// </summary>
         HeadgearVisible = 0x08,
+
+        /// <summary>
+        /// Is set when "Display Sheathed Arms" is ticked.
+        /// </summary>
         WeaponsVisible = 0x10,
+
+        /// <summary>
+        /// Is set when "Manually adjust visor (select gear only)." is ticked.
+        /// </summary>
         VisorEnabled = 0x20,
+
         Unknown40 = 0x40,
         Unknown80 = 0x80
+    }
+
+    [Flags]
+    public enum GearsetItemFlag : byte {
+        None = 0,
+
+        /// <summary>
+        /// Shows a yellow exclamation mark with message "One or more items were missing from your Armoury Chest."
+        /// </summary>
+        ItemMissing = 0x01,
+
+        Unknown02 = 0x02,
+
+        /// <summary>
+        /// Shows a gray exclamation mark with message "One or more items were not the specified color."
+        /// </summary>
+        ColorDiffers = 0x04,
+
+        /// <summary>
+        /// Shows a gray exclamation mark with message "One or more items were not melded with the specified materia."
+        /// </summary>
+        MateriaDiffers = 0x08,
+
+        /// <summary>
+        /// Shows a gray exclamation mark with message "One or more items did not have the specified appearance."
+        /// </summary>
+        AppearanceDiffers = 0x10,
+
+        Unknown20 = 0x20,
+        Unknown40 = 0x40,
+        Unknown80 = 0x80,
+    }
+
+    /// <summary>
+    /// A helper enum for easier access of GearsetItems in the ItemsSpan.
+    /// </summary>
+    public enum GearsetItemIndex {
+        MainHand = 0,
+        OffHand,
+        Head,
+        Body,
+        Hands,
+        Belt,
+        Legs,
+        Feet,
+        Ears,
+        Neck,
+        Wrists,
+        RingRight,
+        RingLeft, // aka RightLeft
+        SoulStone,
     }
 
     [StructLayout(LayoutKind.Explicit, Size = Size)]
     public struct GearsetItem {
         public const int Size = 0x1C;
 
-        [FieldOffset(0x0)] public uint ItemID;
-        [FieldOffset(0x4)] public uint GlamourId;
-        [FieldOffset(0x8)] public byte Stain;
+        [FieldOffset(0x00)] public uint ItemID;
+        [FieldOffset(0x04)] public uint GlamourId;
+        [FieldOffset(0x08)] public byte Stain;
 
-        [FieldOffset(0xA)] public fixed ushort Materia[5];
+        [FieldOffset(0x0A)] public fixed ushort Materia[5];
         [FieldOffset(0x14)] public fixed byte MateriaGrade[5];
+        [FieldOffset(0x19)] public GearsetItemFlag Flags;
     }
 
     [StructLayout(LayoutKind.Explicit, Size = 0x1C0)]
-    public struct GearsetEntry {
-        [FieldOffset(0x000)] public byte ID;    // This may actually be set number, which is not _quite_ ID.
-        [FieldOffset(0x001)] public fixed byte Name[0x2F];
+    public partial struct GearsetEntry {
+        [FieldOffset(0x00)] public byte ID;    // This may actually be set number, which is not _quite_ ID.
+        [FieldOffset(0x01)] public fixed byte Name[0x30];
         [FieldOffset(0x31)] public byte ClassJob;
         [FieldOffset(0x32)] public byte GlamourSetLink;
         [FieldOffset(0x34)] public short ItemLevel;
         /// <remarks>This is the BannerIndex, but offset by 1. If it's 0, the gearset is not linked to a banner.</remarks>
         [FieldOffset(0x36)] public byte BannerIndex;
         [FieldOffset(0x37)] public GearsetFlag Flags;
-
-        private const int ItemDataOffset = 0x38;
-        [FieldOffset(ItemDataOffset)] public fixed byte ItemsData[GearsetItem.Size * 14];
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 00)] public GearsetItem MainHand;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 01)] public GearsetItem OffHand;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 02)] public GearsetItem Head;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 03)] public GearsetItem Body;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 04)] public GearsetItem Hands;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 05)] public GearsetItem Belt;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 06)] public GearsetItem Legs;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 07)] public GearsetItem Feet;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 08)] public GearsetItem Ears;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 09)] public GearsetItem Neck;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 10)] public GearsetItem Wrists;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 11)] public GearsetItem RingRight;
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 12)] public GearsetItem RightLeft; // ?!
-        [FieldOffset(ItemDataOffset + GearsetItem.Size * 13)] public GearsetItem SoulStone;
+        [FixedSizeArray<GearsetItem>(14)]
+        [FieldOffset(0x38)] public fixed byte Items[0x1C * 14];
 
         /// <returns>Returns a pointer to the BannerModuleEntry* or null if the gearset is not linked to a banner.</returns>
         public BannerModuleEntry* GetBanner() {

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3827,9 +3827,9 @@ classes:
       0x140691020: RemoveGlamourPlateLink
       0x140691030: HasLinkedGlamourPlate
       0x140691220: GetClassJobIcon
-      0x1406916F0: GetBannerIndexByGearsetIndex
-      0x140691750: SetBannerIndexForGearsetIndex
-      0x140691810: IsGearsetLinkedWithBanner
+      0x1406916F0: GetBannerIndex
+      0x140691750: SetBannerIndex
+      0x140691810: HasLinkedBanner
       0x140691BE0: FindGearsetIDByName
   Client::UI::Misc::ItemFinderModule:
     vtbls:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3830,6 +3830,7 @@ classes:
       0x1406916F0: GetBannerIndexByGearsetIndex
       0x140691750: SetBannerIndexForGearsetIndex
       0x140691810: IsGearsetLinkedWithBanner
+      0x140691BE0: FindGearsetIDByName
   Client::UI::Misc::ItemFinderModule:
     vtbls:
       - ea: 0x1419AB3C8


### PR DESCRIPTION
**Additions:**
- Added `int FindGearsetIDByName(Utf8String* gearsetName)`.
- Added `GearsetItemFlag` enum which is used in the new `GearsetItem.Flags` field.
- `Unknown04` in `GearsetFlag` identified as `MainHandMissing`.
- Remarks to known `GearsetFlag` values.
- XML docs to `GetBannerIndex`, `SetBannerIndex` and `HasLinkedBanner` (also renamed them, see below).

**Replacements:**
- Replaced `Gearsets` class and `Gearset` field with a `FixedSizeArray<GearsetEntry>(100)` field called `Entries`.
- Replaced `ItemsData` field with a `FixedSizeArray<GearsetItem>(14)` field called `Items`.
  - I added a helper enum called `GearsetItemIndex` which can be used as an index for the ItemsSpan, for example:  
`var mainHand = gearsetEntry.ItemsSpan[(int)GearsetItemIndex.MainHand];`

**Return type changes:**
- `IsValidGearset` and `HasLinkedGlamourPlate` now return `bool`, because that is really all they can return.
- `CreateGearset` now returns a `sbyte`, where `-1` means it failed.
- `GetBannerIndex` now returns a `sbyte`, where `-1` means the gear set was not linked to a banner.

**Removals:**
- Removed `vtbl` in favour of `RaptureGearsetModule.StaticAddressPointers.VTable` (generated via `VTableAddressAttribute`).
- Removed `ModuleName`, which was obsolete already (=> `UserFileEvent.FileName`).

**Renames:**
These were really long and I got inspred by `LinkGlamourPlate` and `HasLinkedGlamourPlate` to shorten them:
- `GetBannerIndexByGearsetIndex` renamed to `GetBannerIndex`.
- `SetBannerIndexForGearsetIndex` renamed to `SetBannerIndex`.
- `IsGearsetLinkedWithBanner` renamed to `HasLinkedBanner`.

Of course, these changes are intended to be merged when patch 6.5 arrives.
I'm open to feedback, especially on changes to the return types (I don't mind changing them back if it's unwelcome, but this is how I think they're being used). 😉