### PR TITLE
Fix InventoryManager.MoveItemSlot sig

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/InventoryManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InventoryManager.cs
@@ -14,7 +14,7 @@ public unsafe partial struct InventoryManager {
     [MemberFunction("E8 ?? ?? ?? ?? 03 F8 BB")]
     public partial int GetItemCountInContainer(uint itemId, InventoryType inventoryType, bool isHq = false, short minCollectability = 0);
 
-    [MemberFunction("E8 ?? ?? ?? ?? 33 DB 89 1E")]
+    [MemberFunction("E8 ?? ?? ?? ?? 33 DB 89 5E 08")]
     public partial int MoveItemSlot(InventoryType srcContainer, ushort srcSlot, InventoryType dstContainer, ushort dstSlot, byte unk = 0);
 
     [MemberFunction("E8 ?? ?? ?? ?? 85 C0 7F 6D")]


### PR DESCRIPTION
Either IDA is failing me, or this sig is wrong.
annas sig_checker.py found it.