### PR TITLE
Add AgentHUD.IsMainCommandEnabled

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHUD.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHUD.cs
@@ -32,6 +32,9 @@ public unsafe partial struct AgentHUD {
 
     [FieldOffset(0x13F0)] public HudPartyMemberEnmity* PartyEnmityList;
 
+    [MemberFunction("48 8B 81 ?? ?? ?? ?? 44 8B C2 83 E2 1F")]
+    public partial bool IsMainCommandEnabled(uint mainCommandId);
+
     [MemberFunction("E8 ?? ?? ?? ?? 41 B0 01 EB 27")]
     public partial bool SetMainCommandEnabledState(uint mainCommandId, bool enabled);
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4890,6 +4890,7 @@ classes:
     funcs:
       0x140C03810: ctor
       0x140C04090: Finalize
+      0x140C059A0: IsMainCommandEnabled
       0x140C059D0: SetMainCommandEnabledState
       0x140C09CB0: UpdateParty
       0x140C0DCF0: UpdateHotBar


### PR DESCRIPTION
The counterpart to `AgentHUD.SetMainCommandEnabledState`, added in #649.