### PR TITLE
Reintroduce TextureReady as obsolete

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTexture.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTexture.cs
@@ -22,6 +22,8 @@ public unsafe partial struct AtkTexture : ICreatable {
     [FieldOffset(0x8)] public void* Crest;
     [FieldOffset(0x8)] public Texture* KernelTexture;
     [FieldOffset(0x10)] public TextureType TextureType;
+    [FieldOffset(0x11), Obsolete("Use IsTextureReady() instead", true)] public bool TextureReady;
+    [FieldOffset(0x11)] private bool CachedIsTextureReady; // Use IsTextureReady() to get this
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 87 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? 4C 89 BF")]
     public partial void Ctor();


### PR DESCRIPTION
The field `AtkTexture.TextureReady` was (accidentally?) [removed](https://github.com/aers/FFXIVClientStructs/pull/556/files#diff-b4de5d2de8a117307e2c6b2b3f960a2edba1e9da3b0a27bf57fe66f1f2f2fd5dL25) in #556.

I reintroduced it as obsolete with a comment to use the function instead.

The field contains the cached result of that function, which is why I added it as `private bool CachedIsTextureReady`, so it's in the CExporters structs.