### PR TITLE
First pass of SteamAPI

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
@@ -66,12 +66,18 @@ public unsafe partial struct Framework {
     [FieldOffset(0x2BF0)] public GameVersion GameVersion;
     
     /// <summary>
+    /// Set if <c>IsSteam</c> was set for this instance as part of <c>SetupSteamApi</c>. Set even if loading the Steam API
+    /// fails for some reason.
+    /// </summary>
+    [FieldOffset(0x35B4)] public bool IsSteamGame;
+    
+    /// <summary>
     /// Access the Steam API wrapper/interface.
     /// </summary>
     /// <remarks>
     /// The struct backed by this API should not be considered stable. If you use this, you are signing up for API breakage.
     /// </remarks>
-    [FieldOffset(0x35B8)] public SteamApi SteamApi;
+    [FieldOffset(0x35B8)] public SteamApi* SteamApi;
 
     /// <summary>
     /// Handle (type HMODULE) of steam_api64.dll

--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
@@ -9,6 +9,7 @@ using FFXIVClientStructs.FFXIV.Common.Component.BGCollision;
 using FFXIVClientStructs.FFXIV.Common.Lua;
 using FFXIVClientStructs.FFXIV.Component.Excel;
 using FFXIVClientStructs.FFXIV.Component.Exd;
+using FFXIVClientStructs.FFXIV.Component.SteamApi;
 
 namespace FFXIVClientStructs.FFXIV.Client.System.Framework;
 // Client::System::Framework::Framework
@@ -63,6 +64,14 @@ public unsafe partial struct Framework {
     [FieldOffset(0x2BC8)] public LuaState LuaState;
 
     [FieldOffset(0x2BF0)] public GameVersion GameVersion;
+    
+    /// <summary>
+    /// Access the Steam API wrapper/interface.
+    /// </summary>
+    /// <remarks>
+    /// The struct backed by this API should not be considered stable. If you use this, you are signing up for API breakage.
+    /// </remarks>
+    [FieldOffset(0x35B8)] public SteamApi SteamApi;
 
     /// <summary>
     /// Handle (type HMODULE) of steam_api64.dll
@@ -83,6 +92,14 @@ public unsafe partial struct Framework {
 
     [MemberFunction("E8 ?? ?? ?? ?? 89 47 2C")]
     public static partial long GetServerTime();
+
+    /// <summary>
+    /// Checks if the Steam API has been initialized by checking whether the <see cref="SteamApi"/> pointer is valid,
+    /// and whether the sub-struct reports itself as ready.
+    /// </summary>
+    /// <returns>Returns true if the API is ready, false otherwise.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 88 43 08 84 C0 74 16")]
+    public partial bool IsSteamApiInitialized();
 
     public string GamePath {
         get {

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/AuthSessionTicketResponseCallback.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/AuthSessionTicketResponseCallback.cs
@@ -1,0 +1,10 @@
+namespace FFXIVClientStructs.FFXIV.Component.SteamApi.Callbacks;
+
+[StructLayout(LayoutKind.Explicit, Size = SteamCallbackBase.Size)]
+public unsafe partial struct AuthSessionTicketResponseCallback {
+    [FieldOffset(0x0)] public SteamCallbackBase SteamCallbackBase;
+
+    [VirtualFunction(1)]
+    public partial void Run(SteamTypes.AuthSessionTicketResponse* outResponse);
+}
+

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/AuthSessionTicketResponseCallback.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/AuthSessionTicketResponseCallback.cs
@@ -5,6 +5,6 @@ public unsafe partial struct AuthSessionTicketResponseCallback {
     [FieldOffset(0x0)] public SteamCallbackBase SteamCallbackBase;
 
     [VirtualFunction(1)]
-    public partial void Run(SteamTypes.AuthSessionTicketResponse* outResponse);
+    public partial void Run(SteamTypes.AuthSessionTicketResponse* outCallbackParams);
 }
 

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/FloatingGamepadTextInputDismissedCallback.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/FloatingGamepadTextInputDismissedCallback.cs
@@ -1,0 +1,10 @@
+namespace FFXIVClientStructs.FFXIV.Component.SteamApi.Callbacks;
+
+[StructLayout(LayoutKind.Explicit, Size = SteamCallbackBase.Size)]
+public unsafe partial struct FloatingGamepadTextInputDismissedCallback {
+    [FieldOffset(0x0)] public SteamCallbackBase SteamCallbackBase;
+
+    // doesn't actually send any data back - just called when closed.
+    [VirtualFunction(1)]
+    public partial void Run(void* outData);
+}

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/FloatingGamepadTextInputDismissedCallback.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/FloatingGamepadTextInputDismissedCallback.cs
@@ -4,7 +4,10 @@ namespace FFXIVClientStructs.FFXIV.Component.SteamApi.Callbacks;
 public unsafe partial struct FloatingGamepadTextInputDismissedCallback {
     [FieldOffset(0x0)] public SteamCallbackBase SteamCallbackBase;
 
-    // doesn't actually send any data back - just called when closed.
+    /// <summary>
+    /// Callback to fire when the floating gamepad text input was dismissed.
+    /// </summary>
+    /// <param name="outCallbackParams">Unused by this callback.</param>
     [VirtualFunction(1)]
-    public partial void Run(void* outData);
+    public partial void Run(void* outCallbackParams);
 }

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/GamepadTextInputDismissedCallback.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/GamepadTextInputDismissedCallback.cs
@@ -5,5 +5,5 @@ public unsafe partial struct GamepadTextInputDismissedCallback {
     [FieldOffset(0x0)] public SteamCallbackBase SteamCallbackBase;
 
     [VirtualFunction(1)]
-    public partial void Run(SteamTypes.GamepadTextInputDismissedData* outData);
+    public partial void Run(SteamTypes.GamepadTextInputDismissedData* outCallbackParams);
 }

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/GamepadTextInputDismissedCallback.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/Callbacks/GamepadTextInputDismissedCallback.cs
@@ -1,0 +1,9 @@
+namespace FFXIVClientStructs.FFXIV.Component.SteamApi.Callbacks;
+
+[StructLayout(LayoutKind.Explicit, Size = SteamCallbackBase.Size)]
+public unsafe partial struct GamepadTextInputDismissedCallback {
+    [FieldOffset(0x0)] public SteamCallbackBase SteamCallbackBase;
+
+    [VirtualFunction(1)]
+    public partial void Run(SteamTypes.GamepadTextInputDismissedData* outData);
+}

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamApi.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamApi.cs
@@ -50,4 +50,12 @@ public unsafe partial struct SteamApi {
 
     [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 48 8B E9 41 8B D9 48 8D 0D ?? ?? ?? ?? 41 8B F8")]
     public partial bool ShowFloatingGamepadTextInput(int fieldXPosition, int fieldYPosition, int textFieldWidth, int textFieldHeight);
+
+    /// <summary>
+    /// Method called by <see cref="GamepadTextInputDismissedCallback"/> when the gamepad text input has returned.
+    /// Stores results in <see cref="VirtualKeyboardEnteredText"/>, and sets <see cref="VirtualKeyboardOpened"/> to false.
+    /// </summary>
+    /// <param name="callbackEvent">The callback event that triggered this dump</param>
+    [MemberFunction("40 53 48 83 EC 20 80 3A 00")]
+    public partial void DumpEnteredGamepadText(SteamTypes.GamepadTextInputDismissedData* callbackEvent);
 }

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamApi.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamApi.cs
@@ -1,0 +1,53 @@
+using FFXIVClientStructs.FFXIV.Client.System.String;
+using FFXIVClientStructs.FFXIV.Component.SteamApi.Callbacks;
+
+namespace FFXIVClientStructs.FFXIV.Component.SteamApi;
+
+/// <remarks>
+/// This struct <b><em>WILL</em></b> break! I make no guarantees about the API of this struct <em>at all</em>.
+/// You are on your own.
+/// </remarks>
+[StructLayout(LayoutKind.Explicit, Size = 0x4D0)]
+public unsafe partial struct SteamApi {
+    // 0x0 to 0x400 appears to be blank space, though some references to AuthTicket and FriendsList do exist.
+    
+    [FieldOffset(0x408)] public bool SteamApiInitialized;
+
+    [FieldOffset(0x40C)] public float TimeSinceLastCallbackRun;
+    [FieldOffset(0x410)] public uint SteamAppId;
+    [FieldOffset(0x414)] public SteamTypes.CSteamId SteamLocalUserId;
+    
+    // invalid ptr - steam says not to store the byte* ptr they return. SE does.
+    [FieldOffset(0x420)] public void* PersonaNamePtr;
+
+    [FieldOffset(0x428)] public bool AuthTicketPresent;
+    [FieldOffset(0x42C)] public SteamTypes.AuthSessionTicketResponse AuthTicket;
+
+    // set to true if the virtual keyboard was opened but a callback that it's closed has yet to be received
+    [FieldOffset(0x434)] public bool VirtualKeyboardOpened;
+    
+    // only populated by GamepadTextInputDismissed
+    [FieldOffset(0x438)] public Utf8String VirtualKeyboardEnteredText;
+
+    [FieldOffset(0x4A0)] public AuthSessionTicketResponseCallback AuthSessionTicketResponseCallback;
+    [FieldOffset(0x4B0)] public FloatingGamepadTextInputDismissedCallback FloatingGamepadTextInputDismissedCallback;
+    [FieldOffset(0x4C0)] public GamepadTextInputDismissedCallback GamepadTextInputDismissedCallback;
+    
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B D8 48 8B CB 48 89 9F")]
+    public partial void Ctor();
+
+    [MemberFunction("48 89 5C 24 ?? 57 48 83 EC 20 48 8B D9 FF 15 ?? ?? ?? ?? 48 8D 8B")]
+    public partial void Dtor();
+
+    [MemberFunction("48 83 EC 28 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 8B 08")]
+    public partial int GetSteamServerTime();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 45 48 8D 15")]
+    public partial bool IsRunningOnSteamDeck();
+
+    [MemberFunction("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 48 8B F1 8B FA 48 81 C1")]
+    public partial bool ShowGamepadTextInput(int maxChars);
+
+    [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 48 8B E9 41 8B D9 48 8D 0D ?? ?? ?? ?? 41 8B F8")]
+    public partial bool ShowFloatingGamepadTextInput(int fieldXPosition, int fieldYPosition, int textFieldWidth, int textFieldHeight);
+}

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamCallbackBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamCallbackBase.cs
@@ -25,5 +25,7 @@ public unsafe partial struct SteamCallbackBase {
         
     [VirtualFunction(3)]
     public partial void Dtor(bool freeMemory);
+
+    public bool IsRegistered => Flags.HasFlag(SteamCallbackFlags.Registered);
 }
 

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamCallbackBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamCallbackBase.cs
@@ -7,18 +7,23 @@ public unsafe partial struct SteamCallbackBase {
     [Flags]
     public enum SteamCallbackFlags : byte {
         Registered = 1 << 0,
-        GameServer = 2 << 0,  // unused
+        GameServer = 1 << 1,  // unused
     }
         
     [FieldOffset(0x0)] public void** vtbl;
     [FieldOffset(0x8)] public SteamCallbackFlags Flags;
-    [FieldOffset(0xC)] public int CallbackId;
+    [FieldOffset(0xC)] public int CallbackId; 
 
+    /// <remarks>
+    /// This method just calls <see cref="Run"/> in virtually all cases. Additionally, thanks to some SteamAPI
+    /// shenanigans, vf0 and vf1 may be swapped on occasion. This shouldn't realistically matter ever, but
+    /// worth noting. Just use <see cref="Run"/>.
+    /// </remarks>
     [VirtualFunction(0)]
-    public partial void RunExtended(void* param, bool bIoFailure, long hSteamApiCall);
+    public partial void RunExtended(void* outCallbackParams, bool bIoFailure, long hSteamApiCall);
 
     [VirtualFunction(1)]
-    public partial void Run(void* param);
+    public partial void Run(void* outCallbackParams);
 
     [VirtualFunction(2)]
     public partial nint GetSize();

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamCallbackBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamCallbackBase.cs
@@ -1,0 +1,29 @@
+namespace FFXIVClientStructs.FFXIV.Component.SteamApi;
+
+[StructLayout(LayoutKind.Explicit, Size = Size)]
+public unsafe partial struct SteamCallbackBase {
+    public const int Size = 0x10;
+    
+    [Flags]
+    public enum SteamCallbackFlags : byte {
+        Registered = 1 << 0,
+        GameServer = 2 << 0,  // unused
+    }
+        
+    [FieldOffset(0x0)] public void** vtbl;
+    [FieldOffset(0x8)] public SteamCallbackFlags Flags;
+    [FieldOffset(0xC)] public int CallbackId;
+
+    [VirtualFunction(0)]
+    public partial void RunExtended(void* param, bool bIoFailure, long hSteamApiCall);
+
+    [VirtualFunction(1)]
+    public partial void Run(void* param);
+
+    [VirtualFunction(2)]
+    public partial nint GetSize();
+        
+    [VirtualFunction(3)]
+    public partial void Dtor(bool freeMemory);
+}
+

--- a/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamTypes.cs
+++ b/FFXIVClientStructs/FFXIV/Component/SteamApi/SteamTypes.cs
@@ -1,0 +1,26 @@
+namespace FFXIVClientStructs.FFXIV.Component.SteamApi;
+
+public static class SteamTypes {
+    [StructLayout(LayoutKind.Explicit, Size = 0x8)]
+    public struct AuthSessionTicketResponse {
+        [FieldOffset(0x0)] public uint HAuthTicket;
+        [FieldOffset(0x4)] public int EResult; // really a Steam enum, not included for brevity's sake.
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x12)]
+    public struct GamepadTextInputDismissedData {
+        [FieldOffset(0x0)] public bool Submitted;
+        [FieldOffset(0x4)] public uint SubmittedTextSize; // really "m_UnsubmittedText"
+        [FieldOffset(0x8)] public uint AppId;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x8)]
+    public struct CSteamId {
+        [FieldOffset(0x0)] public ulong RawSteamId;
+
+        public byte Universe => (byte)((RawSteamId >> 56) & 0xFF);
+        public uint AccountId => (uint)(RawSteamId & 0xFFFFFFFF);
+        public uint AccountType => (byte)((RawSteamId >> 52) & 0xF);
+        public uint AccountInstance => (uint)((RawSteamId >> 32) & 0xFFFFF);
+    }
+}

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -12542,7 +12542,7 @@ classes:
       0x140634F90: IsRunningOnSteamDeck
       0x140634FD0: ShowGamepadTextInput
       0x140635050: ShowFloatingGamepadTextInput
-      0x1406350F0: GetEnteredGamepadText
+      0x1406350F0: DumpEnteredGamepadText
   Component::SteamApi::SteamCallbackBase:
     vtbls:
       - ea: 0x141A16B10  # the true vtbl

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -52,6 +52,10 @@ globals:
   0x1421FBFB8: g_Client::Game::UI::Chain.RemainingTime # not a pointer
   0x1421FBFBC: g_Client::Game::UI::Chain.MaxTime # not a pointer
   0x1422152D0: g_Conditions # bool array, size is Condition sheet row count
+  0x1421741D0: g_Component::SteamApi::InterfaceContext::ISteamFriends
+  0x1421741B8: g_Component::SteamApi::InterfaceContext::ISteamUser
+  0x142174200: g_Component::SteamApi::InterfaceContext::ISteamApps
+  0x1421741E8: g_Component::SteamApi::InterfaceContext::ISteamUtils
   0x1421AC1D0: g_SomeOtherRenderingState
   0x1421BE514: g_InvSqrt3
   0x142188E28: g_OodleNew
@@ -1526,7 +1530,9 @@ classes:
       0x1400950E0: TaskHousingEvent
       0x1400950F0: TaskResourceManager
       0x140095100: TaskUpdateGame
-      0x140095930: InitSteamApi
+      0x140095930: SetupSteamApi
+      0x140095A60: TeardownSteamApi
+      0x140095AC0: IsSteamApiInitialized
       0x140095F20: Finalize
       0x140097390: GetSavePath
   Component::Excel::ExcelModuleInterface:
@@ -12523,6 +12529,64 @@ classes:
     funcs:
       0x14144EB50: ctor
       0x14144ECD0: Finalize
+  Component::SteamApi::SteamApi:
+    funcs:
+      0x140634AC0: ctor
+      0x140634BC0: dtor
+      0x140634C40: SteamApiInit
+      0x140634D70: RunSteamCallbacks
+      0x140634DB0: EndAuthSession
+      0x140634E20: ClearSessionData
+      0x140634E60: GetDLCData
+      0x140634F60: GetSteamServerTime  # static
+      0x140634F90: IsRunningOnSteamDeck
+      0x140634FD0: ShowGamepadTextInput
+      0x140635050: ShowFloatingGamepadTextInput
+      0x1406350F0: GetEnteredGamepadText
+  Component::SteamApi::SteamCallbackBase:
+    vtbls:
+      - ea: 0x141A16B10  # the true vtbl
+    vfuncs:
+      0: RunExtended  # (void* param, bool bIoFailure, long hSteamApiCall);
+      1: Run          # (void* param)
+      2: GetSize
+      3: Dtor
+  Component::SteamApi::SteamCallbackBase2:
+    vtbls: 
+      - ea: 0x141A16B50
+        base: Component::SteamApi::SteamCallbackBase
+  Component::SteamApi::Callbacks::AuthSessionTicketResponseCallback:
+    vtbls:
+      - ea: 0x141A16B30
+        base: Component::SteamApi::SteamCallbackBase
+  Component::SteamApi::Callbacks::FloatingGamepadTextInputDismissedCallback:
+    vtbls:
+      - ea: 0x141A16B70
+        base: Component::SteamApi::SteamCallbackBase2
+  Component::SteamApi::Callbacks::GamepadTextInputDismissedCallback:
+    vtbls:
+      - ea: 0x141A16B90
+        base: Component::SteamApi::SteamCallbackBase
+  Component::SteamApi::Interface::ISteamApps:
+    instances:
+      - ea: 0x142174200
+    funcs:
+      0x140635400: GetInterface
+  Component::SteamApi::Interface::ISteamFriends:
+    instances:
+      - ea: 0x1421741D0
+    funcs:
+      0x140635430: GetInterface
+  Component::SteamApi::Interface::ISteamUser:
+    instances:
+      - ea: 0x1421741B8
+    funcs:
+      0x140635460: GetInterface
+  Component::SteamApi::Interface::ISteamUtils:
+    instances:
+      - ea: 0x1421741E8
+    funcs:
+      0x140635490: GetInterface
   Client::Game::Object::HousingObject:
     vtbls:
       - ea: 0x141C2E500


### PR DESCRIPTION
Creates a new `Component::SteamApi`, as I'm not really sure where else this stuff belongs.

The SteamAPI code appears to have been at least partially generated via templates/macros, and as such things may not be reflected properly.