### PR TITLE
AddonActionbarX Slot, add ComponentDragDrop

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonActionBarBase.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonActionBarBase.cs
@@ -45,6 +45,7 @@ public unsafe partial struct AddonActionBarBase {
 [StructLayout(LayoutKind.Explicit, Size = 0xC8)]
 public unsafe struct ActionBarSlot {
     [FieldOffset(0x04)] public int ActionId;       // Not cleared when slot is emptied
+    [FieldOffset(0x88)] public AtkComponentDragDrop* ComponentDragDrop;
     [FieldOffset(0x90)] public AtkComponentNode* Icon;
     [FieldOffset(0x98)] public AtkTextNode* ControlHintTextNode;
     [FieldOffset(0xA0)] public AtkResNode* IconFrame;


### PR DESCRIPTION
This address is a pointer to the component, whose ownernode is the node for the entire slot.