### PR TITLE
Add RaptureAtkModule.AgentUpdateFlag

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
@@ -14,7 +14,8 @@ public unsafe partial struct RaptureAtkModule {
 
     [FieldOffset(0x0)] public AtkModule AtkModule;
 
-    [FieldOffset(0x10D40)] public Utf8String* AddonNames; // pointer to an array of 855 Utf8Strings
+    [FieldOffset(0x87F7)] public AgentUpdateFlags AgentUpdateFlag; // reset happens in RaptureAtkModule_OnUpdate
+    [FieldOffset(0x10D40)] public Utf8String* AddonNames; // pointer to an array of 853 Utf8Strings
 
     [FieldOffset(0x10E20)] public AgentModule AgentModule;
 
@@ -62,6 +63,19 @@ public unsafe partial struct RaptureAtkModule {
         [FieldOffset(0x244)] public bool IsDirty;
 
         public bool IsPrefixTitle => ((Flags >> (8 * 3)) & 0xFF) == 1;
+    }
+
+    [Flags]
+    public enum AgentUpdateFlags : byte
+    {
+        None = 0x00,
+        InventoryUpdate = 0x01,
+        ActionBarUpdate = 0x02, // Triggered by using Actions, Inventories, Gearsets, Macros
+        RetainerUpdate = 0x04,
+        NameplateUpdate = 0x08,
+        UnlocksUpdate = 0x10, // Triggered by Mounts, Minions, Orchestrion Rolls, Sightseeing Log, UnlockLinks...
+        MainCommandEnabledStateUpdate = 0x20,
+        HousingInventoryUpdate = 0x40,
     }
 }
 


### PR DESCRIPTION
This PR adds `RaptureAtkModule.AgentUpdateFlag`, which is (in most cases) set in packet handlers and checked in agents (although some agents set them too).

I'm not 100% sure on all names, especially `NameplateUpdate`, but I tried to make the most sense of them based on where they are used.

As an example, these flags are set when I open and then close the retainer menu:

![log](https://github.com/aers/FFXIVClientStructs/assets/96642047/1c0426f2-ddac-4c94-b7a9-78ff3bd9fe5c)

Earlier I tried out `UnlocksUpdate`, which was set after I unlocked an Orchestrion Roll. 👍

Also, `RaptureGearsetModule.ReassignGearsetId` (PR #646) is usually called before setting this flag to 2 (`ActionBarUpdate`), which is why I digged deeper on this.