### PR TITLE
Rename VTable to vtbl

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Data/CharacterData.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Data/CharacterData.cs
@@ -10,7 +10,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Character.Data;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x48)]
 public unsafe struct CharacterData {
-    [FieldOffset(0x0)] public void* VTable;
+    [FieldOffset(0x0)] public void* vtbl;
     [FieldOffset(0x8)] public float ModelScale;
     [FieldOffset(0xC)] public int ModelCharaId;
     [FieldOffset(0x10)] public int ModelSkeletonId;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Achievement.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Achievement.cs
@@ -5,7 +5,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 /// </summary>
 [StructLayout(LayoutKind.Explicit, Size = 0x550)]
 public unsafe partial struct Achievement {
-    [FieldOffset(0x00)] public void** VTable;
+    [FieldOffset(0x00)] public void** vtbl;
     [FieldOffset(0x08)] public AchievementState State;
     [FieldOffset(0x0C)] public fixed byte CompletedAchievements[428];
 

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/CharacterUtility.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/CharacterUtility.cs
@@ -10,7 +10,7 @@ public unsafe partial struct CharacterUtility {
     public const int ResourceHandleCount = 87;
 
     [FieldOffset(0x0)]
-    public void* VTable;
+    public void* vtbl;
 
     [FieldOffset(0x8)]
     [FixedSizeArray<Pointer<ResourceHandle>>(ResourceHandleCount)]

--- a/FFXIVClientStructs/FFXIV/Client/System/Scheduler/Base/SchedulerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Scheduler/Base/SchedulerState.cs
@@ -6,5 +6,5 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Scheduler.Base;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x18)]
 public unsafe partial struct SchedulerState {
-    [FieldOffset(0)] public void** VTable;
+    [FieldOffset(0)] public void** vtbl;
 }

--- a/FFXIVClientStructs/FFXIV/Client/System/Scheduler/Resource/SchedulerResource.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Scheduler/Resource/SchedulerResource.cs
@@ -4,7 +4,7 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Scheduler.Resource;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x88)]
 public unsafe partial struct SchedulerResource {
-    [FieldOffset(0x00)] public void** VTable;
+    [FieldOffset(0x00)] public void** vtbl;
     [FieldOffset(0x08)] public SchedulerResource* Next;
     [FieldOffset(0x10)] public SchedulerResource* Previous;
     [FieldOffset(0x20)] public ResourceHandle* Resource;
@@ -14,7 +14,7 @@ public unsafe partial struct SchedulerResource {
 
     [StructLayout(LayoutKind.Explicit, Size = 0x40)]
     public partial struct ResourceName {
-        [FieldOffset(0x00)] public void** VTable;
+        [FieldOffset(0x00)] public void** vtbl;
         [FieldOffset(0x08)] public byte* DataPointer;
         [FieldOffset(0x10)] public ushort Unk1;
         [FieldOffset(0x12)] public fixed byte Buffer[0x2E];

--- a/FFXIVClientStructs/FFXIV/Client/System/Scheduler/Resource/SchedulerResourceManagement.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Scheduler/Resource/SchedulerResourceManagement.cs
@@ -2,7 +2,7 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Scheduler.Resource;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x58)]
 public unsafe partial struct SchedulerResourceManagement {
-    [FieldOffset(0x00)] public void** VTable;
+    [FieldOffset(0x00)] public void** vtbl;
     [FieldOffset(0x08)] public SchedulerResource* Begin;
     [FieldOffset(0x10)] public void* Unknown;
     [FieldOffset(0x18)] public ulong NumResources;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerInterface.cs
@@ -21,7 +21,7 @@ public unsafe partial struct AgentBannerInterface {
         // dtor: E8 ?? ?? ?? ?? 48 83 EF ?? 75 ?? BA ?? ?? ?? ?? 48 8B CE E8 ?? ?? ?? ?? 48 89 7D
         [StructLayout(LayoutKind.Explicit, Size = CharacterDataSize)]
         public struct CharacterData {
-            [FieldOffset(0x000)] public void** VTable;
+            [FieldOffset(0x000)] public void** vtbl;
 
             [FieldOffset(0x018)] public Utf8String Name1;
             [FieldOffset(0x080)] public Utf8String Name2;


### PR DESCRIPTION
This PR changes all `VTable` fields to be named `vtbl` instead.

`VTable` should be handled as a reserved name, because `VTable` is added by the [VirtualFunctionGenerator](https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs.InteropSourceGenerators/VirtualFunctionGenerator.cs#L109).

If we do this now, with all the other breaking changes, we can add VirtualFunctions any time without breaking existing VTable fields, since they are called vtbl then. 😜