### PR TITLE
Update AtkEventType enum

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
@@ -30,9 +30,9 @@ public enum AtkEventType : byte {
     DragDropDiscard = 54, // sent when dropping an icon into empty screenspace, eg to remove an action from a hotbar
     DragDropCancel = 55, // sent on MouseUp if the cursor has not moved since DragDropBegin, OR on MouseDown over a locked icon
     
-    [Obsolete("Use AtkEventType.DragDropDiscard instead", true)]
+    [Obsolete("Use AtkEventType.DragDropDiscard instead")]
     DragDropUnk54 = 54,
-    [Obsolete("Use AtkEventType.DragDropCancel instead", true)]
+    [Obsolete("Use AtkEventType.DragDropCancel instead")]
     DragDropUnk55 = 55,
 
     // AtkComponentIconText

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
@@ -23,9 +23,16 @@ public enum AtkEventType : byte {
     ListItemToggle = 35,
 
     // AtkComponentDragDrop 
+    DragDropBegin = 47, // sent on MouseDown over a draggable icon (will NOT send for a locked icon)
+    DragDropInsert = 50, // sent when dropping an icon into a hotbar/inventory slot or similar
     DragDropRollOver = 52,
     DragDropRollOut = 53,
+    DragDropDiscard = 54, // sent when dropping an icon into empty screenspace, eg to remove an action from a hotbar
+    DragDropCancel = 55, // sent on MouseUp if the cursor has not moved since DragDropBegin, OR on MouseDown over a locked icon
+    
+    [Obsolete("Use AtkEventType.DragDropDiscard instead", true)]
     DragDropUnk54 = 54,
+    [Obsolete("Use AtkEventType.DragDropCancel instead", true)]
     DragDropUnk55 = 55,
 
     // AtkComponentIconText


### PR DESCRIPTION
(Updated with some suggested name revisions)
- Added event types 47 `DragDropBegin` and 50 `DragDropInsert`
- Obsoleted type 54 `DragDropUnk54`, to be replaced by `DragDropDiscard`
- Obsoleted type 55 `DragDropUnk55`, to be replaced by `DragDropCancel`

@MidoriKami  relevant to `AddonEventManager`.