### PR TITLE
Add PvpSetModule

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/PvpSetModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/PvpSetModule.cs
@@ -1,0 +1,22 @@
+using FFXIVClientStructs.FFXIV.Client.UI.Misc.UserFileManager;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
+
+// The struct layout is purely speculative, as additional PvP actions were removed from the game.
+
+// Client::UI::Misc::PvpSetModule
+//   Client::UI::Misc::UserFileManager::UserFileEvent
+// ctor "E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 48 8B D7 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 48 8B D7 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4"
+[StructLayout(LayoutKind.Explicit, Size = 0x98)]
+public unsafe partial struct PvpSetModule {
+    [FieldOffset(0)] public UserFileEvent UserFileEvent;
+    [FixedSizeArray<AdditionalPvpActions>(20)]
+    [FieldOffset(0x40)] public fixed byte AdditionalActions[20 * 2 * 0x2];
+    [FieldOffset(0x90)] internal byte Unk90;
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x4)]
+    public struct AdditionalPvpActions {
+        [FieldOffset(0)] public ushort ActionId1;
+        [FieldOffset(2)] public ushort ActionId2;
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
@@ -98,6 +98,9 @@ public unsafe partial struct UIModule {
     [VirtualFunction(32)]
     public partial RecommendEquipModule* GetRecommendEquipModule();
 
+    [VirtualFunction(33)]
+    public partial PvpSetModule* GetPvpSetModule();
+
     [VirtualFunction(34)]
     public partial InfoModule* GetInfoModule();
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4987,6 +4987,12 @@ classes:
       0x140629CB0: Finalize
       0x14062A3E0: Update
       0x14062A860: HandleInputUpdate
+  Client::UI::Misc::PvpSetModule:
+    vtbls:
+      - ea: 0x141A1C7D0
+        base: Client::UI::Misc::UserFileManager::UserFileEvent
+    funcs:
+      0x1406BF860: ctor
   Client::System::Crypt::SimpleString:
     vtbls:
       - ea: 0x141A16880


### PR DESCRIPTION
This module stores - or rather stored - the selected additional PvP actions in a `PVPSET.DAT`.
Additional PvP actions have long since been removed from the game, so this struct layout is purely speculative and based on the ctor and ids I found in memory.
The index in the `AdditionalActions` array could've been the `JobIndex` column of the `ClassJob` row.