### PR TITLE
Add Character.GazeContainer

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -30,14 +30,7 @@ public unsafe partial struct Character {
     [FieldOffset(0x970)] public ActionTimelineManager ActionTimelineManager;
     [FieldOffset(0xCB0)] public GazeContainer Gaze;
 
-    /// <summary>
-    /// The current target for this character's gaze. Can be set independently of soft or hard targets, and may be set
-    /// by NPCs or minions. For players, an action cast will generally target the LookTarget (which generally will be
-    /// the soft target if set, then the hard target).
-    /// </summary>
-    /// <remarks>
-    /// Unlike other GameObjectIDs, this one appears to be set to fully 0 if the player is not looking at anything.
-    /// </remarks>
+    /// <inheritdoc cref="GazeController.TargetInfo.LookTargetId"/>
     [Obsolete("Use Character.Gaze.Controller.Torso.TargetInfo.LookTargetId")]
     [FieldOffset(0xCB0 + 0x50)] public GameObjectID LookTargetId;
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -31,7 +31,7 @@ public unsafe partial struct Character {
     [FieldOffset(0xCB0)] public GazeContainer Gaze;
 
     /// <inheritdoc cref="GazeController.Gaze.TargetInformation.TargetId"/>
-    [Obsolete("Use Character.Gaze.Controller.Torso.TargetInfo.TargetId")]
+    [Obsolete("Use Character.Gaze.Controller.GazesSpan[0].TargetInfo.TargetId")]
     [FieldOffset(0xCB0 + 0x50)] public GameObjectID LookTargetId;
 
     [FieldOffset(0x12F0)] public VfxContainer Vfx;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -15,20 +15,21 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Character;
 [VTableAddress("48 8D 05 ?? ?? ?? ?? 48 8B D9 48 89 01 48 8D 05 ?? ?? ?? ?? 48 89 81 ?? ?? ?? ?? 48 81 C1 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8D 8B ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8D 8B ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8D 35", 3)]
 public unsafe partial struct Character {
     [FieldOffset(0x0)] public GameObject GameObject;
-
     [FieldOffset(0x1A0)] public CharacterData CharacterData;
 
+    [Obsolete("Use MovementBytes so that the name can be used for a struct in the future.")]
     [FieldOffset(0x210)] public fixed byte Movement[0x420];
+    [FieldOffset(0x210)] public fixed byte MovementBytes[0x420];
     [FieldOffset(0x630)] public EmoteController EmoteController;
-
-
     [FieldOffset(0x670)] public MountContainer Mount;
     [FieldOffset(0x6D8)] public CompanionContainer Companion;
-
     [FieldOffset(0x6F8)] public DrawDataContainer DrawData;
     [FieldOffset(0x8A0)] public OrnamentContainer Ornament;
     [FieldOffset(0x918)] public ReaperShroudContainer ReaperShroud;
+
     [FieldOffset(0x970)] public ActionTimelineManager ActionTimelineManager;
+    [FieldOffset(0xCB0)] public GazeContainer Gaze;
+
     /// <summary>
     /// The current target for this character's gaze. Can be set independently of soft or hard targets, and may be set
     /// by NPCs or minions. For players, an action cast will generally target the LookTarget (which generally will be
@@ -37,17 +38,21 @@ public unsafe partial struct Character {
     /// <remarks>
     /// Unlike other GameObjectIDs, this one appears to be set to fully 0 if the player is not looking at anything.
     /// </remarks>
+    [Obsolete("Use Character.Gaze.Controller.Torso.TargetInfo.LookTargetId")]
     [FieldOffset(0xCB0 + 0x50)] public GameObjectID LookTargetId;
 
     [FieldOffset(0x12F0)] public VfxContainer Vfx;
 
-    [FieldOffset(0x1410)] public byte StatusFlags4;
+    [FieldOffset(0x13E0 + 0x30)] public byte StatusFlags4;
+
     [FieldOffset(0x1418)] public CharacterSetup CharacterSetup;
 
     [FieldOffset(0x1920)] public Balloon Balloon;
 
     [FieldOffset(0x1B28)] public float Alpha;
+
     [FieldOffset(0x1B30)] public Companion* CompanionObject; // minion
+
     [FieldOffset(0x1B40)] public fixed byte FreeCompanyTag[6];
 
     /// <summary>
@@ -125,10 +130,7 @@ public unsafe partial struct Character {
     [MemberFunction("E8 ?? ?? ?? ?? B8 ?? ?? ?? ?? 4C 3B F0")]
     public partial void SetSoftTargetId(GameObjectID id);
 
-    public bool IsMounted() {
-        // inlined as of 6.5
-        return this.Mount.MountId != 0;
-    }
+    public bool IsMounted() => Mount.MountId != 0;
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 4F ?? E8 ?? ?? ?? ?? 48 8B 4C 24 ??")]
     public partial void SetMode(CharacterModes mode, byte modeParam);
@@ -281,6 +283,36 @@ public unsafe partial struct Character {
             ShroudAttacking = 0x01, // On when the character is using a skill from reaper shroud, can be on for a short time without shroud itself being on.
             ShroudActive = 0x02, // On as long as the transformation is enabled.
             ShroudLoading = 0x0100, // On at the start before the VFX is loaded.
+        }
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x620)]
+    public struct GazeContainer {
+        [FieldOffset(0x00)] public void** ContainerVTable;
+        [FieldOffset(0x08)] public BattleChara* OwnerObject;
+        [FieldOffset(0x10)] public GazeController Controller;
+        /// <summary>
+        /// When using /facecamera, this is the rotation of the camera.<br/>
+        /// When editing banner and the character is following the camera (either with head or eyes), this field holds the position of the camera.
+        /// </summary>
+        [FieldOffset(0x5F0)] public Vector3 CameraVector; // maybe Vector4 with unused W field?
+
+        [FieldOffset(0x600)] public byte FaceCameraFlag; // looks like a bitfield but only with one bit used
+
+        [FieldOffset(0x604)] public Vector2 BannerHeadDirection;
+        [FieldOffset(0x60C)] public Vector2 BannerEyesDirection;
+        [FieldOffset(0x614)] public BannerCameraFollowFlags BannerCameraFollowFlag;
+
+        public bool IsFacingCamera {
+            get => (FaceCameraFlag & 0x1) == 0x1;
+            set => FaceCameraFlag |= 0x1;
+        }
+
+        [Flags]
+        public enum BannerCameraFollowFlags : byte {
+            None = 0,
+            Head = 1,
+            Eyes = 2,
         }
     }
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -293,7 +293,7 @@ public unsafe partial struct Character {
         [FieldOffset(0x600)] public byte FaceCameraFlag; // looks like a bitfield but only with one bit used
 
         [FieldOffset(0x604)] public Vector2 BannerHeadDirection;
-        [FieldOffset(0x60C)] public Vector2 BannerEyesDirection;
+        [FieldOffset(0x60C)] public Vector2 BannerEyeDirection;
         [FieldOffset(0x614)] public BannerCameraFollowFlags BannerCameraFollowFlag;
 
         public bool IsFacingCamera {

--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -30,8 +30,8 @@ public unsafe partial struct Character {
     [FieldOffset(0x970)] public ActionTimelineManager ActionTimelineManager;
     [FieldOffset(0xCB0)] public GazeContainer Gaze;
 
-    /// <inheritdoc cref="GazeController.TargetInfo.LookTargetId"/>
-    [Obsolete("Use Character.Gaze.Controller.Torso.TargetInfo.LookTargetId")]
+    /// <inheritdoc cref="GazeController.Gaze.TargetInformation.TargetId"/>
+    [Obsolete("Use Character.Gaze.Controller.Torso.TargetInfo.TargetId")]
     [FieldOffset(0xCB0 + 0x50)] public GameObjectID LookTargetId;
 
     [FieldOffset(0x12F0)] public VfxContainer Vfx;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/GazeController.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/GazeController.cs
@@ -14,7 +14,7 @@ public unsafe partial struct GazeController {
     [VTableAddress("48 8D 05 ?? ?? ?? ?? 48 89 01 33 D2 89 51 18", 3)]
     [StructLayout(LayoutKind.Explicit, Size = 0x1E0)]
     public partial struct Gaze {
-        [FieldOffset(0x10)] public TargetInfo TargetInfo;
+        [FieldOffset(0x10)] public TargetInformation TargetInfo;
         // [FieldOffset(0x38)] public fixed byte Unk38[0x40]; // struct
         // [FieldOffset(0x78)] public fixed byte Unk78[0x28]; // struct
         // [FieldOffset(0xA0)] public Matrix4x4 UnkA0; // maybe?
@@ -22,19 +22,19 @@ public unsafe partial struct GazeController {
         // [FieldOffset(0x120)] public fixed byte Unk120[0x10]; // struct
         // [FieldOffset(0x130)] public fixed byte Unk130[0x10]; // struct
         // [FieldOffset(0x140)] public fixed byte Unk140[0x10]; // struct
-    }
 
-    [VTableAddress("89 51 18 48 8D 05 ?? ?? ?? ?? 48 89 41 10 48 8D 05", 6)]
-    [StructLayout(LayoutKind.Explicit, Size = 0x28)]
-    public partial struct TargetInfo {
-        /// <summary>
-        /// The current target for this character's gaze. Can be set independently of soft or hard targets, and may be set
-        /// by NPCs or minions. For players, an action cast will generally target the LookTarget (which generally will be
-        /// the soft target if set, then the hard target).
-        /// </summary>
-        /// <remarks>
-        /// Unlike other GameObjectIDs, this one appears to be set to fully 0 if the player is not looking at anything.
-        /// </remarks>
-        [FieldOffset(0x10)] public GameObjectID LookTargetId;
+        [VTableAddress("89 51 18 48 8D 05 ?? ?? ?? ?? 48 89 41 10 48 8D 05", 6)]
+        [StructLayout(LayoutKind.Explicit, Size = 0x28)]
+        public partial struct TargetInformation {
+            /// <summary>
+            /// The current target for this character's gaze. Can be set independently of soft or hard targets, and may be set
+            /// by NPCs or minions. For players, an action cast will generally target the LookTarget (which generally will be
+            /// the soft target if set, then the hard target).
+            /// </summary>
+            /// <remarks>
+            /// Unlike other GameObjectIDs, this one appears to be set to fully 0 if the player is not looking at anything.
+            /// </remarks>
+            [FieldOffset(0x10)] public GameObjectID TargetId;
+        }
     }
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/GazeController.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/GazeController.cs
@@ -1,0 +1,40 @@
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
+
+namespace FFXIVClientStructs.FFXIV.Client.Game.Control;
+
+[VTableAddress("48 89 5C 24 ?? 48 8D 05 ?? ?? ?? ?? BA", 8)]
+[StructLayout(LayoutKind.Explicit, Size = 0x5E0)]
+public unsafe partial struct GazeController {
+    [FieldOffset(0x08)] public BattleChara* OwnerObject;
+    [FieldOffset(0x20)] public Gaze Torso;
+    [FieldOffset(0x200)] public Gaze Head;
+    [FieldOffset(0x3E0)] public Gaze Eyes;
+
+    [VTableAddress("48 8D 05 ?? ?? ?? ?? 48 89 01 33 D2 89 51 18", 3)]
+    [StructLayout(LayoutKind.Explicit, Size = 0x1E0)]
+    public partial struct Gaze {
+        [FieldOffset(0x10)] public TargetInfo TargetInfo;
+        // [FieldOffset(0x38)] public fixed byte Unk38[0x40]; // struct
+        // [FieldOffset(0x78)] public fixed byte Unk78[0x28]; // struct
+        // [FieldOffset(0xA0)] public Matrix4x4 UnkA0; // maybe?
+        // [FieldOffset(0xE0)] public Matrix4x4 UnkE0; // maybe?
+        // [FieldOffset(0x120)] public fixed byte Unk120[0x10]; // struct
+        // [FieldOffset(0x130)] public fixed byte Unk130[0x10]; // struct
+        // [FieldOffset(0x140)] public fixed byte Unk140[0x10]; // struct
+    }
+
+    [VTableAddress("89 51 18 48 8D 05 ?? ?? ?? ?? 48 89 41 10 48 8D 05", 6)]
+    [StructLayout(LayoutKind.Explicit, Size = 0x28)]
+    public partial struct TargetInfo {
+        /// <summary>
+        /// The current target for this character's gaze. Can be set independently of soft or hard targets, and may be set
+        /// by NPCs or minions. For players, an action cast will generally target the LookTarget (which generally will be
+        /// the soft target if set, then the hard target).
+        /// </summary>
+        /// <remarks>
+        /// Unlike other GameObjectIDs, this one appears to be set to fully 0 if the player is not looking at anything.
+        /// </remarks>
+        [FieldOffset(0x10)] public GameObjectID LookTargetId;
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/GazeController.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/GazeController.cs
@@ -7,22 +7,24 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Control;
 [VTableAddress("48 89 5C 24 ?? 48 8D 05 ?? ?? ?? ?? BA", 8)]
 [StructLayout(LayoutKind.Explicit, Size = 0x5E0)]
 public unsafe partial struct GazeController {
-    [FieldOffset(0x08)] public BattleChara* OwnerObject;
-    [FieldOffset(0x20)] public Gaze Torso;
-    [FieldOffset(0x200)] public Gaze Head;
-    [FieldOffset(0x3E0)] public Gaze Eyes;
+    [FieldOffset(0x10)] public BattleChara* OwnerObject;
+
+    /// <remarks>
+    /// 0 = Torso<br/>
+    /// 1 = Head<br/>
+    /// 2 = Eyes
+    /// </remarks>
+    [FixedSizeArray<Gaze>(3)]
+    [FieldOffset(0x20)] public fixed byte Gazes[3 * Gaze.Size];
+
+    [FieldOffset(0x5C4)] public int GazesCount;
 
     [VTableAddress("48 8D 05 ?? ?? ?? ?? 48 89 01 33 D2 89 51 18", 3)]
-    [StructLayout(LayoutKind.Explicit, Size = 0x1E0)]
+    [StructLayout(LayoutKind.Explicit, Size = Size)]
     public partial struct Gaze {
+        public const int Size = 0x1E0;
+
         [FieldOffset(0x10)] public TargetInformation TargetInfo;
-        // [FieldOffset(0x38)] public fixed byte Unk38[0x40]; // struct
-        // [FieldOffset(0x78)] public fixed byte Unk78[0x28]; // struct
-        // [FieldOffset(0xA0)] public Matrix4x4 UnkA0; // maybe?
-        // [FieldOffset(0xE0)] public Matrix4x4 UnkE0; // maybe?
-        // [FieldOffset(0x120)] public fixed byte Unk120[0x10]; // struct
-        // [FieldOffset(0x130)] public fixed byte Unk130[0x10]; // struct
-        // [FieldOffset(0x140)] public fixed byte Unk140[0x10]; // struct
 
         [VTableAddress("89 51 18 48 8D 05 ?? ?? ?? ?? 48 89 41 10 48 8D 05", 6)]
         [StructLayout(LayoutKind.Explicit, Size = 0x28)]

--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/GazeController.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/GazeController.cs
@@ -1,5 +1,6 @@
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using FFXIVClientStructs.FFXIV.Common.Math;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game.Control;
 
@@ -26,15 +27,31 @@ public unsafe partial struct GazeController {
         [VTableAddress("89 51 18 48 8D 05 ?? ?? ?? ?? 48 89 41 10 48 8D 05", 6)]
         [StructLayout(LayoutKind.Explicit, Size = 0x28)]
         public partial struct TargetInformation {
+            [FieldOffset(0x8)] public TargetInfoType Type;
+
             /// <summary>
             /// The current target for this character's gaze. Can be set independently of soft or hard targets, and may be set
             /// by NPCs or minions. For players, an action cast will generally target the LookTarget (which generally will be
             /// the soft target if set, then the hard target).
             /// </summary>
             /// <remarks>
+            /// Used when Type is <see cref="TargetInfoType.GameObjectID"/>.<br/>
             /// Unlike other GameObjectIDs, this one appears to be set to fully 0 if the player is not looking at anything.
             /// </remarks>
             [FieldOffset(0x10)] public GameObjectID TargetId;
+
+            /// <remarks>
+            /// Used when Type is <see cref="TargetInfoType.Unk2"/> or <see cref="TargetInfoType.Unk3"/>.
+            /// </remarks>
+            [FieldOffset(0x10)] public Vector3 Unk10;
+            [FieldOffset(0x20)] public int Unk20;
+
+            public enum TargetInfoType {
+                None = 0,
+                GameObjectID = 1,
+                Unk2 = 2,
+                Unk3 = 3,
+            }
         }
     }
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4819,7 +4819,7 @@ classes:
       - ea: 0x141A03250
     funcs:
       0x1404E1A80: ctor
-  Client::Game::Control::GazeController::Gaze::TargetInfo:
+  Client::Game::Control::GazeController::Gaze::TargetInformation:
     vtbls:
       - ea: 0x141A03238
   Client::Game::Character::DrawData:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4748,6 +4748,8 @@ classes:
   Client::Game::Control::EmoteController:
     vtbls:
       - ea: 0x141A1F0F8
+    funcs:
+      0x1404E93C0: Initialize
   Client::Game::Character::DrawDataContainer:
     vtbls:
       - ea: 0x141A1EF20
@@ -4762,6 +4764,7 @@ classes:
     vtbls:
       - ea: 0x141B42EB0
     funcs:
+      0x141312A70: ctor
       0x141312D90: GetCompanionDataID
       0x141312BD0: SetupCompanion
   Client::Game::Character::CharacterSetup:
@@ -4789,7 +4792,10 @@ classes:
     funcs:
       0x14132DAC0: LoadCharacterSound
   Client::Game::Character::MountContainer:
+    vtbls:
+      - ea: 0x141B42ED8
     funcs:
+      0x141312E70: ctor
       0x141313A60: CreateAndSetupMount
       0x141315150: SetupMount
   Client::Game::Character::ReaperShroudContainer:
@@ -4797,6 +4803,25 @@ classes:
       - ea: 0x141A38178
       - ea: 0x141A381A0
         base: Client::Graphics::Vfx::VfxDataListenner
+  Client::Game::Character::GazeContainer:
+    vtbls:
+      - ea: 0x141A1EF70
+    funcs:
+      0x141326C30: ctor
+      0x141326D50: Update
+  Client::Game::Control::GazeController:
+    vtbls:
+      - ea: 0x141A03258
+    funcs:
+      0x140504310: ctor
+  Client::Game::Control::GazeController::Gaze:
+    vtbls:
+      - ea: 0x141A03250
+    funcs:
+      0x1404E1A80: ctor
+  Client::Game::Control::GazeController::Gaze::TargetInfo:
+    vtbls:
+      - ea: 0x141A03238
   Client::Game::Character::DrawData:
     vtbls:
       - ea: 0x141A008D0


### PR DESCRIPTION
It looks like the struct at Character+0xCB0 is used to handle head/eye-tracking, so I called it `GazeContainer`, if that's alright.
I use `BannerHeadDirection` and `BannerEyesDirection` already and wanted to add them, but then I went exploring.
Sadly I couldn't make much sense of it, but at least I learned about the `/facecamera` command which has fields in there (local player only?!). 👀

---

Other small changes on `Character`:
- Copied the field `Character.Movement` (fixed bytes) to `Character.MovementBytes` and marked `Character.Movement` obsolete, so it can be used for a struct in the future. I can also just mark it obsolete and don't make a new field, if thats better.
- Copied `LookTargetId` into `GazeController.TargetInfo` and marked the old one obsolete.
- Changed FieldOffset of `StatusFlags4` to make it easier to see it's inside a struct that hasn't been added yet. Same offset.
- Removed/added new lines based on memory layout.

Also added some ctor functions and vtbls from other Containers to the data.yml.