### PR TITLE
Add MountListModule

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/MountListModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/MountListModule.cs
@@ -1,0 +1,65 @@
+using FFXIVClientStructs.FFXIV.Client.UI.Misc.UserFileManager;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
+
+// Client::UI::Misc::MountListModule
+//   Client::UI::Misc::UserFileManager::UserFileEvent
+// ctor "E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 48 8D 8F ?? ?? ?? ?? 49 8B D4 E8 ?? ?? ?? ?? 33 C0"
+[StructLayout(LayoutKind.Explicit, Size = 0x98)]
+public unsafe partial struct MountListModule {
+    [FieldOffset(0)] public UserFileEvent UserFileEvent;
+    // [FieldOffset(0x40)] public byte Unk40; // set to 1 in ReadFile
+    [FieldOffset(0x42)] public fixed ushort UnseenMounts[10]; // Order column of Mount sheet, offset by 1
+    [FieldOffset(0x56)] public fixed ushort Favorites[30]; // Order column of Mount sheet, offset by 1
+    // [FieldOffset(0x92)] public uint Unk92;
+
+    [MemberFunction("48 83 EC 28 44 0F B7 DA")]
+    public partial bool AddToUnseenMounts(ushort orderId);
+
+    [MemberFunction("48 83 EC 28 32 C0")]
+    public partial bool RemoveFromUnseenMounts(ushort orderId);
+
+    [MemberFunction("48 83 EC 28 44 0F B7 D2 4C 8B C9 45 32 C0 66 90 41 0F B6 C0 66 83 7C 41 ?? ?? 74 10 41 FE C0 41 80 F8 1E 72 EB 33 C0 48 83 C4 28 C3 32 C9 45 0F B7 C2")]
+    public partial bool AddToFavorites(ushort orderId);
+
+    [MemberFunction("48 83 EC 28 45 32 C0 44 0F B7 CA")]
+    public partial bool RemoveFromFavorites(ushort orderId);
+
+    private Span<ushort> FavoritesSpan {
+        get {
+            fixed (ushort* ptr = &Favorites[0]) {
+                return new Span<ushort>(ptr, 30);
+            }
+        }
+    }
+
+    public bool SwapFavorites(int favoriteSlotIndex1, int favoriteSlotIndex2) {
+        if (favoriteSlotIndex1 >= 30 || favoriteSlotIndex2 >= 30)
+            return false;
+        (Favorites[favoriteSlotIndex1], Favorites[favoriteSlotIndex2]) = (Favorites[favoriteSlotIndex2], Favorites[favoriteSlotIndex1]);
+        UserFileEvent.IsSavePending = true;
+        UserFileEvent.SaveFile(false);
+        return true;
+    }
+
+    public bool IsFavorite(ushort orderId) {
+        foreach (ref var fav in FavoritesSpan)
+            if (fav == orderId + 1)
+                return true;
+        return false;
+    }
+
+    public bool HasAnyFavorites() {
+        foreach (ref var fav in FavoritesSpan)
+            if (fav != 0)
+                return true;
+        return false;
+    }
+
+    public bool HasFreeFavoriteSlots() {
+        foreach (ref var fav in FavoritesSpan)
+            if (fav == 0)
+                return true;
+        return false;
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
@@ -116,6 +116,9 @@ public unsafe partial struct UIModule {
     [VirtualFunction(38)]
     public partial UI3DModule* GetUI3DModule();
 
+    [VirtualFunction(43)]
+    public partial MountListModule* GetMountListModule();
+
     [VirtualFunction(49)]
     public partial FieldMarkerModule* GetFieldMarkerModule();
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4958,6 +4958,7 @@ classes:
       34: GetInfoModule
       36: GetAgentModule
       38: GetUI3DModule
+      43: GetMountListModule
       55: GetInputTimerModule
       57: GetRetainerCommentModule
       58: GetBannerModule
@@ -5044,6 +5045,23 @@ classes:
       0x140629CB0: Finalize
       0x14062A3E0: Update
       0x14062A860: HandleInputUpdate
+  Client::UI::Misc::MountListModule:
+    vtbls:
+      - ea: 0x141A1C918
+        base: Client::UI::Misc::UserFileManager::UserFileEvent
+    funcs:
+      0x1406C1570: ctor
+      0x1406C1860: GetUnseenMountPtrById
+      0x1406C18B0: GetUnseenMountPtr
+      0x1406C18D0: AddToUnseenMounts
+      0x1406C1980: RemoveFromUnseenMounts
+      0x1406C1A30: GetFavoritePtrById
+      0x1406C1A80: GetFavoritePtr
+      0x1406C1AA0: AddToFavorites
+      0x1406C1B60: RemoveFromFavorites
+      0x1406C1BE0: SwapFavorites
+      0x1406C1C30: HasAnyFavorites
+      0x1406C1C50: HasFreeFavoriteSlots
   Client::System::Crypt::SimpleString:
     vtbls:
       - ea: 0x141A16880

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4959,6 +4959,7 @@ classes:
       36: GetAgentModule
       38: GetUI3DModule
       43: GetMountListModule
+      44: GetEmjModule
       55: GetInputTimerModule
       57: GetRetainerCommentModule
       58: GetBannerModule
@@ -5062,6 +5063,12 @@ classes:
       0x1406C1BE0: SwapFavorites
       0x1406C1C30: HasAnyFavorites
       0x1406C1C50: HasFreeFavoriteSlots
+  Client::UI::Misc::EmjModule:
+    vtbls:
+      - ea: 0x141A1C980
+        base: Client::UI::Misc::UserFileManager::UserFileEvent
+    funcs:
+      0x1406C1DA0: ctor
   Client::System::Crypt::SimpleString:
     vtbls:
       - ea: 0x141A16880


### PR DESCRIPTION
This manager stores unseen and favorite mounts in a `MUNTLST.DAT`.
Couldn't generate reliable signatures for some functions, so I had to add some code for them.

Also sneaked in EmjModule (added to data.yml only). It's unused and doesn't store any data.