### PR TITLE
Update InfoModule

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
@@ -4,6 +4,8 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Info;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x1C70)]
 public unsafe partial struct InfoModule {
+    public static InfoModule* Instance() => UIModule.Instance()->GetInfoModule();
+
     [FieldOffset(0x1978)] public fixed long InfoProxyArray[34];
     [FieldOffset(0x1A88)] public ulong LocalContentId;
     [FieldOffset(0x1A90)] public Utf8String LocalCharName;
@@ -16,7 +18,21 @@ public unsafe partial struct InfoModule {
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 55 68")]
     public partial InfoProxyInterface* GetInfoProxyById(uint id);
+
+    /// <summary>
+    /// Checks if the local player has a specific online status set.
+    /// </summary>
+    /// <param name="id">The RowId in the OnlineStatus sheet.</param>
+    [MemberFunction("48 8B 81 ?? ?? ?? ?? 0F B6 CA 48 D3 E8")]
+    public partial bool IsOnlineStatusSet(uint id);
+
+    /// <summary>
+    /// Checks if the local player is in a cross world duty.
+    /// </summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 44 8B 8C 24 ?? ?? ?? ?? 84 C0")]
+    public partial bool IsInCrossWorldDuty();
 }
+
 public enum InfoProxyId : uint {
     //ShellCommandChatLinkShell refers to 3,18
     //Party Decline, PartyInv,PartyJoin  refer to 2

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
@@ -12,6 +12,7 @@ public unsafe partial struct InfoModule {
     [FieldOffset(0x1AF8)] public Utf8String UnkString1;
     [FieldOffset(0x1B60)] public Utf8String UnkString2;
     [FieldOffset(0x1BC8)] public Utf8String UnkString3;
+    [FieldOffset(0x1C30)] public ulong OnlineStatusFlags;
 
     public InfoProxyInterface* GetInfoProxyById(InfoProxyId id)
         => GetInfoProxyById((uint)id);

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1516,6 +1516,8 @@ classes:
       0x1400ADAA0: GetInfoProxyById
       0x1400ADAC0: GetLocalCharacterName
       0x1400ADB40: GetLocalContentID
+      0x1400ADC10: IsOnlineStatusSet
+      0x1400ADC90: IsInCrossWorldDuty
   Client::UI::Info::InfoProxyBlacklist:
     vtbls:
       - ea: 0x1419BCFA8
@@ -2153,6 +2155,7 @@ classes:
     funcs:
       0x14021AC90: ctor
       0x14021ACE0: Initialize
+      0x14021C790: IsInCrossWorldDuty
   Application::Network::PacketReceiverCallbackInterface:
     vtbls:
       - ea: 0x1419DB868


### PR DESCRIPTION
This PR adds the following functions to `InfoModule`:

- a static `Instance()` getter
- `bool IsOnlineStatusSet(uint id)` - The id parameter is the RowId of the OnlineStatus sheet.
- `bool IsInCrossWorldDuty()` - Checks a byte in `NetworkModuleProxy` before falling back to checking OnlineStatus 40(?). Seems to be called "Another World" in english. In german the OnlineStatus 40 is a bit more specific, saying something like "In Duty (on another world)".