### PR TITLE
Update RaptureLogModule.PrintMessage

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
@@ -26,7 +26,7 @@ public unsafe partial struct RaptureLogModule {
     [FieldOffset(0x3480)] public int MsgSourceArrayLength;
 
     [MemberFunction("E8 ?? ?? ?? ?? 39 9E ?? ?? ?? ?? 7E 4B")]
-    public partial uint PrintMessage(ushort logKindId, Utf8String* senderName, Utf8String* message, int timestamp, bool a6 = false); // a6 has something to do with Linkshells
+    public partial uint PrintMessage(ushort logKindId, Utf8String* senderName, Utf8String* message, int timestamp, bool silent = false);
 
     [MemberFunction("E8 ?? ?? ?? ?? 44 03 FB")]
     public partial void ShowLogMessage(uint logMessageID);


### PR DESCRIPTION
Last week I added PrintMessage, but didn't know what the last parameter was.
Now, I found out that it supresses the new message sound (if enabled in the config).

The comment was based off wrong ConfigOptions, which weren't updated when I checked them.