### PR TITLE
Update RetainerCommentModule

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RetainerCommentModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RetainerCommentModule.cs
@@ -1,5 +1,3 @@
-using System.Text;
-using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc.UserFileManager;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
@@ -9,46 +7,23 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 // ctor "E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 48 8B D7"
 [StructLayout(LayoutKind.Explicit, Size = 0x5A0)]
 public unsafe partial struct RetainerCommentModule {
-    public static RetainerCommentModule* Instance() => Framework.Instance()->GetUiModule()->GetRetainerCommentModule();
+    public static RetainerCommentModule* Instance() => UIModule.Instance()->GetRetainerCommentModule();
 
     [FieldOffset(0)] public UserFileEvent UserFileEvent;
-    [FieldOffset(0x40)] public RetainerCommentList Retainers;
+
+    [FixedSizeArray<RetainerComment>(10)]
+    [FieldOffset(0x48)] public fixed byte Retainers[0x88 * 10];
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B BC 24 ?? ?? ?? ?? 48 8B B4 24 ?? ?? ?? ?? 49 8B 4E 10")]
     [GenerateCStrOverloads]
-    public partial void* SetComment(ulong retainerID, byte* comment);
+    public partial void SetComment(ulong retainerId, byte* comment);
 
     [MemberFunction("32 C0 0F 1F 40 00 66 66 0F 1F 84 ?? 00 00 00 00 44 0F B6 C0 4C 8D 51")]
     public partial byte* GetComment(ulong retainerId);
 
-    [StructLayout(LayoutKind.Sequential, Size = 0x410)]
-    public struct RetainerCommentList {
-        private fixed byte data[0x68 * 10];
-
-        public RetainerComment* this[int i] {
-            get {
-                if (i is < 0 or > 9) return null;
-                fixed (byte* p = data) {
-                    return (RetainerComment*)(p + sizeof(RetainerComment) * i);
-                }
-            }
-        }
-    }
-
-    [StructLayout(LayoutKind.Sequential, Size = 0x68)]
+    [StructLayout(LayoutKind.Explicit, Size = 0x88)]
     public struct RetainerComment {
-        public ulong ID;
-        public string Comment {
-            get {
-                var comment = Instance()->GetComment(ID);
-                if (comment == null || comment[0] == 0) return string.Empty;
-                int i;
-                for (i = 0; i < 0x5B; i++) if (comment[i] == 0) break;
-                return Encoding.UTF8.GetString(comment, i).TrimEnd('\0');
-
-            }
-            set => Instance()->SetComment(ID, value);
-        }
-
+        [FieldOffset(0)] public ulong Id;
+        [FieldOffset(0x8)] public fixed byte Comment[0x5B];
     }
 }


### PR DESCRIPTION
- Fixed offset of `Retainers` and fixed `RetainerComment` size.
- Replaced `RetainerCommentList` with `FixedSizeArray<RetainerComment>(10)`.
- Replaced the `Comment` property with a fixed byte array.
- Made `RetainerComment` struct layout explicit.
- Changed return type of `SetComment` from `void*` to `void`.