### PR TITLE
Add ReassignGearsetId

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
@@ -79,6 +79,20 @@ public unsafe partial struct RaptureGearsetModule {
     public partial void UpdateGearset(int gearsetId);
 
     /// <summary>
+    /// Reassign a gearsets ID (aka. swap gearset positions).<br/>
+    /// The game calls this "Reassign Set Number".
+    /// </summary>
+    /// <remarks>
+    /// Check if the return value is a valid gearset id and then call
+    /// <see cref="RaptureHotbarModule.ReassignGearsetId"/> to update hotbars accordingly.
+    /// </remarks>
+    /// <param name="gearsetId">The ID of the gearset to switch.</param>
+    /// <param name="newGearsetId">The ID the gearset should be reassigned to.</param>
+    /// <returns>Returns <c>-1</c> if either gearset ID is invalid, <c>-2</c> if the player is editing a portrait, otherwise the old gearset ID.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 8B E8 83 F8 FE 0F 8E ?? ?? ?? ?? 80 BF")]
+    public partial int ReassignGearsetId(int gearsetId, int newGearsetId);
+
+    /// <summary>
     /// Link a glamour plate to a specific gearset.
     /// </summary>
     /// <param name="gearsetId">The gearset ID to link a glamour plate to </param>

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.cs
@@ -67,6 +67,17 @@ public unsafe partial struct RaptureHotbarModule {
     public partial byte ExecuteSlotById(uint hotbarId, uint slotId);
 
     /// <summary>
+    /// Updates all hotbar slots that link to an old gearset id and replaces them with a link to the new id.
+    /// </summary>
+    /// <remarks>
+    /// Usually called right after <see cref="RaptureGearsetModule.ReassignGearsetId"/>.
+    /// </remarks>
+    /// <param name="gearsetId">The new/current ID of the gearset.</param>
+    /// <param name="oldGearsetId">The old ID of the gearset, which needs to be updated.</param>
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 4E 10 48 8B 01 FF 50 40 48 8B 5C 24")]
+    public partial void ReassignGearsetId(int gearsetId, int oldGearsetId);
+
+    /// <summary>
     /// Retrieves a pointer to a specific hotbar slot via hotbar ID or slot ID. If the hotbar slot specified is out of
     /// bounds, return the <see cref="ScratchSlot"/>. 
     /// </summary>

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4069,6 +4069,7 @@ classes:
       0x140691590: ExecuteSlot
       0x14068C670: ExecuteSlotById
       0x14068C6B0: GetSlotById
+      0x14068FBA0: ReassignGearsetId
       0x140690C70: GetSlotAppearance   # static
       0x140691F90: WriteSavedSlot
   Client::UI::Misc::RaptureHotbarModule::HotbarSlot:
@@ -4110,6 +4111,7 @@ classes:
       0x1406A1FA0: CreateGearset
       0x1406A2030: DeleteGearset
       0x1406A2200: UpdateGearset # (this, gearsetIndex)
+      0x1406A2390: ReassignGearsetId
       0x1406A2640: LinkGlamourPlate
       0x1406A2760: RemoveGlamourPlateLink
       0x1406A2770: HasLinkedGlamourPlate


### PR DESCRIPTION
This PR adds two functions:
- `RaptureGearsetModule.ReassignGearsetId`, which swaps two gearsets positions in the list
- `RaptureHotbarModule.ReassignGearsetId` updates links to the gearsets on the hotbars accordingly.