### PR TITLE
Revert API breakage in ConfigBase

### DIFF
--- a/FFXIVClientStructs/FFXIV/Common/Configuration/ConfigBase.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Configuration/ConfigBase.cs
@@ -96,5 +96,5 @@ public unsafe partial struct ConfigBase {
     [FieldOffset(0x50)] public Utf8String UnkString;
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 63 58")]
-    public partial ConfigEntry* GetConfigOption(uint index);
+    public partial void* GetConfigOption(uint index);  // TODO (Dalamud API 10: Change to ConfigEntry*)
 }


### PR DESCRIPTION
Proposed fix for a noted API break on a possibly-critical method.