### PR TITLE
Add AtkDragDropInterface & AtkDragDropManager

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentDragDrop.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentDragDrop.cs
@@ -9,6 +9,7 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 [StructLayout(LayoutKind.Explicit, Size = 0x110)]
 public unsafe partial struct AtkComponentDragDrop {
     [FieldOffset(0x0)] public AtkComponentBase AtkComponentBase;
+    [FieldOffset(0xC0)] public AtkDragDropInterface AtkDragDropInterface;
     [FieldOffset(0xF8)] public AtkComponentIcon* AtkComponentIcon;
 
     [MemberFunction("E8 ?? ?? ?? ?? 83 F8 FF 74 40")]

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentListItemRenderer.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentListItemRenderer.cs
@@ -10,5 +10,6 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 [StructLayout(LayoutKind.Explicit, Size = 0x1A8)]
 public struct AtkComponentListItemRenderer {
     [FieldOffset(0x0)] public AtkComponentButton AtkComponentButton;
+    [FieldOffset(0xF0)] public AtkDragDropInterface AtkDragDropInterface;
     [FieldOffset(0x184)] public int ListItemIndex;
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkDragDropInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkDragDropInterface.cs
@@ -1,8 +1,7 @@
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x30)]
-public unsafe partial struct AtkDragDropInterface
-{
+public unsafe partial struct AtkDragDropInterface {
     [FieldOffset(0x00)] public void* vtbl;
     [FieldOffset(0x08)] public AtkComponentNode* ComponentNode;
     [FieldOffset(0x10)] public AtkResNode* ActiveNode;

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkDragDropInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkDragDropInterface.cs
@@ -1,0 +1,28 @@
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
+
+[StructLayout(LayoutKind.Explicit, Size = 0x30)]
+public unsafe partial struct AtkDragDropInterface
+{
+    [FieldOffset(0x00)] public void* vtbl;
+    [FieldOffset(0x08)] public AtkComponentNode* ComponentNode;
+    [FieldOffset(0x10)] public AtkResNode* ActiveNode;
+    // [FieldOffset(0x18)] public void* UnkBuffer; // Points to a buffer of 12 bytes? (freed on dtor)
+    // [FieldOffset(0x20)] public uint Unk2;
+    // [FieldOffset(0x24)] public uint Unk3;
+    // [FieldOffset(0x28)] public nint Unk4;
+
+    [VirtualFunction(1)]
+    public partial void GetScreenPosition(float* screenX, float* screenY);
+
+    [VirtualFunction(3)]
+    public partial AtkComponentNode* GetComponentNode();
+
+    [VirtualFunction(4)]
+    public partial void SetComponentNode(AtkComponentNode* node);
+
+    [VirtualFunction(5)]
+    public partial AtkResNode* GetActiveNode();
+
+    [VirtualFunction(7)]
+    public partial AtkComponentBase* GetComponent();
+}

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkDragDropManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkDragDropManager.cs
@@ -7,24 +7,29 @@ public unsafe struct AtkDragDropManager {
     //[FieldOffset(0x08)] public uint UnkNum_1; //some sort of identifier?
     //[FieldOffset(0x0C)] public int UnkNum_2; //ActionId, ItemId, InventorySlotIndex, ListIndex  etc.
 
-    //[FieldOffset(0x20)] public Utf8String UnkString;
-
     [FieldOffset(0x90)] public AtkStage* AtkStage;
 
     //the first 2 seem to point to some subclass of DragDrop, maybe some temp thing
-    //[FieldOffset(0x98)] public AtkComponentDragDrop* UnkDragDrop_1;
-    //[FieldOffset(0xA0)] public AtkComponentDragDrop* UnkDragDrop_2;
-    //[FieldOffset(0xA8)] public AtkComponentDragDrop* UnkDragDrop_3;
+    [FieldOffset(0x98)] public AtkDragDropInterface* DragDrop1;
+    
+	// vvv Not set in some cases where DragDropS isn't used (like with hotbars)
+    [FieldOffset(0xA0)] public AtkDragDropInterface* DragDrop2;
+    [FieldOffset(0xA8)] public AtkComponentDragDrop* DragDropS;
+	// ^^^
 
     //returns some sort of (event?)mask from some static array
-    //[FieldOffset(0xB0)] public delegate*unmanaged<int, ulong> UnkFunc;
+    //public const int MaskSize = 0x57;
+    //[FieldOffset(0xB0)] public delegate*unmanaged<int, ulong> GetMask;
 
     [FieldOffset(0xB8)] public short DragStartX;
-    [FieldOffset(0xBA)] public short DragStartY;
+	[FieldOffset(0xBA)] public short DragStartY;
 
-    //[FieldOffset(0xBB)] public byte UnkBool_1;
-    //[FieldOffset(0xBC)] public byte UnkBool_2;
-    //[FieldOffset(0xBD)] public byte UnkBool_3;
-    //[FieldOffset(0xBE)] public byte UnkBool_4;
-    //[FieldOffset(0xBF)] public byte UnkBool_5;
+    [FieldOffset(0xBC)] public bool IsDragging;
+    // True if the item was clicked on (user must click again to drop it somewhere)
+    [FieldOffset(0xBD)] public bool ReclickToDrop;
+    // Set to true once the mouse moves during a drag
+    [FieldOffset(0xBE)] public bool MouseMoved;
+    // False if dropping on anything not ui (like the world)
+    // Can't be false if ReclickToDrop is false
+    [FieldOffset(0xBF)] public bool IsNotDiscarding;
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkDragDropManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkDragDropManager.cs
@@ -11,18 +11,18 @@ public unsafe struct AtkDragDropManager {
 
     //the first 2 seem to point to some subclass of DragDrop, maybe some temp thing
     [FieldOffset(0x98)] public AtkDragDropInterface* DragDrop1;
-    
-	// vvv Not set in some cases where DragDropS isn't used (like with hotbars)
+
+    // vvv Not set in some cases where DragDropS isn't used (like with hotbars)
     [FieldOffset(0xA0)] public AtkDragDropInterface* DragDrop2;
     [FieldOffset(0xA8)] public AtkComponentDragDrop* DragDropS;
-	// ^^^
+    // ^^^
 
     //returns some sort of (event?)mask from some static array
     //public const int MaskSize = 0x57;
     //[FieldOffset(0xB0)] public delegate*unmanaged<int, ulong> GetMask;
 
     [FieldOffset(0xB8)] public short DragStartX;
-	[FieldOffset(0xBA)] public short DragStartY;
+    [FieldOffset(0xBA)] public short DragStartY;
 
     [FieldOffset(0xBC)] public bool IsDragging;
     // True if the item was clicked on (user must click again to drop it somewhere)


### PR DESCRIPTION
AtkDragDropInterface is a previously missed base class that's implemented by AtkComponentDragDrop and AtkComponentListRenderer. This PR was made because AtkDragDropManager holds pointers to these interfaces, and that struct has been updated with new fields, too.