### PR TITLE
Update some structs

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
@@ -31,7 +31,7 @@ public unsafe partial struct AgentCharaCard {
     // dtor "E8 ?? ?? ?? ?? BA ?? ?? ?? ?? 48 8B CF E8 ?? ?? ?? ?? 48 89 73 ?? E8"
     [StructLayout(LayoutKind.Explicit, Size = 0x950)]
     public unsafe partial struct Storage {
-        [FieldOffset(0x4)] public ushort ObjectId;
+        [FieldOffset(0x4)] public uint ObjectId;
         [FieldOffset(0x8)] public ulong ContentId;
 
         [FieldOffset(0x58)] public Utf8String Name;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
@@ -32,7 +32,7 @@ public unsafe partial struct AgentCharaCard {
     [StructLayout(LayoutKind.Explicit, Size = 0x950)]
     public unsafe partial struct Storage {
         [FieldOffset(0x4)] public ushort ObjectId;
-        [FieldOffset(0x8)] public ulong CountentId;
+        [FieldOffset(0x8)] public ulong ContentId;
 
         [FieldOffset(0x58)] public Utf8String Name;
         [FieldOffset(0xC0)] public ushort WorldId;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
@@ -1,4 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using FFXIVClientStructs.FFXIV.Client.Graphics.Kernel;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using FFXIVClientStructs.FFXIV.Component.GUI;
@@ -26,14 +27,25 @@ public unsafe partial struct AgentCharaCard {
 
 
     // Client::UI::Agent::AgentCharaCard::Storage
-    // ctor E8 ?? ?? ?? ?? 48 8B F0 48 89 73 ?? C6 06
-    // dtor E8 ?? ?? ?? ?? BA ?? ?? ?? ?? 48 8B CF E8 ?? ?? ?? ?? 48 89 73 ?? E8 
+    // ctor "E8 ?? ?? ?? ?? 48 8B F0 48 89 73 ?? C6 06"
+    // dtor "E8 ?? ?? ?? ?? BA ?? ?? ?? ?? 48 8B CF E8 ?? ?? ?? ?? 48 89 73 ?? E8"
     [StructLayout(LayoutKind.Explicit, Size = 0x950)]
-    public struct Storage {
+    public unsafe partial struct Storage {
+        [FieldOffset(0x4)] public ushort ObjectId;
+        [FieldOffset(0x8)] public ulong CountentId;
+
         [FieldOffset(0x58)] public Utf8String Name;
+        [FieldOffset(0xC0)] public ushort WorldId;
+        [FieldOffset(0xC2)] public byte ClassJobId;
+
+        [FieldOffset(0xC4)] public byte GcRank;
+
+        [FieldOffset(0xC8)] public ushort Level;
+        [FieldOffset(0xCA)] public ushort TitleId;
+
         [FieldOffset(0xD8)] public Utf8String FreeCompany;
-        [FieldOffset(0x140)] public Utf8String SearchComment1;
-        [FieldOffset(0x1A8)] public Utf8String SearchComment2; // One of these is probably the raw one without formatting
+        [FieldOffset(0x140)] public Utf8String SearchComment;
+        [FieldOffset(0x1A8)] public Utf8String SearchCommentRaw; // contains unresolved AutoTranslatePayloads
 
         [FieldOffset(0x250)] public uint Activity1IconId;
         [FieldOffset(0x258)] public Utf8String Activity1Name;
@@ -48,6 +60,7 @@ public unsafe partial struct AgentCharaCard {
         [FieldOffset(0x480)] public uint Activity6IconId;
         [FieldOffset(0x488)] public Utf8String Activity6Name;
 
-        [FieldOffset(0x540)] public CharaView CharaView; // size >= 0x390
+        [FieldOffset(0x540)] public CharaViewPortrait CharaView;
+        [FieldOffset(0x900)] public Texture* PortraitTexture;
     }
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
@@ -57,7 +57,7 @@ public struct ItemReward {
     [FieldOffset(0x08)] public int Quantity; // -1 seems to be arrow up
     [FieldOffset(0x10)] public uint IconId;
     [FieldOffset(0x18)] public Utf8String TooltipString;
-    [FieldOffset(0x84)] public Utf8String UnkString; // This string seems to be unused?
+    [FieldOffset(0x88)] public Utf8String UnkString; // This string seems to be unused?
 }
 
 public enum ContentsRouletteRole : byte {

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContext.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContext.cs
@@ -1,6 +1,7 @@
 using System.Drawing;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.System.String;
+using FFXIVClientStructs.FFXIV.Client.UI.Info;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
@@ -13,36 +14,31 @@ public unsafe partial struct AgentContext {
     [FieldOffset(0x28)] public fixed byte ContextMenuArray[0x678 * 2];
     [FieldOffset(0x28)] public ContextMenu MainContextMenu;
     [FieldOffset(0x6A0)] public ContextMenu SubContextMenu;
-
     [FieldOffset(0xD18)] public ContextMenu* CurrentContextMenu;
     [FieldOffset(0xD20)] public Utf8String ContextMenuTitle;
     [FieldOffset(0xD88)] public Point Position;
     [FieldOffset(0xD90)] public uint OwnerAddon;
 
-    [FieldOffset(0xDA0)] public ContextMenuTarget ContextMenuTarget;
-    [FieldOffset(0xE00)] public ContextMenuTarget* CurrentContextMenuTarget;
-    [FieldOffset(0xE08)] public Utf8String TargetName;
-    [FieldOffset(0xE70)] public Utf8String YesNoTargetName;
+    [FieldOffset(0xDA0)] public InfoProxyCommonList.CharacterData ContextMenuTarget;
+    [FieldOffset(0xE08)] public InfoProxyCommonList.CharacterData* CurrentContextMenuTarget;
+    [FieldOffset(0xE10)] public Utf8String TargetName;
+    [FieldOffset(0xE78)] public Utf8String YesNoTargetName;
 
-    [FieldOffset(0xEE0)] public ulong TargetContentId;
-    [FieldOffset(0xEE8)] public ulong YesNoTargetContentId;
-    [FieldOffset(0xEF0)] public GameObjectID TargetObjectId;
-    [FieldOffset(0xEF8)] public GameObjectID YesNoTargetObjectId;
-    [FieldOffset(0xF00)] public short TargetHomeWorldId;
-    [FieldOffset(0xF02)] public short YesNoTargetHomeWorldId;
-    [FieldOffset(0xF04)] public byte YesNoEventId;
+    [FieldOffset(0xEE8)] public ulong TargetContentId;
+    [FieldOffset(0xEF0)] public ulong YesNoTargetContentId;
+    [FieldOffset(0xEF8)] public GameObjectID TargetObjectId;
+    [FieldOffset(0xF00)] public GameObjectID YesNoTargetObjectId;
+    [FieldOffset(0xF08)] public short TargetHomeWorldId;
+    [FieldOffset(0xF0A)] public short YesNoTargetHomeWorldId;
+    [FieldOffset(0xF0C)] public byte YesNoEventId;
 
-    [FieldOffset(0xF08)] public int TargetGender;
-    [FieldOffset(0xF0C)] public uint TargetMountSeats;
+    [FieldOffset(0xF10)] public int TargetGender;
+    [FieldOffset(0xF14)] public uint TargetMountSeats;
 
-    [FieldOffset(0x1730)]
-    public void* UpdateChecker; // AgentContextUpdateChecker*, if handler returns false the menu closes
-
-    [FieldOffset(0x1738)]
-    public long UpdateCheckerParam; //objectid of the target or list index of an addon or other things
-
-    [FieldOffset(0x1740)] public byte ContextMenuIndex;
-    [FieldOffset(0x1741)] public byte OpenAtPosition; // if true menu opens at Position else at cursor location
+    [FieldOffset(0x1738)] public void* UpdateChecker; // AgentContextUpdateChecker*, if handler returns false the menu closes
+    [FieldOffset(0x1740)] public long UpdateCheckerParam; //objectid of the target or list index of an addon or other things
+    [FieldOffset(0x1748)] public byte ContextMenuIndex;
+    [FieldOffset(0x1749)] public byte OpenAtPosition; // if true menu opens at Position else at cursor location
 
     [MemberFunction("E8 ?? ?? ?? ?? 45 88 7C 24")]
     public partial void OpenContextMenu(bool bindToOwner = true, bool closeExisting = true);
@@ -106,21 +102,4 @@ public unsafe partial struct ContextMenu {
     [FieldOffset(0x664)] public uint ContextSubMenuMask;
     [FieldOffset(0x668)] public byte* ContextTitleString;
     [FieldOffset(0x670)] public byte SelectedContextItemIndex;
-}
-
-[StructLayout(LayoutKind.Explicit, Size = 0x60)]
-public unsafe struct ContextMenuTarget {
-    [FieldOffset(0x00)] public ulong ContentId;
-    [FieldOffset(0x14)] public byte AddonListIndex;
-    [FieldOffset(0x16)] public ushort CurrentWorldId;
-    [FieldOffset(0x18)] public ushort HomeWorldId;
-    [FieldOffset(0x1A)] public ushort TerritoryTypeId;
-    [FieldOffset(0x1C)] public byte GrandCompany;
-    [FieldOffset(0x1D)] public byte ClientLanguage;
-    [FieldOffset(0x1E)] public byte LanguageBitmask;
-    [FieldOffset(0x20)] public byte Gender;
-    [FieldOffset(0x21)] public byte ClassJobId;
-    [FieldOffset(0x22)] public fixed byte Name[32];
-    [FieldOffset(0x42)] public fixed byte FcName[14];
-    [FieldOffset(0x50)] public void* Unk_Info_Ptr;
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCommonList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCommonList.cs
@@ -53,7 +53,8 @@ public unsafe partial struct InfoProxyCommonList {
         [FieldOffset(0x24)] public GrandCompany GrandCompany;
         [FieldOffset(0x25)] public Language ClientLanguage;
         [FieldOffset(0x26)] public LanguageMask Languages;
-        // 2 bytes
+        // 1 byte
+        [FieldOffset(0x28)] public byte Sex;
         [FieldOffset(0x29)] public byte Job;
         [FieldOffset(0x2A)] public fixed byte Name[32];
         [FieldOffset(0x4A)] public fixed byte FCTag[6];

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
@@ -18,12 +18,12 @@ public unsafe partial struct RaptureLogModule {
     [FieldOffset(0xF0)] public RaptureTextModule* RaptureTextModule;
 
     [FixedSizeArray<RaptureLogModuleTab>(5)]
-    [FieldOffset(0x528)] public fixed byte ChatTabs[5 * 0x928];
+    [FieldOffset(0x530)] public fixed byte ChatTabs[5 * 0x928];
 
     [FieldOffset(0x33E8)] public fixed byte ChatTabsPendingReload[4]; // set to 1 to reload the tab, see "48 8D 9F ?? ?? ?? ?? 48 8D B7 ?? ?? ?? ?? 80 3B 00"
 
-    [FieldOffset(0x3470)] public LogMessageSource* MsgSourceArray;
-    [FieldOffset(0x3478)] public int MsgSourceArrayLength;
+    [FieldOffset(0x3478)] public LogMessageSource* MsgSourceArray;
+    [FieldOffset(0x3480)] public int MsgSourceArrayLength;
 
     [MemberFunction("E8 ?? ?? ?? ?? 44 03 FB")]
     public partial void ShowLogMessage(uint logMessageID);


### PR DESCRIPTION
**AgentCharaCard:**
- Added a few fields
- Renamed `SearchComment1` to `SearchComment` (this one has resolved payloads/pronouns/whatever you call them)
- Renamed `SearchComment2` to `SearchCommentRaw` (this one has unresolved payloads/pronouns/whatever you call them)
- Updated type of the CharaView field to `CharaViewPortrait`

**AgentContentsFinder:**
- Offset fix in `ItemReward`

**AgentContext:**
- Offset fixes
- Replaced `ContextMenuTarget` with `InfoProxyCommonList.CharacterData`
  -  Explanation: At 0x14023735C it calls `Client::UI::Info::InfoProxyCommonlist_SearchEntryByContenID` and sets the result (a pointer) to AgentContext+0xE08, which was of type `ContextMenuTarget*`. Just before that was a field of type `ContextMenuTarget` (no pointer). After I checked `InfoProxyCommonlist` and found the `CharacterData` struct, which fields matched `ContextMenuTarget`, and because `ContextMenuTarget` had a size of 0x60, `InfoProxyCommonList.CharacterData` has a size of 0x68 and everything shifted by 0x8, I came to the conclusion that `ContextMenuTarget` was actually `InfoProxyCommonList.CharacterData`.

**InfoProxyCommonList:**
- Added a field to `CharacterData` that previously was contained in `ContextMenuTarget`

**RaptureLogModule:**
- Offset fixes