### PR TITLE
FixedSizeArray cleanup

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
@@ -3,12 +3,8 @@ using FFXIVClientStructs.FFXIV.Application.Network.WorkDefinitions;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game;
 
-// idk if this is a manager, but I don't know what else to call it
 [StructLayout(LayoutKind.Explicit, Size = 0xF40)]
 public unsafe partial struct QuestManager {
-    [Obsolete("Use NormalQuestsSpan", true)]
-    [FieldOffset(0x10)] public QuestListArray Quest;
-
     [FixedSizeArray<QuestWork>(30)]
     [FieldOffset(0x10)] public fixed byte NormalQuests[0x18 * 30];
     [FixedSizeArray<DailyQuestWork>(12)]
@@ -41,7 +37,7 @@ public unsafe partial struct QuestManager {
     public static partial byte GetQuestSequence(ushort questId);
 
     /**
-     * <inheritdoc cref="QuestManager.GetQuestSequence(ushort)"/>
+     * <inheritdoc cref="GetQuestSequence(ushort)"/>
      * <remarks>This is a helper method to handle trimming uints down to the game-requested ushort.</remarks>
      */
     public static byte GetQuestSequence(uint questId) => GetQuestSequence((ushort)(questId & 0xFFFF));
@@ -56,10 +52,10 @@ public unsafe partial struct QuestManager {
     public partial bool IsQuestAccepted(ushort questId);
 
     /**
-     * <inheritdoc cref="QuestManager.IsQuestAccepted(ushort)"/>
+     * <inheritdoc cref="IsQuestAccepted(ushort)"/>
      * <remarks>This is a helper method to handle trimming uints down to the game-requested ushort.</remarks>
      */
-    public bool IsQuestAccepted(uint questId) => this.IsQuestAccepted((ushort)(questId & 0xFFFF));
+    public bool IsQuestAccepted(uint questId) => IsQuestAccepted((ushort)(questId & 0xFFFF));
 
     /// <summary>
     /// Check if a specific levequest has been completed.
@@ -131,35 +127,5 @@ public unsafe partial struct QuestManager {
         var span = BeastReputationSpan;
         if (index >= span.Length) return null;
         return (BeastReputationWork*)Unsafe.AsPointer(ref span[(int)index]);
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    public struct QuestListArray {
-        [FieldOffset(0x00)] private fixed byte data[0x18 * 30];
-
-        public Quest* this[int index] {
-            get {
-                if (index < 0 || index > 30) return null;
-
-                fixed (byte* pointer = data) {
-                    return (Quest*)(pointer + sizeof(Quest) * index);
-                }
-            }
-        }
-
-        [StructLayout(LayoutKind.Explicit, Size = 0x18)]
-        public struct Quest {
-            [FieldOffset(0x08)] public ushort QuestID;
-            [FieldOffset(0x0B)] public QuestFlags Flags; // 1 for Priority, 8 for Hidden
-
-            public bool IsHidden => Flags.HasFlag(QuestFlags.Hidden);
-
-            [Flags]
-            public enum QuestFlags : byte {
-                None,
-                Priority,
-                Hidden = 0x8
-            }
-        }
     }
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/RetainerManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/RetainerManager.cs
@@ -5,14 +5,10 @@ public unsafe partial struct RetainerManager {
     [StaticAddress("48 8D 0D ?? ?? ?? ?? 48 8B 18", 3)]
     public static partial RetainerManager* Instance();
 
-    [Obsolete("Use Retainers", true)]
-    [FieldOffset(0x000)] public RetainerList Retainer;
-    [FixedSizeArray<RetainerList.Retainer>(10)]
+    [FixedSizeArray<Retainer>(10)]
     [FieldOffset(0x000)] public fixed byte Retainers[0x48 * 10];
     [FieldOffset(0x2D0)] public fixed byte DisplayOrder[10];
     [FieldOffset(0x2DA)] public byte Ready;
-    [Obsolete("Use GetRetainerCount() instead.", true)]
-    [FieldOffset(0x2DB)] public byte RetainerCount;
     [FieldOffset(0x2DB)] public byte MaxRetainerEntitlement;
 
     /// <summary>
@@ -22,7 +18,7 @@ public unsafe partial struct RetainerManager {
     [FieldOffset(0x2E8)] public uint RetainerObjectId;
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 85 C0 74 05 4C 39 20")]
-    public partial RetainerList.Retainer* GetRetainerBySortedIndex(uint sortedIndex);
+    public partial Retainer* GetRetainerBySortedIndex(uint sortedIndex);
 
 
     /// <summary>
@@ -35,56 +31,31 @@ public unsafe partial struct RetainerManager {
     /// Will return the Retainer referenced by LastSelectedRetainerId.
     /// </summary>
     [MemberFunction("E8 ?? ?? ?? ?? 0F B6 78 29")]
-    public partial RetainerList.Retainer* GetActiveRetainer();
+    public partial Retainer* GetActiveRetainer();
 
-    [StructLayout(LayoutKind.Explicit, Size = 0x2D0)]
-    public struct RetainerList {
-        [FieldOffset(0x00)] private fixed byte Retainers[0x2D0];
-        [FieldOffset(0x48 * 0)] public Retainer Retainer0;
-        [FieldOffset(0x48 * 1)] public Retainer Retainer1;
-        [FieldOffset(0x48 * 2)] public Retainer Retainer2;
-        [FieldOffset(0x48 * 3)] public Retainer Retainer3;
-        [FieldOffset(0x48 * 4)] public Retainer Retainer4;
-        [FieldOffset(0x48 * 5)] public Retainer Retainer5;
-        [FieldOffset(0x48 * 6)] public Retainer Retainer6;
-        [FieldOffset(0x48 * 7)] public Retainer Retainer7;
-        [FieldOffset(0x48 * 8)] public Retainer Retainer8;
-        [FieldOffset(0x48 * 9)] public Retainer Retainer9;
+    [StructLayout(LayoutKind.Explicit, Size = 0x48)]
+    public struct Retainer {
+        [FieldOffset(0x00)] public ulong RetainerID;
+        [FieldOffset(0x08)] public fixed byte Name[0x20];
+        [FieldOffset(0x28)] public bool Available;
+        [FieldOffset(0x29)] public byte ClassJob;
+        [FieldOffset(0x2A)] public byte Level;
+        [FieldOffset(0x2B)] public byte ItemCount;
+        [FieldOffset(0x2C)] public uint Gil;
+        [FieldOffset(0x30)] public RetainerTown Town;
+        [FieldOffset(0x31)] public byte MarkerItemCount;
+        [FieldOffset(0x34)] public uint MarketExpire; // 7 Days after last opened retainer
+        [FieldOffset(0x38)] public uint VentureID;
+        [FieldOffset(0x3C)] public uint VentureComplete;
+    }
 
-        public Retainer* this[int index] {
-            get {
-                if (index is < 0 or >= 10) return null;
-                fixed (byte* p = Retainers) {
-                    var r = (Retainer*)p;
-                    return r + index;
-                }
-            }
-        }
-
-        [StructLayout(LayoutKind.Explicit, Size = 0x48)]
-        public struct Retainer {
-            [FieldOffset(0x00)] public ulong RetainerID;
-            [FieldOffset(0x08)] public fixed byte Name[0x20];
-            [FieldOffset(0x28)] public bool Available;
-            [FieldOffset(0x29)] public byte ClassJob;
-            [FieldOffset(0x2A)] public byte Level;
-            [FieldOffset(0x2B)] public byte ItemCount;
-            [FieldOffset(0x2C)] public uint Gil;
-            [FieldOffset(0x30)] public RetainerTown Town;
-            [FieldOffset(0x31)] public byte MarkerItemCount;
-            [FieldOffset(0x34)] public uint MarketExpire; // 7 Days after last opened retainer
-            [FieldOffset(0x38)] public uint VentureID;
-            [FieldOffset(0x3C)] public uint VentureComplete;
-        }
-
-        public enum RetainerTown : byte {
-            LimsaLominsa = 1,
-            Gridania = 2,
-            Uldah = 3,
-            Ishgard = 4,
-            Kugane = 7,
-            Crystarium = 10,
-            OldSharlayan = 12
-        }
+    public enum RetainerTown : byte {
+        LimsaLominsa = 1,
+        Gridania = 2,
+        Uldah = 3,
+        Ishgard = 4,
+        Kugane = 7,
+        Crystarium = 10,
+        OldSharlayan = 12
     }
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
@@ -7,9 +6,6 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 public unsafe partial struct Map {
     [StaticAddress("48 8D 0D ?? ?? ?? ?? 41 8B D4 66 89 44 24", 3)]
     public static partial Map* Instance();
-
-    [Obsolete("Use QuestDataSpan instead", true)]
-    [FieldOffset(0x90)] public QuestMarkerArray QuestMarkers;
 
     [FixedSizeArray<MarkerInfo>(30)]
     [FieldOffset(0x90)] public fixed byte QuestData[0x90 * 30];
@@ -27,31 +23,6 @@ public unsafe partial struct Map {
     [FieldOffset(0x3EA8)] public SimpleMapMarkerContainer SimpleCustomTalkMarkerData;
     [FieldOffset(0x3F48)] public MapMarkerContainer GemstoneTraderMarkerData;
     [FieldOffset(0x3F50)] public SimpleMapMarkerContainer SimpleGemstoneTraderMarkerData;
-
-    [Obsolete("Use QuestDataSpan instead", true)]
-    [StructLayout(LayoutKind.Sequential, Size = 0x10E0)]
-    public struct QuestMarkerArray {
-        private fixed byte data[30 * 0x90];
-
-        public MapMarkerInfo* this[int index] {
-            get {
-                if (index is < 0 or > 30) return null;
-
-                fixed (byte* pointer = data) {
-                    return (MapMarkerInfo*)(pointer + sizeof(MapMarkerInfo) * index);
-                }
-            }
-        }
-    }
-
-    [Obsolete("Use MarkerInfo structure instead", true)]
-    [StructLayout(LayoutKind.Explicit, Size = 0x90)]
-    public struct MapMarkerInfo {
-        [FieldOffset(0x04)] public uint QuestID;
-        [FieldOffset(0x08)] public Utf8String Name;
-        [FieldOffset(0x8B)] public byte ShouldRender;
-        [FieldOffset(0x88)] public ushort RecommendedLevel;
-    }
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x10)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRetainerList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRetainerList.cs
@@ -3,15 +3,14 @@ using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
 // Client::UI::Agent::AgentRetainerList
 //   Client::UI::Agent::AgentInterface
 //     Component::GUI::AtkModuleInterface::AtkEventInterface
-
-// size 0x550
-// ctor 48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F1 E8 ?? ?? ?? ?? 33 C9
+// ctor "48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B F1 E8 ?? ?? ?? ?? 33 C9 48 8D 05 ?? ?? ?? ?? 48 89 06"
 [Agent(AgentId.RetainerList)]
 [StructLayout(LayoutKind.Explicit, Size = 0x5B8)]
-public unsafe struct AgentRetainerList {
+public unsafe partial struct AgentRetainerList {
     public static AgentRetainerList* Instance() {
         return (AgentRetainerList*)Framework.Instance()->GetUiModule()->GetAgentModule()->GetAgentByInternalId(
             AgentId.RetainerList);
@@ -21,32 +20,8 @@ public unsafe struct AgentRetainerList {
     [FieldOffset(0x30)] public uint RetainerListOpenedTime;
     [FieldOffset(0x34)] public uint RetainerListSortAddonId;
     [FieldOffset(0x48)] public byte RetainerCount;
-    [FieldOffset(0x50)] public RetainerList Retainers;
-
-    [StructLayout(LayoutKind.Explicit, Size = 0x460)]
-    public struct RetainerList {
-        [FieldOffset(0x00)] private fixed byte Retainers[0x460];
-        [FieldOffset(0x70 * 0)] public Retainer Retainer0;
-        [FieldOffset(0x70 * 1)] public Retainer Retainer1;
-        [FieldOffset(0x70 * 2)] public Retainer Retainer2;
-        [FieldOffset(0x70 * 3)] public Retainer Retainer3;
-        [FieldOffset(0x70 * 4)] public Retainer Retainer4;
-        [FieldOffset(0x70 * 5)] public Retainer Retainer5;
-        [FieldOffset(0x70 * 6)] public Retainer Retainer6;
-        [FieldOffset(0x70 * 7)] public Retainer Retainer7;
-        [FieldOffset(0x70 * 8)] public Retainer Retainer8;
-        [FieldOffset(0x70 * 9)] public Retainer Retainer9;
-
-        public Retainer* this[int index] {
-            get {
-                if (index is < 0 or >= 10) return null;
-                fixed (byte* p = Retainers) {
-                    var r = (Retainer*)p;
-                    return r + index;
-                }
-            }
-        }
-    }
+    [FixedSizeArray<Retainer>(10)]
+    [FieldOffset(0x50)] public fixed byte Retainers[0x70 * 10];
 
     [StructLayout(LayoutKind.Explicit, Size = 0x70)]
     public struct Retainer {

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RetainerCommentModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RetainerCommentModule.cs
@@ -1,5 +1,3 @@
-using System.Text;
-using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc.UserFileManager;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
@@ -9,46 +7,23 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 // ctor "E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 48 8B D7"
 [StructLayout(LayoutKind.Explicit, Size = 0x5A0)]
 public unsafe partial struct RetainerCommentModule {
-    public static RetainerCommentModule* Instance() => Framework.Instance()->GetUiModule()->GetRetainerCommentModule();
+    public static RetainerCommentModule* Instance() => UIModule.Instance()->GetRetainerCommentModule();
 
     [FieldOffset(0)] public UserFileEvent UserFileEvent;
-    [FieldOffset(0x40)] public RetainerCommentList Retainers;
+
+    [FixedSizeArray<RetainerComment>(10)]
+    [FieldOffset(0x48)] public fixed byte Retainers[0x88 * 10];
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B BC 24 ?? ?? ?? ?? 48 8B B4 24 ?? ?? ?? ?? 49 8B 4E 10")]
     [GenerateCStrOverloads]
-    public partial void* SetComment(ulong retainerID, byte* comment);
+    public partial void SetComment(ulong retainerId, byte* comment);
 
     [MemberFunction("32 C0 0F 1F 40 00 66 66 0F 1F 84 ?? 00 00 00 00 44 0F B6 C0 4C 8D 51")]
     public partial byte* GetComment(ulong retainerId);
 
-    [StructLayout(LayoutKind.Sequential, Size = 0x410)]
-    public struct RetainerCommentList {
-        private fixed byte data[0x68 * 10];
-
-        public RetainerComment* this[int i] {
-            get {
-                if (i is < 0 or > 9) return null;
-                fixed (byte* p = data) {
-                    return (RetainerComment*)(p + sizeof(RetainerComment) * i);
-                }
-            }
-        }
-    }
-
-    [StructLayout(LayoutKind.Sequential, Size = 0x68)]
+    [StructLayout(LayoutKind.Explicit, Size = 0x88)]
     public struct RetainerComment {
-        public ulong ID;
-        public string Comment {
-            get {
-                var comment = Instance()->GetComment(ID);
-                if (comment == null || comment[0] == 0) return string.Empty;
-                int i;
-                for (i = 0; i < 0x5B; i++) if (comment[i] == 0) break;
-                return Encoding.UTF8.GetString(comment, i).TrimEnd('\0');
-
-            }
-            set => Instance()->SetComment(ID, value);
-        }
-
+        [FieldOffset(0)] public ulong Id;
+        [FieldOffset(0x8)] public fixed byte Comment[0x5B];
     }
 }


### PR DESCRIPTION
This PR removes structs that are no longer necessary because of FixedSizeArrays, and some obsolete fields that may have been part of the cleanup in #556.

Not included are:

- `RaptureHotbarModule`, because Kaz left a comment waiting for "better fixed arrays".
- `RaptureGearsetModule` (handled by #562).
- `RaptureMacroModule` (handled by #504).

Also fixed `RetainerCommentModule` and removed the Comment property in favour of a cleaner fixed byte array (since the offset and size was wrong, I assume nobody used it anyway).