### PR TITLE
Update AtkUnitBase, Add AtkSimpleTween

### DIFF
--- a/FFXIVClientStructs/FFXIV/Common/Math/Bounds.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Math/Bounds.cs
@@ -1,0 +1,22 @@
+using System.Drawing;
+
+namespace FFXIVClientStructs.FFXIV.Common.Math;
+
+[StructLayout(LayoutKind.Explicit, Size = 0x10)]
+public struct Bounds {
+    [FieldOffset(0x0)] public Point Pos1; // Top Left
+    [FieldOffset(0x8)] public Point Pos2; // Bottom Right
+
+    public readonly int Width => Pos2.X - Pos1.X;
+    public readonly int Height => Pos2.Y - Pos1.Y;
+    public readonly Vector2 Size => new(Width, Height);
+
+    public readonly int CenterX => (Pos1.X + Pos2.X) / 2;
+    public readonly int CenterY => (Pos1.Y + Pos2.Y) / 2;
+    public readonly Vector2 Center => new(CenterX, CenterY);
+
+    public readonly bool ContainsPoint(int x, int y) => x >= Pos1.X && x <= Pos2.X && y >= Pos1.Y && y <= Pos2.Y;
+    public readonly bool ContainsPoint(Point p) => ContainsPoint(p.X, p.Y);
+
+    public override string ToString() => $"{Pos1}, {Pos2}";
+}

--- a/FFXIVClientStructs/FFXIV/Common/Math/Vector2.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Math/Vector2.cs
@@ -124,6 +124,7 @@ public struct Vector2 : IEquatable<Vector2>, IFormattable {
 
     public static implicit operator System.Numerics.Vector2(Vector2 v) => new(v.X, v.Y);
     public static implicit operator Vector2(System.Numerics.Vector2 v) => new(v.X, v.Y);
+    public static implicit operator Vector2(System.Drawing.Point p) => new(p.X, p.Y);
 
     public static Vector2 operator +(Vector2 a, Vector2 b) => new(a.X + b.X, a.Y + b.Y);
     public static Vector2 operator -(Vector2 a, Vector2 b) => new(a.X - b.X, a.Y - b.Y);

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentDropDownList.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentDropDownList.cs
@@ -10,6 +10,7 @@ public unsafe partial struct AtkComponentDropDownList {
     [FieldOffset(0xC8)] public AtkComponentList* List;
 
     [FieldOffset(0xD8)] public bool IsOpen;
+    [FieldOffset(0xD9)] public bool OpenStateChangePending;
 
     [MemberFunction("E8 ?? ?? ?? ?? 45 89 3E")]
     public partial void SelectItem(int index);

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
@@ -40,6 +40,10 @@ public enum AtkEventType : byte {
     IconTextRollOut = 57,
     IconTextClick = 58,
 
+    // AtkSimpleTween
+    TweenProgress = 64,
+    TweenComplete = 65,
+
     // AtkComponentWindow
     WindowRollOver = 67,
     WindowRollOut = 68,

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkResNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkResNode.cs
@@ -176,6 +176,9 @@ public unsafe partial struct AtkResNode : ICreatable {
         RemoveEvent((ushort)eventType, eventParam, listener, isSystemEvent);
     }
 
+    [MemberFunction("E8 ?? ?? ?? ?? 8B 5C 24 2C")]
+    public partial void GetBounds(Bounds* outBounds);
+
     [MemberFunction("48 85 C9 74 0B 8B 41 44")]
     public partial void GetPositionFloat(float* outX, float* outY);
 

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkSimpleTween.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkSimpleTween.cs
@@ -1,0 +1,102 @@
+using FFXIVClientStructs.FFXIV.Client.System.Memory;
+
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
+
+// Component::GUI::AtkSimpleTween
+//   Component::GUI::AtkEventTarget
+
+/// <summary>
+/// Runs simple transitions on an AtkResNode.
+/// </summary>
+/// <remarks>
+/// Transitions are calculated with a sinusoidal ease-out function and will run simultaneously.
+/// </remarks>
+[StructLayout(LayoutKind.Explicit, Size = 0x50)]
+public unsafe partial struct AtkSimpleTween : ICreatable {
+    [FieldOffset(0x8)] public SimpleTweenState State;
+    [FieldOffset(0x10)] public AtkResNode* Node;
+    [FieldOffset(0x18)] public float CurrentTimestamp;
+    [FieldOffset(0x1C)] public float Duration;
+    [FieldOffset(0x20)] public StdVector<SimpleTweenAnimation> Animations;
+    [FieldOffset(0x38)] public int Id;
+    [FieldOffset(0x40)] public AtkEvent* Event;
+    [FieldOffset(0x48)] public float EasingFactor;
+
+    [MemberFunction("E8 ?? ?? ?? ?? 89 6B 58")]
+    public partial void Ctor();
+
+    [VirtualFunction(1)]
+    public partial void Dtor();
+
+    [MemberFunction("E9 ?? ?? ?? ?? 48 83 B9 ?? ?? ?? ?? ?? 74 8E")]
+    public partial void Clear();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 44 8B 87 ?? ?? ?? ?? 4C 8B CF")]
+    public partial void Prepare(int duration, AtkResNode* node, SimpleTweenValue* values, uint numValues, float easingFactor = 0.5f);
+
+    [MemberFunction("E8 ?? ?? ?? ?? FF 4F 5C")]
+    public partial void Execute();
+
+    /// <remarks>
+    /// Only <see cref="AtkEventType.TweenProgress"/> and <see cref="AtkEventType.TweenComplete"/> will be dispatched.
+    /// </remarks>
+    [MemberFunction("48 83 EC 48 0F B6 44 24 ?? 4C 8B D1")]
+    public partial void RegisterEvent(AtkEventType eventType, uint eventParam, AtkEventListener* listener, AtkResNode* nodeParam, bool systemEvent);
+
+    [MemberFunction("0F B6 44 24 ?? 48 83 C1 40")]
+    public partial void UnregisterEvent(AtkEventType eventType, uint eventParam, AtkEventListener* listener, bool systemEvent);
+
+    [MemberFunction("48 83 EC 28 0F 57 C0 83 FA 08")]
+    public partial float GetNodeValue(SimpleTweenValueType type);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 5B 08 48 85 DB 75 DF")]
+    public partial void SetNodeValue(SimpleTweenValueType type, float value);
+
+    [MemberFunction("E8 ?? ?? ?? ?? EB 31 48 63 50 38")]
+    public partial void Update(float delta);
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x20)]
+public unsafe struct SimpleTweenAnimation {
+    [FieldOffset(0x0)] public SimpleTweenAnimation* Next;
+    [FieldOffset(0x8)] public SimpleTweenAnimation* Previous;
+    [FieldOffset(0x10)] public SimpleTweenValueType Type;
+    [FieldOffset(0x14)] public float StartValue;
+    [FieldOffset(0x18)] public float Delta; // SimpleTweenValue.Value - StartValue
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x8)]
+public struct SimpleTweenValue {
+    [FieldOffset(0)] public SimpleTweenValueType Type;
+    [FieldOffset(0x4)] public float Value;
+}
+
+public enum SimpleTweenState : uint {
+    None = 0,
+    Tweening = 1,
+    Complete = 2
+}
+
+public enum SimpleTweenValueType : uint {
+    X = 0,
+    Y = 1,
+    ScaleX = 2,
+    ScaleY = 3,
+    /// <remarks>
+    /// Will be converted into two separate SimpleTweenAnimations, ScaleX and ScaleY, with the same value.<br/>
+    /// Can not be used with GetNodeValue or SetNodeValue.
+    /// </remarks>
+    Scale = 4,
+    /// <remarks>
+    /// When the alpha value reaches 0, it will automatically make the node invisible (same as calling <see cref="AtkResNode.ToggleVisibility(bool)"/> with <c>false</c>).<br/>
+    /// In order to make the transition from 0 work, it is necessary to call <see cref="AtkResNode.ToggleVisibility(bool)"/> with <c>true</c> first.
+    /// </remarks>
+    Alpha = 5,
+    Width = 6,
+    Height = 7,
+    /// <remarks>
+    /// When using this, the node must be a <see cref="AtkTextNode"/>, so it can read/write <see cref="AtkTextNode.NodeText"/>.<br/>
+    /// Internally, the value is cast from float to int and then converted to an Utf8String.
+    /// </remarks>
+    NodeText = 8,
+}

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldManager.cs
@@ -37,6 +37,8 @@ public unsafe partial struct AtkUldManager {
     [FieldOffset(0x28)] public ResourceHandle* UldResourceHandle; // addons release this reference, components do not
     [FieldOffset(0x30)] public DuplicateNodeInfo* DuplicateNodeInfoList; // these are nodes duplicated by the loader during load
     [FieldOffset(0x38)] public AtkTimelineManager* TimelineManager;
+    [FieldOffset(0x40)] public ushort DrawOrderIndex;
+    [Obsolete("Use DrawOrderIndex")]
     [FieldOffset(0x40)] public ushort Unk40;
     [FieldOffset(0x42)] public ushort NodeListCount;
     [FieldOffset(0x48)] public void* AtkResourceRendererManager;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1541,6 +1541,10 @@ classes:
   Component::GUI::AtkUnitList:
     vtbls:
       - ea: 0x1419BD640
+    funcs:
+      0x1405435F0: Append
+      0x140543650: Remove
+      0x1405436E0: InsertAfter
   Component::GUI::AtkUnitManager:
     vtbls:
       - ea: 0x1419BD648
@@ -1554,6 +1558,7 @@ classes:
       0x140545540: GetAddonById
       0x1405455A0: GetAddonByName
       0x140545650: GetAddonByNode
+      0x140548A40: UpdateDrawOrderIndexes
   Client::UI::RaptureAtkUnitManager:
     vtbls:
       - ea: 0x1419BD7A0
@@ -3311,6 +3316,20 @@ classes:
     vtbls:
       - ea: 0x141A05B18
         base: Component::GUI::AtkEventTarget
+    vfuncs:
+      1: dtor
+    funcs:
+      0x140515A80: ctor
+      0x140515C40: Prepare
+      0x140515CF0: Execute
+      0x140515DC0: Clear
+      0x140515EA0: RegisterEvent
+      0x140515EE0: UnregisterEvent
+      0x140515F30: SetValues
+      0x140516060: AddAnimation
+      0x140516190: GetNodeValue
+      0x140516320: SetNodeValue
+      0x140516440: Update
   Component::GUI::AtkTexture:
     vtbls:
       - ea: 0x141A05A98
@@ -3340,6 +3359,7 @@ classes:
       0x140519D00: ctor
       0x14053C470: GetSingleton
       0x14053C480: GetSingleton2
+      0x1405486B0: GetSingleton3
       0x1405A0F20: Finalize
   Component::GUI::AtkCursor:
     funcs:
@@ -3401,6 +3421,7 @@ classes:
       0x14052ADF0: RegisterEvent
       0x14052AE30: UnregisterEvent
       0x14052AE70: DispatchEvent
+      0x14052AFD0: GetBounds
       0x14052B1E0: GetPositionFloat
       0x14052B200: SetPositionFloat
       0x14052B250: GetPositionShort
@@ -3439,7 +3460,7 @@ classes:
       0x14052C060: GetIsUsingDepthBasedDrawPriority
       0x14052C080: SetUseDepthBasedDrawPriority
       0x14052C0D0: SetDepth
-      0x14052C4A0: Init
+      0x14052C4A0: Initialize
       0x14052C670: SetScale0  # SetScale jumps to this
       0x140537080: SetSize
       0x14052AD50: GetTimelineLabel
@@ -3523,6 +3544,11 @@ classes:
       16: Hide2
       17: SetScaleToHudLayoutScale
       18: ShouldCollideWithWindow
+      22: ShouldIgnoreInputs
+      23: GetRootNode
+      26: GetWindowBounds
+      29: GetRootBounds
+      36: Focus
       40: Initialize
       41: Finalize
       42: Update
@@ -3531,6 +3557,8 @@ classes:
       48: OnSetup
       50: OnRefresh
       51: OnRequestedUpdate
+      53: FireCloseCallback
+      57: OnOpenTransitionStarted
       61: OnMouseOver
       62: OnMouseOut
     funcs:
@@ -3549,6 +3577,9 @@ classes:
       0x140539CA0: CalculateBounds
       0x14053A470: SetFlag
       0x14053BFD0: Draw
+      0x14053C2D0: LoadUldByName
+      0x14053C3F0: SetOpenTransition
+      0x14053C430: SetCloseTransition
       0x14053C4F0: SubscribeAtkArrayData # handler: "4C 8B D2 48 8B D1 41 83 F9 04"
       0x14053C680: UnsubscribeAtkArrayData # handler: "48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B DA 48 8B F9 41 83 F9 04"
       0x14053C930: SetFocusNode


### PR DESCRIPTION
Notes on AtkSimpleTween:
- AtkSimpleTween can be used on any AtkResNode, not just the RootNode of an AtkUnitBase.
- Can be used to tween values of X, Y, ScaleX, ScaleY, Alpha, Width, Height, or NodeText (on AtkTextNodes only).
- It's fine to call `Clear()` whenever - the animation will simply stop at the current values.
- It's not necessary to unregister events because they will be removed with the next `Prepare` call anyway.
- Any registered event that’s not of type TweenProgress or TweenComplete will be ignored.
- Special case: When the alpha value reaches 0, the node is automatically made invisible (the same as calling `AtkResNode.ToggleVisibility(false)`). To make the transition from 0 work you have to call `AtkResNode.ToggleVisibility(true)` first.

Example to toggle the Alpha value over 2 seconds with optional event dispatching.
```cs
if (ImGui.Button("Tween Alpha")) {
	var currentAlpha = addon->RootNodeTween.GetNodeValue(SimpleTweenValueType.Alpha);
	if (currentAlpha == 0f)
		addon->RootNodeTween.RootNode->ToggleVisibility(true);

	var values = stackalloc SimpleTweenValue[1];
	values[0].Type = SimpleTweenValueType.Alpha;
	values[0].Value = currentAlpha == 1f ? 0f : 1f;
	addon->RootNodeTween.Prepare(2000, addon->RootNode, values, 1);
	addon->RootNodeTween.RegisterEvent(AtkEventType.TweenProgress, 0, (AtkEventListener*)addon, null, false);
	addon->RootNodeTween.RegisterEvent(AtkEventType.TweenComplete, 0, (AtkEventListener*)addon, null, false);
	addon->RootNodeTween.Execute();
}
```