### PR TITLE
Add binary attribute for .png files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text eol=crlf
+*.png binary


### PR DESCRIPTION
There are `.png` files in this repo now (in [Ghidra/images](https://github.com/aers/FFXIVClientStructs/tree/main/Ghidra/images)), so git should handle them as binary files.

Alternatively, they could be uploaded with GitHubs editor (just drag the images into the markdown), so they aren’t in the repo at all. 🤷‍♂️ 