### PR TITLE
Small FixedStringGenerator cleanup

### DIFF
--- a/FFXIVClientStructs.InteropSourceGenerators/FixedStringGenerator.cs
+++ b/FFXIVClientStructs.InteropSourceGenerators/FixedStringGenerator.cs
@@ -83,7 +83,7 @@ internal sealed class FixedStringGenerator : IIncrementalGenerator {
         }
 
         public void RenderFixedString(IndentedStringBuilder builder) {
-            builder.AppendLine($"public string {PropertyName} {{ get {{ fixed (byte* p = {FieldName}) {{ var str = Encoding.UTF8.GetString(p, {MaxLength}); var nullIdx = str.IndexOf('\0'); return nullIdx >= 0 ? str[..nullIdx] : str; }} }} }}");
+            builder.AppendLine($"public string {PropertyName} {{ get {{ fixed (byte* ptr = {FieldName}) {{ var str = Encoding.UTF8.GetString(ptr, {MaxLength:X}); var nullIdx = str.IndexOf('\\0'); return nullIdx >= 0 ? str[..nullIdx] : str; }} }} }}");
         }
     }
 
@@ -91,7 +91,6 @@ internal sealed class FixedStringGenerator : IIncrementalGenerator {
         public string RenderSource() {
             IndentedStringBuilder builder = new();
 
-            builder.AppendLine("using System.Runtime.CompilerServices;");
             builder.AppendLine("using System.Text;");
 
             StructInfo.RenderStart(builder);


### PR DESCRIPTION
Just some small changes:

- Escaped the null terminator for the generated code
Before:
![before](https://github.com/aers/FFXIVClientStructs/assets/96642047/d97a0f2c-d97c-4c13-b642-473dd4727c64)
After:
![after](https://github.com/aers/FFXIVClientStructs/assets/96642047/aab114fb-7fdc-4708-a25b-eab1cd6d1155)
- Renamed `p` to `ptr`
- Using hex format for max length
- Removed an unused `using` statement