### PR TITLE
FixedStringGenerator cleanup hotfix

### DIFF
--- a/FFXIVClientStructs.InteropSourceGenerators/FixedStringGenerator.cs
+++ b/FFXIVClientStructs.InteropSourceGenerators/FixedStringGenerator.cs
@@ -83,7 +83,7 @@ internal sealed class FixedStringGenerator : IIncrementalGenerator {
         }
 
         public void RenderFixedString(IndentedStringBuilder builder) {
-            builder.AppendLine($"public string {PropertyName} {{ get {{ fixed (byte* ptr = {FieldName}) {{ var str = Encoding.UTF8.GetString(ptr, {MaxLength:X}); var nullIdx = str.IndexOf('\\0'); return nullIdx >= 0 ? str[..nullIdx] : str; }} }} }}");
+            builder.AppendLine($"public string {PropertyName} {{ get {{ fixed (byte* ptr = {FieldName}) {{ var str = Encoding.UTF8.GetString(ptr, 0x{MaxLength:X}); var nullIdx = str.IndexOf('\\0'); return nullIdx >= 0 ? str[..nullIdx] : str; }} }} }}");
         }
     }
 


### PR DESCRIPTION
I forgot to add the `0x` prefix. Sorry.