### PR TITLE
Update RaptureAtkModule

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
@@ -45,6 +45,9 @@ public unsafe partial struct RaptureAtkModule {
     [VirtualFunction(39)]
     public partial void SetUiVisibility(bool uiVisible);
 
+    [VirtualFunction(58)]
+    public partial void Update(float delta);
+
     public bool IsUiVisible {
         get => !RaptureAtkUnitManager.Flags.HasFlag(RaptureAtkModuleFlags.UiHidden);
         set => SetUiVisibility(value);

--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
@@ -9,6 +9,7 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 //   Component::GUI::AtkModule
 //     Component::GUI::AtkModuleInterface
 [StructLayout(LayoutKind.Explicit, Size = 0x28F98)]
+[VTableAddress("33 C9 48 8D 05 ?? ?? ?? ?? 48 89 8F", 5)]
 public unsafe partial struct RaptureAtkModule {
     public static RaptureAtkModule* Instance() => UIModule.Instance()->GetRaptureAtkModule();
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3642,7 +3642,7 @@ classes:
       17: SetHandlerFunction
       26: IsAddonReady
       39: SetUIVisibility
-      58: OnUpdate
+      58: Update
       63: OpenMapWithMapLink
     funcs:
       0x14056A6F0: ctor


### PR DESCRIPTION
This makes it possible to hook `OnUpdate` to read out the `AgentUpdateFlag` before it's reset to 0.