### PR TITLE
Add Control.IsWalking

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
@@ -7,6 +7,7 @@ public unsafe partial struct Control {
     [FieldOffset(0x00)] public CameraManager CameraManager;
     [FieldOffset(0x180)] public TargetSystem TargetSystem;
 
+    [FieldOffset(0x5A7B)] public bool IsWalking;
     [FieldOffset(0x5AE8)] public uint LocalPlayerObjectId;
     [FieldOffset(0x5AF0)] public BattleChara* LocalPlayer;
 


### PR DESCRIPTION
A boolean that controls whether the local player should walk or not.

It's toggled at "88 83 ?? ?? ?? ?? 0F B6 05".
Technically it's at +0x55B inside some `Client::Game::Control::MoveControl` (located at Control + 0x5520), but this was a speedy commit to beat Kaz, so I didn’t look into it much further. ![WICKED](https://cdn.frankerfacez.com/emoticon/457124/1)