### PR TITLE
[CExporter] Skip already processed enum values

### DIFF
--- a/ida/CExporter/Exporter.cs
+++ b/ida/CExporter/Exporter.cs
@@ -424,14 +424,18 @@ public abstract class ExporterBase {
         sb.AppendLine("{");
 
         var values = Enum.GetValues(type);
+        var processedValues = new List<object>();
         for (var i = 0; i < values.Length; i++) {
             var value = values.GetValue(i)!;
+            if (processedValues.Contains(value))
+                continue;
             var name = Enum.GetName(type, value);
             sb.Append($"    {name} = {value:D}");
             if (i < values.Length - 1)
                 sb.AppendLine(",");
             else
                 sb.AppendLine();
+            processedValues.Add(value);
         }
 
         sb.AppendLine("};");


### PR DESCRIPTION
I just wanted to import structs into IDA that I exported locally and got an error in IDA:

```
Error FFXIVClientStructs\ida\ffxiv_client_structs.h:3528: Variable 'HANGUL' has already been defined
Component::GUI::NodeType: failed to add constant Text=3 (0x3)
Total 1 errors
```

This happens because the new [`SeVirtualKey`](https://github.com/aers/FFXIVClientStructs/blob/6ab86ffe30f0d9939e7f0e0fcaa86b2e72f6cd9d/FFXIVClientStructs/FFXIV/Client/UI/UIInputData.cs#L166) enum has multiple entries with the same value, like:
```
KANA = 21,
HANGEUL = KANA,
HANGUL = KANA,
```
CExporter generates this, which makes IDA fail to import it:
```
HANGUL = 21,
HANGUL = 21,
HANGUL = 21,
```

I added a list that keeps track of processed values and skips duplicates.
Output with this fix is just
```
HANGUL = 21,
```

I guess it should be KANA, but thats C# at fault. 🤷‍♂️ 