### PR TITLE
Fix HotbarShareStateBitmask offset for 6.5

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.cs
@@ -24,7 +24,7 @@ public unsafe partial struct RaptureHotbarModule {
     /// <summary>
     /// A bitfield representing whether a specific hotbar is to be considered "shared" or not.
     /// </summary>
-    [FieldOffset(0x78)] public fixed byte HotbarShareStateBitmask[4];
+    [FieldOffset(0x7C)] public fixed byte HotbarShareStateBitmask[4];
 
     /// <summary>
     /// An array of all active hotbars loaded and available to the player. This field tracks both normal hotbars


### PR DESCRIPTION
This moved by 4 bytes.
With all hotbars set to shared:
![x64dbg_VquUEcZ9KT](https://github.com/aers/FFXIVClientStructs/assets/1273787/71ee4119-3f92-489a-a82f-f7599c28b823)
