### PR TITLE
CExporter: Add support for int64 pointers

### DIFF
--- a/ida/CExporter/Extensions.cs
+++ b/ida/CExporter/Extensions.cs
@@ -30,12 +30,14 @@ public static class TypeExtensions {
             _ when type == typeof(long) || type == typeof(nint) => "__int64",
             _ when type == typeof(ushort) => "unsigned __int16",
             _ when type == typeof(uint) => "unsigned __int32",
-            _ when type == typeof(ulong) => "unsigned __int64",
+            _ when type == typeof(ulong) || type == typeof(nuint) => "unsigned __int64",
             _ when type == typeof(sbyte) => "signed __int8",
             _ when type == typeof(short*) => "__int16*",
             _ when type == typeof(ushort*) => "unsigned __int16*",
             _ when type == typeof(int*) => "__int32*",
             _ when type == typeof(uint*) => "unsigned __int32*",
+            _ when type == typeof(long*) || type == typeof(nint*) => "__int64*",
+            _ when type == typeof(ulong*) || type == typeof(nuint*) => "unsigned __int64*",
             _ when type == typeof(float*) => "float*",
             _ when type == typeof(Half) => "__int16", // Half is a struct that is 2 bytes long and does not exist in C so we just use __int16
             _ => unhandled(type)


### PR DESCRIPTION
The [`StdVector<nint>`](https://github.com/aers/FFXIVClientStructs/blob/d00622e6e54bb8a625d8dcb3712da336766361cd/FFXIVClientStructs/FFXIV/Component/Text/MacroDecoder.cs#L5) in MacroDecoder gets exported as
```c
struct StdVector::SystemIntPtr /* Size=0x18 */
{
    /* 0x00 */ System::IntPtr* First;
    /* 0x08 */ System::IntPtr* Last;
    /* 0x10 */ System::IntPtr* End;
};
```
but `System::IntPtr` itself is not defined. This causes errors when importing the structs file.

To solve this, I added the following entries to the FixTypeName function:
- `long*` or `nint*` to `__int64*`
- `ulong*` or `nuint*` to `unsigned __int64*`
- and, as a bonus, `nuint` to `unsigned __int64`