### PR TITLE
UI::Map Use Correct Container

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -21,7 +21,7 @@ public unsafe partial struct Map {
     [FieldOffset(0x3EA8)] public StdList<MarkerInfo> CustomTalk;
     [FieldOffset(0x3F50)] public StdList<MarkerInfo> GemstoneTraders;
     
-    [FieldOffset(0x1AF0), Obsolete("Use CurrentLevequest")] public StdVector<MapMarkerData> ActiveLevequestMarkerData;
+    [FieldOffset(0x1AF0), Obsolete("Use ActiveLevequest")] public StdVector<MapMarkerData> ActiveLevequestMarkerData;
     [FieldOffset(0x1B18), Obsolete("Use List<T> UnacceptedQuests")] public MapMarkerContainer QuestMarkerData;
     [FieldOffset(0x1B60), Obsolete("Use List<T> GuildLeveAssignments")] public MapMarkerContainer GuildLeveAssignmentMapMarkerData;
     [FieldOffset(0x1BA8), Obsolete("Use List<T> GuildOrderGuides")] public MapMarkerContainer GuildOrderGuideMarkerData;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -13,8 +13,7 @@ public unsafe partial struct Map {
     [FixedSizeArray<MarkerInfo>(16)]
     [FieldOffset(0x1178)] public fixed byte LevequestData[0x90 * 16];
 
-    [FieldOffset(0x1AF0)] public StdVector<MapMarkerData> ActiveLevequestMarkerData;
-    
+    [FieldOffset(0x1AF0)] public StdVector<MapMarkerData> ActiveLevequest; // Markers for active levequest missions, they have to be actually started.
     [FieldOffset(0x1B18)] public StdList<MarkerInfo> UnacceptedQuests;
     [FieldOffset(0x1B60)] public StdList<MarkerInfo> GuildLeveAssignments;
     [FieldOffset(0x1BA8)] public StdList<MarkerInfo> GuildOrderGuides;
@@ -22,6 +21,7 @@ public unsafe partial struct Map {
     [FieldOffset(0x3EA8)] public StdList<MarkerInfo> CustomTalk;
     [FieldOffset(0x3F50)] public StdList<MarkerInfo> GemstoneTraders;
     
+    [FieldOffset(0x1AF0), Obsolete("Use CurrentLevequest")] public StdVector<MapMarkerData> ActiveLevequestMarkerData;
     [FieldOffset(0x1B18), Obsolete("Use List<T> UnacceptedQuests")] public MapMarkerContainer QuestMarkerData;
     [FieldOffset(0x1B60), Obsolete("Use List<T> GuildLeveAssignments")] public MapMarkerContainer GuildLeveAssignmentMapMarkerData;
     [FieldOffset(0x1BA8), Obsolete("Use List<T> GuildOrderGuides")] public MapMarkerContainer GuildOrderGuideMarkerData;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -14,12 +14,20 @@ public unsafe partial struct Map {
     [FieldOffset(0x1178)] public fixed byte LevequestData[0x90 * 16];
 
     [FieldOffset(0x1AF0)] public StdVector<MapMarkerData> ActiveLevequestMarkerData;
-    [FieldOffset(0x1B18)] public MapMarkerContainer QuestMarkerData;
-    [FieldOffset(0x1B60)] public MapMarkerContainer GuildLeveAssignmentMapMarkerData;
-    [FieldOffset(0x1BA8)] public MapMarkerContainer GuildOrderGuideMarkerData;
-    [FieldOffset(0x3E98)] public MapMarkerContainer TripleTriadMarkerData;
-    [FieldOffset(0x3EA8)] public MapMarkerContainer CustomTalkMarkerData;
-    [FieldOffset(0x3F50)] public MapMarkerContainer GemstoneTraderMarkerData;
+    
+    [FieldOffset(0x1B18)] public StdList<MarkerInfo> UnacceptedQuests;
+    [FieldOffset(0x1B60)] public StdList<MarkerInfo> GuildLeveAssignments;
+    [FieldOffset(0x1BA8)] public StdList<MarkerInfo> GuildOrderGuides;
+    [FieldOffset(0x3E98)] public StdList<MarkerInfo> TripleTriad;
+    [FieldOffset(0x3EA8)] public StdList<MarkerInfo> CustomTalk;
+    [FieldOffset(0x3F50)] public StdList<MarkerInfo> GemstoneTraders;
+    
+    [FieldOffset(0x1B18), Obsolete("Use List<T> UnacceptedQuests")] public MapMarkerContainer QuestMarkerData;
+    [FieldOffset(0x1B60), Obsolete("Use List<T> GuildLeveAssignments")] public MapMarkerContainer GuildLeveAssignmentMapMarkerData;
+    [FieldOffset(0x1BA8), Obsolete("Use List<T> GuildOrderGuides")] public MapMarkerContainer GuildOrderGuideMarkerData;
+    [FieldOffset(0x3E98), Obsolete("Use List<T> TripleTriad")] public MapMarkerContainer TripleTriadMarkerData;
+    [FieldOffset(0x3EA8), Obsolete("Use List<T> CustomTalk")] public MapMarkerContainer CustomTalkMarkerData;
+    [FieldOffset(0x3F50), Obsolete("Use List<T> GemstoneTraders")] public MapMarkerContainer GemstoneTraderMarkerData;
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x90)]
@@ -46,17 +54,20 @@ public unsafe partial struct MapMarkerData {
 /// <summary>
 /// This container uses a linked list internally to contain Map Markers that contain tooltip information.
 /// </summary>
+[Obsolete("Use StdList<T> instead.")]
 [StructLayout(LayoutKind.Sequential)]
 public unsafe partial struct MapMarkerContainer {
     public LinkedList* List;
     public int Size;
 
+    [Obsolete("Use StdList<T> instead.")]
     [StructLayout(LayoutKind.Sequential)]
     public unsafe partial struct LinkedList {
         public MapMarkerNode* First;
         public MapMarkerNode* Last;
     }
 
+    [Obsolete("Use StdList<T> instead.")]
     public IEnumerable<MarkerInfo> GetAllMarkers() {
         var result = new List<MarkerInfo>();
         var current = List->First;
@@ -70,6 +81,7 @@ public unsafe partial struct MapMarkerContainer {
     }
 }
 
+[Obsolete("Use StdList<T> instead.")]
 [StructLayout(LayoutKind.Sequential)]
 public unsafe partial struct MapMarkerNode {
     public MapMarkerNode* Next;


### PR DESCRIPTION
According to code search, Mappy is the **only** plugin using these fields.

So once this updated ClientStructs is in Dalamud Stable and I am able to switch Mappy to the StdList<T> members, I will PR to remove the obsoletes and MapMarkerContainer structures.