### PR TITLE
Add DynamicEvent (critical engagements)

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/DynamicEvent/DynamicEvent.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/DynamicEvent/DynamicEvent.cs
@@ -1,0 +1,46 @@
+using FFXIVClientStructs.FFXIV.Common.Math;
+using FFXIVClientStructs.FFXIV.Client.System.String;
+
+namespace FFXIVClientStructs.FFXIV.Client.Game.DynamicEvent;
+
+public enum DynamicEventState : byte
+{
+    NotActive = 0,
+    Registration = 1,
+    Waiting = 2,
+    BattleUnderway = 3
+}
+
+public enum DynamicEventRegistrationState : byte
+{
+    NotRegistered = 0,
+    Registered = 1,
+    Ready = 3,
+    Deployed = 4
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x1B0)]
+public struct DynamicEvent
+{
+    [FieldOffset(0x40)] public uint QuestId;
+    [FieldOffset(0x44)] public uint LogMessageId;
+    [FieldOffset(0x4E)] public byte DynamicEventTypeId;
+    [FieldOffset(0x4F)] public byte DynamicEventEnemyTypeId;
+    [FieldOffset(0x50)] public byte MaxParticipants;
+    [FieldOffset(0x51)] public byte DurationMinutes;
+    [FieldOffset(0x52)] public byte LargeScaleBattleId;
+    [FieldOffset(0x53)] public byte SingleBattleId;
+    [FieldOffset(0x54)] public uint FinishTimeEpoch; // end time of current state
+    [FieldOffset(0x58)] public uint SecondsRemaining; // only used while State == BattleUnderWay
+    [FieldOffset(0x5C)] public ushort Duration; // in seconds
+    [FieldOffset(0x60)] public ushort DynamicEventId;
+    [FieldOffset(0x63)] public DynamicEventState State;
+    [FieldOffset(0x64)] public DynamicEventRegistrationState RegistrationState; // self/party registration status
+    [FieldOffset(0x65)] public byte NumCombatants;
+    [FieldOffset(0x66)] public byte Progress; // 0-100
+    [FieldOffset(0x68)] public Utf8String Name;
+    [FieldOffset(0xD0)] public Utf8String Description;
+    [FieldOffset(0x138)] public uint MapIconId;
+
+    [FieldOffset(0x170)] public Vector3 Position;
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/DynamicEvent/DynamicEventManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/DynamicEvent/DynamicEventManager.cs
@@ -1,0 +1,11 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game.DynamicEvent;
+
+[StructLayout(LayoutKind.Explicit, Size = 0x1B28)]
+public unsafe partial struct DynamicEventManager {
+    [FixedSizeArray<DynamicEvent>(16)]
+    [FieldOffset(0x08)] public unsafe fixed byte DynamicEvents[0x1B0 * 16];
+    [FieldOffset(0x1B26)] public byte CurrentEventIndex; // 0xFF or index of registered/deployed DynamicEvent
+
+    [MemberFunction("E8 ?? ?? ?? ?? 45 32 C9 4C 8B D0")]
+    public static partial DynamicEventManager* Instance();
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
@@ -1,10 +1,13 @@
+using FFXIVClientStructs.FFXIV.Client.Game.DynamicEvent;
 using FFXIVClientStructs.FFXIV.Client.Game.Event;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
 
 [StructLayout(LayoutKind.Explicit, Size = 0xC48)]
-public struct ContentDirector {
+public unsafe struct ContentDirector {
     [FieldOffset(0x00)] public Director Director;
+
+    [FieldOffset(0xBB8)] public DynamicEventManager* DynamicEventManager;
 
     [FieldOffset(0xC08)] public float ContentTimeLeft;
 }


### PR DESCRIPTION
Added DynamicEventManager and DynamicEvent to read the Critical Engagement table inside of Bozja/Zadnor. DynamicEventManager.Instance() returns 0 in any other zone.

While inside of the zone, all 16 entries in the table are fully populated with all data for all possible events (12 Critical Engagements, 3 Duels, and 1 Large Scale Battle) that can spawn there.

I plopped the field in to ContentDirector instead of any of its sub-classes since the DynamicEventManager.Instance() function appears to access the field through what should be `ContentDirector*`.

I also turned it in to an unsafe struct to add my pointer I hope thats ok.