### PR TITLE
Update ItemOrderModule and Sorters

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/ItemOrderModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/ItemOrderModule.cs
@@ -29,13 +29,12 @@ public unsafe partial struct ItemOrderModule {
     [FieldOffset(0xA0)] public ItemOrderModuleSorter* ArmourySoulCrystalSorter;
     [FieldOffset(0xA8)] public ItemOrderModuleSorter* ArmouryWaistSorter; // no longer used
     [FieldOffset(0xB0)] public ulong ActiveRetainerId;
-    [FieldOffset(0xB8)] public StdVector<ItemOrderModuleSorterRetainerEntry>* RetainerSorter;
-    [FieldOffset(0xC0)] public long RetainerSorterCount;
+    [FieldOffset(0xB8)] public StdMap<ulong, Pointer<ItemOrderModuleSorter>> RetainerSorter;
     [FieldOffset(0xC8)] public ItemOrderModuleSorter* SaddleBagSorter;
     [FieldOffset(0xD0)] public ItemOrderModuleSorter* PremiumSaddleBagSorter;
 }
 
-[StructLayout(LayoutKind.Explicit, Size = 0x60)]
+[StructLayout(LayoutKind.Explicit, Size = 0x68)]
 public unsafe struct ItemOrderModuleSorter {
     [FieldOffset(0x00)] public InventoryType InventoryType;
 
@@ -47,15 +46,12 @@ public unsafe struct ItemOrderModuleSorter {
     [FieldOffset(0x3C)] public int PercentComplete; // set to 100 if done
     [FieldOffset(0x40)] public StdVector<ItemOrderModuleSorterSortFunctionEntry> SortFunctions;
     [FieldOffset(0x58)] public ItemOrderModuleSorterPreviousOrderEntry* PreviousOrderArray;
+    // [FieldOffset(0x60)] public bool UnkBool; Set to true, only when it's the InventorySorter?
 
-    public long ItemCount => ((nint)Items.Last - (nint)Items.First) >> 3;
-    public long SortFunctionCount => ((nint)SortFunctions.Last - (nint)SortFunctions.First) >> 4;
-}
-
-[StructLayout(LayoutKind.Explicit, Size = 0x40)]
-public unsafe struct ItemOrderModuleSorterRetainerEntry {
-    [FieldOffset(0x20)] public ulong RetainerId;
-    [FieldOffset(0x28)] public ItemOrderModuleSorter* Sorter;
+    [Obsolete("Use Items.Size()", false)]
+    public long ItemCount => (long)Items.Size();
+    [Obsolete("Use SortFunctions.Size()", false)]
+    public long SortFunctionCount => (long)SortFunctions.Size();
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0xC)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/ItemOrderModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/ItemOrderModule.cs
@@ -48,9 +48,9 @@ public unsafe struct ItemOrderModuleSorter {
     [FieldOffset(0x58)] public ItemOrderModuleSorterPreviousOrderEntry* PreviousOrderArray;
     // [FieldOffset(0x60)] public bool UnkBool; Set to true, only when it's the InventorySorter?
 
-    [Obsolete("Use Items.Size()", false)]
+    [Obsolete("Use Items.Size()", true)]
     public long ItemCount => (long)Items.Size();
-    [Obsolete("Use SortFunctions.Size()", false)]
+    [Obsolete("Use SortFunctions.Size()", true)]
     public long SortFunctionCount => (long)SortFunctions.Size();
 }
 

--- a/FFXIVClientStructs/STD/Pair.cs
+++ b/FFXIVClientStructs/STD/Pair.cs
@@ -6,4 +6,9 @@ public struct StdPair<T1, T2>
     where T2 : unmanaged {
     public T1 Item1;
     public T2 Item2;
+
+    public readonly void Deconstruct(out T1 item1, out T2 item2) {
+        item1 = Item1;
+        item2 = Item2;
+    }
 }


### PR DESCRIPTION
- Updated ItemOrderModule.RetainerSorter to the correct type. Breaking change, but the code was inherently broken, anyway.
- ItemOrderModuleSorter had an incorrect size (and an undocumented bool).
- Deprecates ItemCount and SortFunctionCount because they already had easy accessors.
- Snuck in a Deconstruct method for StdPair so they can be used like C# tuples.