### PR TITLE
Add new StdList<T>

### DIFF
--- a/FFXIVClientStructs/STD/List.cs
+++ b/FFXIVClientStructs/STD/List.cs
@@ -6,9 +6,14 @@ public unsafe struct StdList<T> where T : unmanaged {
     public struct Node {
         public Node* Next;
         public Node* Previous;
+        // Unused in the head node
         public T Value;
     }
 
+    // First node is Head->Next
+    // Last node is Head->Previous
     public Node* Head;
+
+    // Size is the number of nodes in the list (excluding the head node)
     public ulong Size;
 }

--- a/FFXIVClientStructs/STD/List.cs
+++ b/FFXIVClientStructs/STD/List.cs
@@ -1,0 +1,14 @@
+namespace FFXIVClientStructs.STD;
+
+[StructLayout(LayoutKind.Sequential, Size = 0x10)]
+public unsafe struct StdList<T> where T : unmanaged {
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Node {
+        public Node* Next;
+        public Node* Previous;
+        public T Value;
+    }
+
+    public Node* Head;
+    public ulong Size;
+}


### PR DESCRIPTION
Will be much more fleshed out with #666. I'm going off of naming by MSVC 11.0, but it should be identical until 2017/14.1. First element is at `Head->Next`, last element is at `Head->Prev`. The head pointer's value type is unused.