### PR TITLE
Update action names to match game internals

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/ActionManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/ActionManager.cs
@@ -207,7 +207,7 @@ public struct ComboDetail {
 
 public enum ActionType : byte {
     None = 0x00,
-    Skill = 0x01, // Spell, Weaponskill, Ability
+    Action = 0x01, // Spell, Weaponskill, Ability. Confusing name, I know.
     Item = 0x02,
     KeyItem = 0x03,
     Ability = 0x04, // Not in UseAction (??)
@@ -216,9 +216,9 @@ public enum ActionType : byte {
     MainCommand = 0x07,
     Companion = 0x08,
     CraftAction = 0x09,
-    Unk_10 = 0x0A, // item?
+    Unk_10 = 0x0A, // Fishing per Sapphire? Something to do with items.
     PetAction = 0x0B,
-    Unk_12 = 0x0C, // Not in UseAction (?)
+    Unk_12 = 0x0C, // Not in UseAction. Sapphire says CompanyAction, but not actually triggered.
     Mount = 0x0D,
     PvPAction = 0x0E,
     FieldMarker = 0x0F,

--- a/FFXIVClientStructs/FFXIV/Client/Game/ActionManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/ActionManager.cs
@@ -207,24 +207,24 @@ public struct ComboDetail {
 
 public enum ActionType : byte {
     None = 0x00,
-    Spell = 0x01,
+    Skill = 0x01, // Spell, Weaponskill, Ability
     Item = 0x02,
     KeyItem = 0x03,
-    Ability = 0x04,
-    General = 0x05,
-    Companion = 0x06,
-    Unk_7 = 0x07,
-    Unk_8 = 0x08, //something with Leve?
+    Ability = 0x04, // Not in UseAction (??)
+    GeneralAction = 0x05,
+    BuddyAction = 0x06,
+    MainCommand = 0x07,
+    Companion = 0x08,
     CraftAction = 0x09,
-    MainCommand = 0x0A,
+    Unk_10 = 0x0A, // item?
     PetAction = 0x0B,
-    Unk_12 = 0x0C,
+    Unk_12 = 0x0C, // Not in UseAction (?)
     Mount = 0x0D,
     PvPAction = 0x0E,
-    Waymark = 0x0F,
+    FieldMarker = 0x0F,
     ChocoboRaceAbility = 0x10,
     ChocoboRaceItem = 0x11,
-    Unk_18 = 0x12,
-    SquadronAction = 0x13,
-    Accessory = 0x14
+    Unk_18 = 0x12, // Not in UseAction (?)
+    BgcArmyAction = 0x13,
+    Ornament = 0x14,
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonFieldMarker.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonFieldMarker.cs
@@ -8,15 +8,15 @@ public unsafe partial struct AddonFieldMarker {
     [FieldOffset(0x00)] public AtkUnitBase AtkUnitBase;
     [FieldOffset(0x230)] public int HoveredButtonIndex; // Index 0-8 of the currently moused over button (A-D, 1-4, Clear)
 
-    [FixedSizeArray<AddonWaymarkInfo>(8)]
-    [FieldOffset(0x238)] public fixed byte WaymarkInfo[0x18 * 8];
+    [FixedSizeArray<AddonFieldMarkerInfo>(8)]
+    [FieldOffset(0x238)] public fixed byte FieldMarkerInfo[0x18 * 8];
 
     [FieldOffset(0x57C)] public int HoveredPresetIndex; // Index 0-4 of the currently moused over slot, -1 if not hovering over a slot
     [FieldOffset(0x580)] public byte SelectedPage;
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x18)]
-public unsafe struct AddonWaymarkInfo {
+public unsafe struct AddonFieldMarkerInfo {
     [FieldOffset(0x00)] public int IconId; // Map IconId
     [FieldOffset(0x04)] public int Active;
     [FieldOffset(0x08)] public byte* TooltipString; //null-terminated cstring

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFieldMarker.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFieldMarker.cs
@@ -15,17 +15,10 @@ public unsafe partial struct AgentFieldMarker {
 
     [FieldOffset(0xC70)] public Utf8String TooltipString;
 
-    public bool IsWaymarkActive(WaymarkIndex waymark) => (ActiveMarkerFlags & (1 << (int)waymark)) != 0;
-    public bool IsWaymarkActive(int index) => (ActiveMarkerFlags & (1 << index)) != 0;
-}
-
-public enum WaymarkIndex {
-    A,
-    B,
-    C,
-    D,
-    One,
-    Two,
-    Three,
-    Four,
+    /// <summary>
+    /// Check if a specific field marker (waymark) has been placed.
+    /// </summary>
+    /// <param name="index">The EXD row ID of the field marker to check.</param>
+    /// <returns>Returns true if the field marker is placed, false otherwise.</returns>
+    public bool IsFieldMarkerActive(int index) => (ActiveMarkerFlags & (1 << index)) != 0;
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.cs
@@ -406,12 +406,12 @@ public enum HotbarSlotType : byte {
     Marker = 0x08,
     CraftAction = 0x09,
     GeneralAction = 0x0A,
-    CompanionOrder = 0x0B,
+    BuddyAction = 0x0B,
     MainCommand = 0x0C,
-    Minion = 0x0D,
+    Companion = 0x0D,
 
     GearSet = 0x0F,
-    PetOrder = 0x10,
+    PetAction = 0x10,
     Mount = 0x11,
     FieldMarker = 0x12,
 
@@ -422,11 +422,11 @@ public enum HotbarSlotType : byte {
     ExtraCommand = 0x18,
     PvPQuickChat = 0x19,
     PvPCombo = 0x1A,
-    SquadronOrder = 0x1B,
+    BgcArmyAction = 0x1B,
 
     Unk_0x1C = 0x1C, // seems to be a legacy type, possibly performance instrument related based on associated icon 000782
     PerformanceInstrument = 0x1D,
     Collection = 0x1E,
-    FashionAccessory = 0x1F,
+    Ornament = 0x1F,
     LostFindsItem = 0x20
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -941,7 +941,7 @@ classes:
       0x1409A7BF0: GetSpellIdForAction
       0x1409A9190: UseActionLocation
       0x1409A9FC0: UseGeneralAction
-      0x1409AACA0: UseWaymarkAction
+      0x1409AACA0: UseFieldMarkerAction
       0x1409AB790: CheckActionResources
       0x1409AF160: GetActionStatus
       0x1409B0F00: CanUseAction
@@ -4840,7 +4840,7 @@ classes:
     vfuncs:
       0: dtor
     funcs:
-      0x14094CD30: ClearWaymarks
+      0x14094CD30: ClearFieldMarkers
   Client::Game::LimitBreakController:
     instances:
       - ea: 0x142182DE0


### PR DESCRIPTION
- ActionType polish based on EXD name and correct values
- HotbarSlotType polish based on same
- Remove "waymark" everywhere
  - Properly refer to it as `FieldMarker`
  - Remove WaymarkIndex, as it's an EXD field