### PR TITLE
Move AgentInterface to Client::UI::Agent

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentActionMenu.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentActionMenu.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentAozContentBriefing.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentAozContentBriefing.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentAozContentResult.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentAozContentResult.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentArchiveItem.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentArchiveItem.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerEditor.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerEditor.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBlacklist.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBlacklist.cs
@@ -1,6 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Info;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
@@ -1,7 +1,6 @@
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentChatLog.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentChatLog.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCompanyCraftMaterial.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCompanyCraftMaterial.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 //Client::UI::Agent::AgentCompanyCraftMaterial

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentContentsFinder.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCraftActionSimulator.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCraftActionSimulator.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 //Client::UI::Agent::AgentCraftActionSimulator

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentDeepDungeonInspect.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentDeepDungeonInspect.cs
@@ -1,6 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Info;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentDeepDungeonMap.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentDeepDungeonMap.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentDeepDungeonStatus.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentDeepDungeonStatus.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFieldMarker.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFieldMarker.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFishGuide.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFishGuide.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.FishGuide)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFreeCompany.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFreeCompany.cs
@@ -1,6 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFreeCompanyCrestEditor.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFreeCompanyCrestEditor.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.FreeCompanyCrestEditor)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFreeCompanyProfile.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFreeCompanyProfile.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFriendList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFriendList.cs
@@ -1,6 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Info;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGatheringNote.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGatheringNote.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.GatheringNote)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGcArmyExpedition.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGcArmyExpedition.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGoldSaucer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGoldSaucer.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.GoldSaucer)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGrandCompanySupply.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGrandCompanySupply.cs
@@ -1,6 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHUD.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHUD.cs
@@ -1,6 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 // Client::UI::Agent::AgentHUD

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHousingPlant.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHousingPlant.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.HousingPlant)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHudLayout.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHudLayout.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 // Client::UI::Agent::AgentHudLayout
 //   Client::UI::Agent::AgentInterface

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentIKDFishingLog.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentIKDFishingLog.cs
@@ -1,6 +1,3 @@
-using FFXIVClientStructs.FFXIV.Client.System.Framework;
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.IKDFishingLog)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentIKDResult.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentIKDResult.cs
@@ -1,6 +1,4 @@
-using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentInspect.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentInspect.cs
@@ -1,7 +1,6 @@
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Info;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentInterface.cs
@@ -1,11 +1,10 @@
-using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Component.GUI;
 
-namespace FFXIVClientStructs.FFXIV.Component.GUI;
+namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
 // Client::UI::Agent::AgentInterface
 //   Component::GUI::AtkModuleInterface::AtkEventInterface
-
-// size = 0x8
-// ctor E8 ?? ?? ?? ?? F6 C3 01 74 0D BA ?? ?? ?? ?? 48 8B CF E8 ?? ?? ?? ?? 48 8B C7 48 8B 5C 24 ?? 48 83 C4 20 5F C3 CC 48 89 5C 24 ?? 48 89 6C 24 ?? 
+// ctor "E8 ?? ?? ?? ?? 80 63 30 80"
 [StructLayout(LayoutKind.Explicit, Size = 0x28)]
 public unsafe partial struct AgentInterface {
     [FieldOffset(0x0)] public AtkEventInterface AtkEventInterface;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.ItemDetail)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemSearch.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemSearch.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 // Client::UI::Agent::AgentItemSearch

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
@@ -1,6 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Component.Excel;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLoot.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLoot.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.Loot)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMJIPouch.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMJIPouch.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMap.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMap.cs
@@ -1,6 +1,5 @@
 using System.Numerics;
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMiragePrismMiragePlate.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMiragePrismMiragePlate.cs
@@ -1,6 +1,3 @@
-using FFXIVClientStructs.FFXIV.Client.System.Framework;
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.MiragePrismMiragePlate)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMiragePrismPrismBox.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMiragePrismPrismBox.cs
@@ -1,6 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMiragePrismPrismItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMiragePrismPrismItemDetail.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.MiragePrismPrismItemDetail)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 // Client::UI::Agent::AgentModule

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMonsterNote.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMonsterNote.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMycBattleAreaInfo.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMycBattleAreaInfo.cs
@@ -1,8 +1,4 @@
-using System.Runtime.InteropServices;
-using FFXIVClientStructs.Attributes;
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
-using FFXIVClientStructs.Interop.Attributes;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMycItemBox.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMycItemBox.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.MycItemBox)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentReadyCheck.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentReadyCheck.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.ReadyCheck)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRecipeNote.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRecipeNote.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentReconstructionBox.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentReconstructionBox.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.ReconstructionBox)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRequest.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRequest.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 // Client::UI::Agent::AgentRequest

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRetainerItemTransfer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRetainerItemTransfer.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRetainerList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRetainerList.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRetainerTask.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRetainerTask.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.RetainerTask)]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRevive.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRevive.cs
@@ -1,6 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentSalvage.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentSalvage.cs
@@ -1,6 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentSatisfactionSupply.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentSatisfactionSupply.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentScenarioTree.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentScenarioTree.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 // ctor E8 ?? ?? ?? ?? EB 03 48 8B C5 33 D2 48 89 47 58

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentScreenLog.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentScreenLog.cs
@@ -1,7 +1,6 @@
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.System.String;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentTeleport.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentTeleport.cs
@@ -1,5 +1,4 @@
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentTryon.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentTryon.cs
@@ -1,6 +1,3 @@
-using FFXIVClientStructs.FFXIV.Client.System.Framework;
-using FFXIVClientStructs.FFXIV.Component.GUI;
-
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 // Client::UI::Agent::AgentTryon

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/CharaView.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/CharaView.cs
@@ -1,6 +1,7 @@
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.System.Memory;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/CharaView.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/CharaView.cs
@@ -2,7 +2,6 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.System.Memory;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 

--- a/FFXIVClientStructs/Interop/Resolver.cs
+++ b/FFXIVClientStructs/Interop/Resolver.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Serilog;
 
 namespace FFXIVClientStructs.Interop;
 


### PR DESCRIPTION
The comment above the struct said
```cs
// Client::UI::Agent::AgentInterface
//   Component::GUI::AtkModuleInterface::AtkEventInterface
```
but it was located in `FFXIVClientStructs.FFXIV.Component.GUI`, so I moved it to `FFXIVClientStructs.FFXIV.Client.UI.Agent`.

🤷‍♂️