### PR TITLE
String stuff

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
@@ -17,10 +17,16 @@ public unsafe partial struct Utf8String : ICreatable, IDisposable {
     [FieldOffset(0x21)] public byte IsUsingInlineBuffer;
     [FieldOffset(0x22)] public fixed byte InlineBuffer[0x40]; // inline buffer used until strlen > 0x40
 
-    public int Length => Math.Max(0, (int)(BufUsed - 1));
-    public ReadOnlySpan<byte> Span => new(StringPtr, Length);
+    public readonly int Length => Math.Max(0, (int)(BufUsed - 1));
+    [Obsolete("Use AsSpan() instead")]
+    public readonly ReadOnlySpan<byte> Span => new(StringPtr, Length);
+
+    public readonly byte this[Index index] => AsSpan()[index];
+    public readonly ReadOnlySpan<byte> this[Range range] => AsSpan()[range];
 
     public Utf8String() => Ctor();
+
+    public readonly ReadOnlySpan<byte> AsSpan() => new(StringPtr, Length);
 
     public static Utf8String* CreateEmpty(IMemorySpace* memorySpace = null) {
         if (memorySpace == null) memorySpace = IMemorySpace.GetDefaultSpace();
@@ -110,4 +116,7 @@ public unsafe partial struct Utf8String : ICreatable, IDisposable {
 
     [MemberFunction("E8 ?? ?? ?? ?? 40 0F B6 C7 48 8D 35")]
     public static partial Utf8String* Concat(Utf8String* str, Utf8String* buffer, Utf8String* other);
+
+    public static implicit operator ReadOnlySpan<byte>(in Utf8String value)
+        => value.AsSpan();
 }

--- a/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
@@ -21,12 +21,14 @@ public unsafe partial struct Utf8String : ICreatable, IDisposable {
     [Obsolete("Use AsSpan() instead")]
     public readonly ReadOnlySpan<byte> Span => new(StringPtr, Length);
 
-    public readonly byte this[Index index] => AsSpan()[index];
-    public readonly ReadOnlySpan<byte> this[Range range] => AsSpan()[range];
+    public readonly ref readonly byte this[int index] => ref AsSpan()[index];
 
     public Utf8String() => Ctor();
 
     public readonly ReadOnlySpan<byte> AsSpan() => new(StringPtr, Length);
+
+    public readonly ReadOnlySpan<byte> Slice(int start) => AsSpan().Slice(start);
+    public readonly ReadOnlySpan<byte> Slice(int start, int length) => AsSpan().Slice(start, length);
 
     public static Utf8String* CreateEmpty(IMemorySpace* memorySpace = null) {
         if (memorySpace == null) memorySpace = IMemorySpace.GetDefaultSpace();

--- a/FFXIVClientStructs/STD/String.cs
+++ b/FFXIVClientStructs/STD/String.cs
@@ -11,6 +11,9 @@ public unsafe struct StdString {
     [FieldOffset(0x10)] public ulong Length;
     [FieldOffset(0x18)] public ulong Capacity;
 
+    public readonly byte this[Index index] => AsSpan()[index];
+    public readonly ReadOnlySpan<byte> this[Range range] => AsSpan()[range];
+
     public readonly ReadOnlySpan<byte> AsSpan() {
         if (Length < 16) {
             fixed (StdString* pThis = &this) {
@@ -33,9 +36,8 @@ public unsafe struct StdString {
         return data;
     }
 
-    public readonly override string ToString() {
-        return Encoding.UTF8.GetString(AsSpan());
-    }
+    public readonly override string ToString()
+        => Encoding.UTF8.GetString(AsSpan());
 
     public static implicit operator ReadOnlySpan<byte>(in StdString value)
         => value.AsSpan();


### PR DESCRIPTION
- Remove handling of ≥ 2 GiB strings in `StdString.GetBytes()` as it would not have worked anyway, as discussed ;
- Make `StdString.GetBytes()` `[Obsolete]` as discussed ;
- Change `Utf8String.Span` to `.AsSpan()` for consistency with the dotnet standard library (`.Span` stays, for now, with `[Obsolete]`) ;
- Add indexers with index and range to the two string structs ;
- Add an implicit cast from `Utf8String` to `ROS<byte>` ;
- Mark some members as `readonly`.

This is a followup to #702.