### PR TITLE
More PlayerState/UIState findings

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -109,7 +109,7 @@ public unsafe partial struct PlayerState {
 
     /// <summary>Carrier Level of Delivery Moogle Quests</summary>
     [FieldOffset(0x559)] public byte DeliveryLevel;
-
+    // [FieldOffset(0x560)] public byte UnkWeddingPlanFlag; // see lua function "GetWeddingPlan"
     /// <summary>
     /// Flag containing information about which DoH job the player is specialized in.
     /// </summary>
@@ -126,6 +126,7 @@ public unsafe partial struct PlayerState {
     [FieldOffset(0x568)] public ushort ActiveGcArmyExpedition;
     [FieldOffset(0x56A)] public ushort ActiveGcArmyTraining;
     [FieldOffset(0x56C)] public bool HasNewGcArmyCandidate; // see lua function "GcArmyIsNewCandidate"
+    // [FieldOffset(0x56D)] public bool UnkGcPvpMountActionCheck; // see "80 3D ?? ?? ?? ?? ?? 75 3C"
 
     [FieldOffset(0x56E)] public fixed byte UnlockedMinerFolkloreTomeBitmask[2];
     [FieldOffset(0x570)] public fixed byte UnlockedBotanistFolkloreTomeBitmask[2];

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -93,6 +93,18 @@ public unsafe partial struct PlayerState {
     [FieldOffset(0x4AA)] public byte PlayerStateFlags2;
     [FieldOffset(0x4AB)] public byte PlayerStateFlags3;
 
+    [FieldOffset(0x4D4)] public byte SightseeingLogUnlockState; // 0 = Not Unlocked, 1 = ARR Part 1, 2 = ARR Part 2
+    [FieldOffset(0x4D5)] public byte SightseeingLogUnlockStateEx; // 3 = Quest "Sights of the North" completed (= AdventureExPhase unlocked?)
+    // Ref: PlayerState.IsAdventureExPhaseComplete
+    // Size: (AdventureExPhaseSheet.RowCount + 7) >> 3
+    /// <remarks> Use <see cref="IsAdventureExPhaseComplete"/> </remarks>
+    [FieldOffset(0x4D6)] public fixed byte UnlockedAdventureExPhaseBitmask[(3 + 7) >> 3];
+
+    // Ref: PlayerState.IsAdventureComplete
+    // Size: (AdventureSheet.RowCount + 7) >> 3
+    /// <remarks> Use <see cref="IsAdventureComplete"/> </remarks>
+    [FieldOffset(0x500)] public fixed byte UnlockedAdventureBitmask[(295 + 7) >> 3];
+
     [FieldOffset(0x529)] public fixed byte UnlockFlags[44];
 
     /// <summary>Carrier Level of Delivery Moogle Quests</summary>
@@ -267,6 +279,20 @@ public unsafe partial struct PlayerState {
     /// <param name="territoryTypeColumn32">Column 32 of TerritoryType</param>
     [MemberFunction("4C 8B C9 85 D2 74 48")]
     public partial bool IsAetherCurrentZoneComplete(uint territoryTypeColumn32);
+
+    /// <summary>
+    /// Check if all vistas of an expansion in the Sightseeing Log have been discovered.
+    /// </summary>
+    /// <param name="adventureExPhaseId">AdventureExPhase RowId</param>
+    [MemberFunction("E8 ?? ?? ?? ?? 88 84 24 ?? ?? ?? ?? 4D 85 F6")]
+    public partial bool IsAdventureExPhaseComplete(uint adventureExPhaseId);
+
+    /// <summary>
+    /// Check if a Sightseeing Log vista has been discovered.
+    /// </summary>
+    /// <param name="adventureId">Index of Row (= RowId - 2162688)</param>
+    [MemberFunction("81 FA ?? ?? ?? ?? 73 1F 0F B6 C2")]
+    public partial bool IsAdventureComplete(uint adventureId);
 
     #endregion
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -58,7 +58,10 @@ public unsafe partial struct PlayerState {
 
     [FieldOffset(0x2BC)] public uint BaseRestedExperience;
 
-    [FieldOffset(0x2D5)] public fixed byte OwnedMountsBitmask[49];
+    // Size: (MountSheet.Max(row => row.Order) + 7) >> 3
+    /// <remarks> Use <see cref="IsMountUnlocked"/> </remarks>
+    [FieldOffset(0x2DD)] public fixed byte OwnedMountsBitmask[(280 + 7) >> 3];
+
     [FieldOffset(0x306)] public byte NumOwnedMounts;
 
     [FieldOffset(0x458)] public uint NumFishCaught;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -125,6 +125,7 @@ public unsafe partial struct PlayerState {
     [FieldOffset(0x564)] public uint SquadronTrainingCompletionTimestamp;
     [FieldOffset(0x568)] public ushort ActiveGcArmyExpedition;
     [FieldOffset(0x56A)] public ushort ActiveGcArmyTraining;
+    [FieldOffset(0x56C)] public bool HasNewGcArmyCandidate; // see lua function "GcArmyIsNewCandidate"
 
     [FieldOffset(0x56E)] public fixed byte UnlockedMinerFolkloreTomeBitmask[2];
     [FieldOffset(0x570)] public fixed byte UnlockedBotanistFolkloreTomeBitmask[2];

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -64,8 +64,18 @@ public unsafe partial struct PlayerState {
 
     [FieldOffset(0x306)] public byte NumOwnedMounts;
 
+    // Ref: "48 8D 0D ?? ?? ?? ?? 41 0F B6 0C 08 41 B0 01 84 D1 0F 95 C1 24 01 02 C0 0A C8 41 0F B6 C4"
+    // Size: (FishParameterSheet.Count(row => row.IsInLog) + 7) >> 3
+    [FieldOffset(0x3B4)] public fixed byte CaughtFishBitmask[(1272 + 7) >> 3];
+
     [FieldOffset(0x458)] public uint NumFishCaught;
     [FieldOffset(0x45C)] public uint FishingBait;
+    // Ref: "41 0F B6 04 00 D3 E2 84 D0 0F 95 85"
+    // Size: (SpearfishingNotebookSheet.RowCount + 7) >> 3
+    [FieldOffset(0x460)] public fixed byte UnlockedSpearfishingNotebookBitmask[(56 + 7) >> 3];
+    // Ref: "48 8D 0D ?? ?? ?? ?? 41 0F B6 0C 08 84 D1 40 0F"
+    // Size: (SpearfishingItemSheet.RowCount + 7) >> 3
+    [FieldOffset(0x467)] public fixed byte CaughtSpearfishBitmask[(287 + 7) >> 3];
 
     [FieldOffset(0x48C)] public uint NumSpearfishCaught;
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -61,7 +61,9 @@ public unsafe partial struct PlayerState {
     // Size: (MountSheet.Max(row => row.Order) + 7) >> 3
     /// <remarks> Use <see cref="IsMountUnlocked"/> </remarks>
     [FieldOffset(0x2DD)] public fixed byte OwnedMountsBitmask[(280 + 7) >> 3];
-
+    // Size: (OrnamentSheet.RowCount + 7) >> 3
+    /// <remarks> Use <see cref="IsOrnamentUnlocked"/> </remarks>
+    [FieldOffset(0x300)] public fixed byte UnlockedOrnamentsBitmask[(41 + 7) >> 3];
     [FieldOffset(0x306)] public byte NumOwnedMounts;
 
     // Ref: "48 8D 0D ?? ?? ?? ?? 41 0F B6 0C 08 41 B0 01 84 D1 0F 95 C1 24 01 02 C0 0A C8 41 0F B6 C4"

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -51,12 +51,12 @@ public unsafe partial struct PlayerState {
     [FieldOffset(0x2B1)] public byte GCRankMaelstrom;
     [FieldOffset(0x2B2)] public byte GCRankTwinAdders;
     [FieldOffset(0x2B3)] public byte GCRankImmortalFlames;
-    [FieldOffset(0x2B4)] public byte HomeAetheryteId;
-    [FieldOffset(0x2B5)] public byte FavouriteAetheryteCount;
-    [FieldOffset(0x2B6)] public fixed byte FavouriteAetheryteArray[4];
-    [FieldOffset(0x2BA)] public byte FreeAetheryteId;
-
-    [FieldOffset(0x2BC)] public uint BaseRestedExperience;
+    [FieldOffset(0x2B4)] public byte HomeAetheryteId; // FIXME: ushort
+    [FieldOffset(0x2B6)] public byte FavouriteAetheryteCount;
+    [FieldOffset(0x2B8)] public fixed byte FavouriteAetheryteArray[4]; // FIXME: ushort[4]
+    [FieldOffset(0x2C0)] public byte FreeAetheryteId; // FIXME: ushort
+    [FieldOffset(0x2C2)] public ushort FreeAetherytePlayStationPlus;
+    [FieldOffset(0x2C4)] public uint BaseRestedExperience;
 
     // Size: (MountSheet.Max(row => row.Order) + 7) >> 3
     /// <remarks> Use <see cref="IsMountUnlocked"/> </remarks>

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -126,6 +126,10 @@ public unsafe partial struct PlayerState {
     [FieldOffset(0x568)] public ushort ActiveGcArmyExpedition;
     [FieldOffset(0x56A)] public ushort ActiveGcArmyTraining;
 
+    [FieldOffset(0x56E)] public fixed byte UnlockedMinerFolkloreTomeBitmask[2];
+    [FieldOffset(0x570)] public fixed byte UnlockedBotanistFolkloreTomeBitmask[2];
+    [FieldOffset(0x572)] public fixed byte UnlockedFishingFolkloreTomeBitmask[2];
+
     #region Weekly Bonus/Weekly Bingo/Wondrous Tails Fields (packet reader: "4C 8B D2 48 8D 81")
 
     /// <summary>RowIds of WeeklyBingoOrderData sheet</summary>

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
@@ -46,27 +46,26 @@ public unsafe partial struct UIState {
     [FieldOffset(0x17954)] public fixed byte UnlockLinkBitmask[0x40];
 
     // Ref: Telepo#UpdateAetheryteList (in the Aetheryte sheet loop)
-    // Size: Number of rows in Aetheryte sheet >> 3
-    [FieldOffset(0x17994)] public fixed byte UnlockedAetherytesBitmask[201 >> 3];
+    // Size: (AetheryteSheet.RowCount + 7) >> 3
+    [FieldOffset(0x17994)] public fixed byte UnlockedAetherytesBitmask[(201 + 7) >> 3];
 
     // Ref: "E8 ?? ?? ?? ?? 48 83 6F ?? ?? 75 06 48 89 77 68"
-    // Size: Number of rows in HowTo sheet >> 3
-    [FieldOffset(0x179AE)] public fixed byte UnlockedHowtoBitmask[288 >> 3];
+    // Size: (HowToSheet.RowCount + 7) >> 3
+    [FieldOffset(0x179AE)] public fixed byte UnlockedHowtoBitmask[(288 + 7) >> 3];
 
     // Ref: g_Client::Game::UI::UnlockedCompanionsMask
     //      direct ref: "48 8D 0D ?? ?? ?? ?? 0F B6 04 08 84 D0 75 10 B8 ?? ?? ?? ?? 48 8B 5C 24"
     //      relative to uistate: "E8 ?? ?? ?? ?? 84 C0 75 A6 32 C0" (case for 0x355)
-    // Size: Number of rows in Companion sheet >> 3
-    [FieldOffset(0x179D2)] public fixed byte UnlockedCompanionsBitmask[512 >> 3];
+    // Size: (CompanionSheet.RowCount + 7) >> 3
+    [FieldOffset(0x179D2)] public fixed byte UnlockedCompanionsBitmask[(512 + 7) >> 3];
 
     // Ref: "42 0F B6 04 30 44 84 C0"
-    // Size: Number of rows in ChocoboTaxiStand sheet >> 3
-    [FieldOffset(0x17A12)] public fixed byte ChocoboTaxiStandsBitmask[87 >> 3];
+    // Size: (ChocoboTaxiStandSheet.RowCount + 7) >> 3
+    [FieldOffset(0x17A12)] public fixed byte ChocoboTaxiStandsBitmask[(87 + 7) >> 3];
 
     // Ref: UIState#IsCutsceneSeen
-    // Size: Max CutsceneWorkIndex.WorkIndex id >> 3
-    //       (just check inside IsCutsceneSeen function for max WorkIndex id)
-    [FieldOffset(0x17A1E)] public fixed byte CutsceneSeenBitmask[1272 >> 3];
+    // Size: (CutsceneWorkIndex.Max(row => row.WorkIndex) + 7) >> 3
+    [FieldOffset(0x17A1E)] public fixed byte CutsceneSeenBitmask[(1272 + 7) >> 3];
 
     [StaticAddress("48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? 48 8B 01", 3)]
     public static partial UIState* Instance();
@@ -136,7 +135,7 @@ public unsafe partial struct UIState {
     /// <param name="aetheryteId">The ID of the aetheryte to check for.</param>
     /// <returns>Returns true if the specified aetheryte is unlocked.</returns>
     public bool IsAetheryteUnlocked(uint aetheryteId) {
-        return ((1 << ((int)aetheryteId & 7)) & this.UnlockedAetherytesBitmask[aetheryteId >> 3]) > 0;
+        return ((1 << ((int)aetheryteId & 7)) & UnlockedAetherytesBitmask[aetheryteId >> 3]) > 0;
     }
 
     /// <summary>
@@ -145,7 +144,7 @@ public unsafe partial struct UIState {
     /// <param name="howtoId">The ID of the HowTo to check for.</param>
     /// <returns>Returns true if the specified HowTo is unlocked.</returns>
     public bool IsHowToUnlocked(uint howtoId) {
-        return ((1 << ((int)howtoId & 7)) & this.UnlockedHowtoBitmask[howtoId >> 3]) > 0;
+        return ((1 << ((int)howtoId & 7)) & UnlockedHowtoBitmask[howtoId >> 3]) > 0;
     }
 
     /// <summary>
@@ -158,18 +157,18 @@ public unsafe partial struct UIState {
     /// <param name="companionId">The ID of the companion/minion to check for.</param>
     /// <returns>Returns true if the specified minion is unlocked.</returns>
     public bool IsCompanionUnlocked(uint companionId) {
-        // Logic borrowed from E8 ?? ?? ?? ?? 84 C0 75 A6 32 C0 and others.
+        // Logic borrowed from "E8 ?? ?? ?? ?? 84 C0 75 A6 32 C0" and others.
 
         // This, for some reason, does not exist as a siggable method in the game code normally. Virtually everyone and
         // everything that does minion checks will have this snippet (or one like it) in place. One does exist in the
         // crossref for the bitmask, but it's over in what I suspect is in the UI module and is bounded. I don't want to
         // replicate this upper bound here as that'll just be something we need to change with alarming regularity.
 
-        return ((1 << ((int)companionId & 7)) & this.UnlockedCompanionsBitmask[companionId >> 3]) > 0;
+        return ((1 << ((int)companionId & 7)) & UnlockedCompanionsBitmask[companionId >> 3]) > 0;
     }
 
     public bool IsChocoboTaxiStandUnlocked(uint chocoboTaxiStandId) {
-        return ((1 << ((ushort)chocoboTaxiStandId & 7)) & this.ChocoboTaxiStandsBitmask[(ushort)chocoboTaxiStandId >> 3]) > 0;
+        return ((1 << ((ushort)chocoboTaxiStandId & 7)) & ChocoboTaxiStandsBitmask[(ushort)chocoboTaxiStandId >> 3]) > 0;
     }
 
     [MemberFunction("E8 ?? ?? ?? ?? 44 22 F0")]

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
@@ -64,7 +64,7 @@ public unsafe partial struct UIState {
     [FieldOffset(0x17A12)] public fixed byte ChocoboTaxiStandsBitmask[(87 + 7) >> 3];
 
     // Ref: UIState#IsCutsceneSeen
-    // Size: (CutsceneWorkIndex.Max(row => row.WorkIndex) + 7) >> 3
+    // Size: (CutsceneWorkIndexSheet.Max(row => row.WorkIndex) + 7) >> 3
     [FieldOffset(0x17A1E)] public fixed byte CutsceneSeenBitmask[(1272 + 7) >> 3];
 
     [StaticAddress("48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? 48 8B 01", 3)]
@@ -176,6 +176,12 @@ public unsafe partial struct UIState {
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 7C 24 ?? 3C")]
     public static partial bool IsInstanceContentUnlocked(uint instanceContentId);
+
+    [MemberFunction("48 83 EC 28 E8 ?? ?? ?? ?? 48 85 C0 74 15 0F B7 40 2A")]
+    public static partial bool IsPublicContentCompleted(uint publicContentId);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 80 BF ?? ?? ?? ?? ?? 74 1E")]
+    public static partial bool IsPublicContentUnlocked(uint publicContentId);
 
     /// <summary> Check if the player has seen the cutscene before. </summary>
     /// <remarks>

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -769,6 +769,8 @@ classes:
       0x140998540: GetNextMapAllowanceTimestamp
       0x14146FDF0: IsInstanceContentUnlocked   # static
       0x1414700D0: IsInstanceContentCompleted  # static
+      0x1414B0850: IsPublicContentUnlocked   # static
+      0x1414B08E0: IsPublicContentCompleted  # static
       0x1409997C0: Terminate
   Client::Game::UI::PlayerState:
     instances:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -784,6 +784,11 @@ classes:
       0x14093C760: IsOrnamentUnlocked
       0x14093B1D0: IsOrchestrionRollUnlocked
       0x14093A330: IsSecretRecipeBookUnlocked # DoH unlockable books
+      0x14093A4A0: SetSightseeingLogUnlockState
+      0x14093A4F0: SetSightseeingLogUnlockStateEx
+      0x14093A540: SetAdventureExPhaseComplete
+      0x14093A590: IsAdventureExPhaseComplete
+      0x14093A860: IsAdventureComplete
       0x14093B110: IsFolkloreTomeUnlocked     # DoL unlockable books
       0x14093C560: IsMcGuffinUnlocked
       0x14093C860: IsFramersKitUnlocked


### PR DESCRIPTION
**Fixed:**
- Bitmask field sizes in both PlayerState and UIState were wrong
  - My bad. They were one byte too short using `rowCount >> 3`. Now it uses `(rowCount + 7) >> 3` to round it up (this is equivalent to `Math.Ceiling(rowCount / 8)`).
- Offsets for Aetheryte ids were wrong and I fixed them, but...

**Bugged:**
- ...Aetheryte ids are ushort, not byte. Changing them would be a breaking change, so I opened a separate PR: #655

**Added:**
- `FreeAetherytePlayStationPlus` (not usable in Windows client)
- Fishing unlocks:
  - `CaughtFishBitmask` and `CaughtSpearfishBitmask`, found via GatherBuddy signatures
  - `UnlockedSpearfishingNotebookBitmask`
- Ornament unlocks:
  - `UnlockedOrnamentsBitmask`
- Sightseeing Log unlocks:
  - `UnlockedAdventureBitmask` and `UnlockedAdventureExPhaseBitmask` with corresponding functions `IsAdventureComplete` and `IsAdventureExPhaseComplete`
  - `SightseeingLogUnlockState` and `SightseeingLogUnlockStateEx`
- `IsPublicContentCompleted` and `IsPublicContentUnlocked`
- Unlocked Folklore Tomes:
  - `UnlockedMinerFolkloreTomeBitmask`, `UnlockedBotanistFolkloreTomeBitmask` and `UnlockedFishingFolkloreTomeBitmask` found via the `PlayerState.IsFolkloreTomeUnlocked` function
- `HasNewGcArmyCandidate`