### PR TITLE
CExporter: export char as wchar_t

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonAOZNotebook.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonAOZNotebook.cs
@@ -61,7 +61,7 @@ public unsafe struct AddonAOZNotebook {
         [FieldOffset(0x20)] public AtkTextNode* AtkTextNode;
         [FieldOffset(0x28)] public AtkResNode* AtkResNode1;
         [FieldOffset(0x30)] public AtkResNode* AtkResNode2;
-        [FieldOffset(0x38)] public char* Name;
+        [FieldOffset(0x38)] public char* Name; // TODO: change to byte*
         [FieldOffset(0x40)] public uint ActionID;
     }
 
@@ -69,7 +69,7 @@ public unsafe struct AddonAOZNotebook {
     public struct ActiveActions {
         [FieldOffset(0x0)] public AtkComponentDragDrop* AtkComponentDragDrop;
         [FieldOffset(0x8)] public AtkTextNode* AtkTextNode;
-        [FieldOffset(0x10)] public char* Name;
+        [FieldOffset(0x10)] public char* Name; // TODO: change to byte*
         [FieldOffset(0x18)] public int ActionID;
     }
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonRecipeNote.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonRecipeNote.cs
@@ -184,27 +184,27 @@ public unsafe struct AddonRecipeNote {
     [FieldOffset(0x810)] public AtkComponentTextInput* Unk810;
     [FieldOffset(0x818)] public AddonRecipeNote* this818;
 
-    [FieldOffset(0xB50)] public char* UnkB50;
-    [FieldOffset(0xB60)] public char* UnkB60;
-    [FieldOffset(0xB70)] public char* UnkB70;
-    [FieldOffset(0xB80)] public char* UnkB80;
-    [FieldOffset(0xB90)] public char* UnkB90;
-    [FieldOffset(0xBA0)] public char* UnkBA0;
-    [FieldOffset(0xBB0)] public char* UnkBB0;
-    [FieldOffset(0xBC0)] public char* UnkBC0;
-    [FieldOffset(0xBD0)] public char* UnkBD0;
-    [FieldOffset(0xBE0)] public char* UnkBE0;
-    [FieldOffset(0xBF0)] public char* UnkBF0;
-    [FieldOffset(0xC00)] public char* UnkC00;
-    [FieldOffset(0xC10)] public char* UnkC10;
+    [FieldOffset(0xB50)] public char* UnkB50; // TODO: change to byte*
+    [FieldOffset(0xB60)] public char* UnkB60; // TODO: change to byte*
+    [FieldOffset(0xB70)] public char* UnkB70; // TODO: change to byte*
+    [FieldOffset(0xB80)] public char* UnkB80; // TODO: change to byte*
+    [FieldOffset(0xB90)] public char* UnkB90; // TODO: change to byte*
+    [FieldOffset(0xBA0)] public char* UnkBA0; // TODO: change to byte*
+    [FieldOffset(0xBB0)] public char* UnkBB0; // TODO: change to byte*
+    [FieldOffset(0xBC0)] public char* UnkBC0; // TODO: change to byte*
+    [FieldOffset(0xBD0)] public char* UnkBD0; // TODO: change to byte*
+    [FieldOffset(0xBE0)] public char* UnkBE0; // TODO: change to byte*
+    [FieldOffset(0xBF0)] public char* UnkBF0; // TODO: change to byte*
+    [FieldOffset(0xC00)] public char* UnkC00; // TODO: change to byte*
+    [FieldOffset(0xC10)] public char* UnkC10; // TODO: change to byte*
 
-    [FieldOffset(0x2138)] public char* Unk2138;
-    [FieldOffset(0x2140)] public char* Unk2140;
-    [FieldOffset(0x2148)] public char* Unk2148;
-    [FieldOffset(0x2150)] public char* Unk2150;
-    [FieldOffset(0x2158)] public char* Unk2158;
-    [FieldOffset(0x2160)] public char* Unk2160;
-    [FieldOffset(0x2168)] public char* Unk2168;
-    [FieldOffset(0x2170)] public char* Unk2170;
-    [FieldOffset(0x2178)] public char* Unk2178;
+    [FieldOffset(0x2138)] public char* Unk2138; // TODO: change to byte*
+    [FieldOffset(0x2140)] public char* Unk2140; // TODO: change to byte*
+    [FieldOffset(0x2148)] public char* Unk2148; // TODO: change to byte*
+    [FieldOffset(0x2150)] public char* Unk2150; // TODO: change to byte*
+    [FieldOffset(0x2158)] public char* Unk2158; // TODO: change to byte*
+    [FieldOffset(0x2160)] public char* Unk2160; // TODO: change to byte*
+    [FieldOffset(0x2168)] public char* Unk2168; // TODO: change to byte*
+    [FieldOffset(0x2170)] public char* Unk2170; // TODO: change to byte*
+    [FieldOffset(0x2178)] public char* Unk2178; // TODO: change to byte*
 }

--- a/ida/CExporter/Extensions.cs
+++ b/ida/CExporter/Extensions.cs
@@ -21,8 +21,8 @@ public static class TypeExtensions {
     public static string FixTypeName(this Type type, Func<Type, bool, string> unhandled, bool shouldLower = true) =>
         type switch {
             _ when type == typeof(void) || type == typeof(void*) || type == typeof(void**) ||
-                   type == typeof(char) || type == typeof(char*) || type == typeof(char**) ||
                    type == typeof(byte) || type == typeof(byte*) || type == typeof(byte**) => shouldLower ? type.Name.ToLower() : type.Name,
+            _ when type == typeof(char) => "wchar_t",
             _ when type == typeof(bool) => "bool",
             _ when type == typeof(float) => "float",
             _ when type == typeof(double) => "double",
@@ -33,6 +33,7 @@ public static class TypeExtensions {
             _ when type == typeof(uint) => "unsigned __int32",
             _ when type == typeof(ulong) || type == typeof(nuint) => "unsigned __int64",
             _ when type == typeof(sbyte) => "signed __int8",
+            _ when type == typeof(char*) => "wchar_t*",
             _ when type == typeof(short*) => "__int16*",
             _ when type == typeof(ushort*) => "unsigned __int16*",
             _ when type == typeof(int*) => "__int32*",
@@ -48,7 +49,7 @@ public static class TypeExtensions {
         // Marshal.SizeOf doesn't work correctly because the assembly is unmarshaled, and more specifically, it sets booleans as 4 bytes long...
         return type switch {
             _ when type == typeof(sbyte) || type == typeof(byte) || type == typeof(bool) => 1,
-            _ when type == typeof(short) || type == typeof(ushort) || type == typeof(Half) => 2,
+            _ when type == typeof(char) || type == typeof(short) || type == typeof(ushort) || type == typeof(Half) => 2,
             _ when type == typeof(int) || type == typeof(uint) || type == typeof(float) => 4,
             _ when type == typeof(long) || type == typeof(ulong) || type == typeof(double) || type.IsPointer || type.IsFunctionPointer || type.IsUnmanagedFunctionPointer || (type.Name == "Pointer`1" && type.Namespace == ExporterStatics.InteropNamespacePrefix[..^1]) => 8,
             _ when type.IsStruct() => type.StructLayoutAttribute?.Size ?? (int?)typeof(Unsafe).GetMethod("SizeOf")?.MakeGenericMethod(type).Invoke(null, null) ?? 0,


### PR DESCRIPTION
C#'s `char` type is UTF-16, so it's size is 2 bytes.
This PR changes CExporter to export C#'s `char` as `wchar_t`.

Since there are no `char**` fields I didn't add a case for it. 🤷‍♂️

I added some TODO comments to change `char*` to `byte*`, as I can't imagine that they are UTF-16.