### PR TITLE
Add ReadyToDraw to GameObject

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -85,6 +85,9 @@ public unsafe partial struct GameObject {
     [VirtualFunction(30)]
     public partial void Highlight(ObjectHighlightColor color);
 
+    [VirtualFunction(38)]
+    public partial void SetReadyToDraw();
+
     [VirtualFunction(47)]
     public partial uint GetNpcID(); //TODO: rename to GetNameId
 
@@ -105,6 +108,9 @@ public unsafe partial struct GameObject {
 
     [MemberFunction("E8 ?? ?? ?? ?? 83 4B 70 01")]
     public partial void SetPosition(float x, float y, float z);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 ?? 48 8B 17 45 33 C9")]
+    public partial bool IsReadyToDraw();
 }
 
 public enum ObjectKind : byte {
@@ -129,8 +135,9 @@ public enum ObjectKind : byte {
 
 [Flags]
 public enum ObjectTargetableFlags : byte {
-    IsTargetable = 2,
-    Unk1 = 4, // This flag is used but purpose is unclear
+    IsTargetable = 1 << 1,
+    Unk1 = 1 << 2, // This flag is used but purpose is unclear
+    ReadyToDraw = 1 << 6
 }
 
 public enum ObjectHighlightColor : byte {

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4464,6 +4464,7 @@ classes:
       28: GetDrawObject_2
       29: UpdateRadius
       30: Highlight
+      38: SetReadyToDraw
       39: Update
       47: GetNameId
       57: IsDead
@@ -4478,6 +4479,7 @@ classes:
       0x140749BB0: GetPosition
       0x140749C00: SetPosition
       0x140749CB0: SetRotation
+      0x14074ADD0: IsReadyToDraw
       0x14074D770: Initialize
       0x14074D9D0: ctor
   Client::Game::Character::Character:


### PR DESCRIPTION
Adding some drawing related stuff.

The ReadyToDraw flag is checked when calling `EnableDraw` and it will early exit if the flag is not set.
It's flagged true during an early frame at the top of `Update` on the `GameObject` typically.

Could be argued that it should be called `HasHadFirstUpdate` or `IsReady` similar so if you have a preference for a different name, let me know.

`ObjectTargetableFlags` may need renaming as it appears it contains more state that just whether something can be targeted, but I've left it as is for now (and I'm to blame for the name anyway).