### PR TITLE
Add missing Fall Guys addons/agents

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
@@ -445,7 +445,8 @@ public enum AgentId : uint {
     SXTBattleLog = 434,
 
     FGSEnterDialog = 436,
-
+    FGSStageIntro = 437,
+    FGSHud = 438,
     FGSWinner = 439,
     FGSResult = 440
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -7109,6 +7109,14 @@ classes:
     vtbls:
       - ea: 0x141A8F9E0
         base: Client::UI::Agent::AgentInterface
+  Client::UI::Agent::AgentFGSStageIntro:
+    vtbls:
+      - ea: 0x141A8F968
+        base: Client::UI::Agent::AgentInterface
+  Client::UI::Agent::AgentFGSHud:
+    vtbls:
+      - ea: 0x141A8F8A0
+        base: Client::UI::Agent::AgentInterface
   Client::UI::Agent::AgentFGSWinner:
     vtbls:
       - ea: 0x141A8FAD0
@@ -8771,6 +8779,90 @@ classes:
         base: Component::GUI::AtkUnitBase
     funcs:
       0x1410CF5E0: ctor
+  Client::UI::AddonFGSCountDown:
+    vtbls:
+      - ea: 0x141B21230
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x141154000: ctor
+  Client::UI::AddonFGSEliminated:
+    vtbls:
+      - ea: 0x141B21A18
+        base: Client::UI::AddonImage
+    funcs:
+      0x141141460: ctor
+  Client::UI::AddonFGSRoundover:
+    vtbls:
+      - ea: 0x141B21F68
+        base: Client::UI::AddonImage
+    funcs:
+      0x141141680: ctor
+  Client::UI::AddonFGSHudGoal:
+    vtbls:
+      - ea: 0x141B430E0
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x1412202D0: ctor
+  Client::UI::AddonFGSHudScore:
+    vtbls:
+      - ea: 0x141B43320
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x1412208A0: ctor
+  Client::UI::AddonFGSHudStatus:
+    vtbls:
+      - ea: 0x141B43560
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x141220D80: ctor
+  Client::UI::AddonFGSHudRaceLog:
+    vtbls:
+      - ea: 0x141B437A0
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x1412215E0: ctor
+  Client::UI::AddonFGSSpectatorMenu:
+    vtbls:
+      - ea: 0x141B439E0
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x141221D00: ctor
+  Client::UI::AddonFGSExitDialog:
+    vtbls:
+      - ea: 0x141B43C50
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x141222100: ctor
+  Client::UI::AddonFGSStageDescription:
+    vtbls:
+      - ea: 0x141B43EB0
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x1412222F0: ctor
+  Client::UI::AddonFGSStageIntroBanner:
+    vtbls:
+      - ea: 0x141B440F0
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x141222900: ctor
+  Client::UI::AddonFGSEnterDialog:
+    vtbls:
+      - ea: 0x141B44330
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x141222D00: ctor
+  Client::UI::AddonFGSResultWinner:
+    vtbls:
+      - ea: 0x141B44570
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x1412230C0: ctor
+  Client::UI::AddonFGSResult:
+    vtbls:
+      - ea: 0x141B447B0
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x141223480: ctor
   Client::Game::Object::EventObject:
     vtbls:
       - ea: 0x141B47538


### PR DESCRIPTION
Agent names are made-up:
- **AgentFGSStageIntro** is used in `UIModule_ShowContentIntroduction`, which opens addons 842 (FGSStageDescription) and 843 (FGSStageIntroBanner). Data is set whenever loading screens in between stages are shown.
- **AgentFGSHud** seems to control the state of all the FGSHud* addons.

🤷‍♂️