### PR TITLE
Add setter to FixedStrings

### DIFF
--- a/FFXIVClientStructs.InteropSourceGenerators/FixedStringGenerator.cs
+++ b/FFXIVClientStructs.InteropSourceGenerators/FixedStringGenerator.cs
@@ -83,7 +83,12 @@ internal sealed class FixedStringGenerator : IIncrementalGenerator {
         }
 
         public void RenderFixedString(IndentedStringBuilder builder) {
-            builder.AppendLine($"public string {PropertyName} {{ get {{ fixed (byte* ptr = {FieldName}) {{ var str = Encoding.UTF8.GetString(ptr, 0x{MaxLength:X}); var nullIdx = str.IndexOf('\\0'); return nullIdx >= 0 ? str[..nullIdx] : str; }} }} }}");
+            builder.AppendLine($"public string {PropertyName} {{");
+            using (builder.Indent()) {
+                builder.AppendLine($"get {{ fixed (byte* ptr = {FieldName}) {{ var str = Encoding.UTF8.GetString(ptr, 0x{MaxLength:X}); var nullIdx = str.IndexOf('\\0'); return nullIdx >= 0 ? str[..nullIdx] : str; }} }}");
+                builder.AppendLine($"set {{ fixed (byte* ptr = {FieldName}) {{ var bytes = Encoding.UTF8.GetBytes(value ?? string.Empty); var lastBytePos = Math.Min(bytes.Length, 0x{MaxLength:X} - 1); Marshal.Copy(bytes, 0, (nint)ptr, lastBytePos); ptr[lastBytePos] = 0; }} }}");
+            }
+            builder.AppendLine("}");
         }
     }
 


### PR DESCRIPTION
This PR will add a setter to the FixedStringsGenerator.

- Checks `value` for `null` and uses `string.Empty` instead,
- Cuts the string off at max length, if it's longer,
- Always sets the null terminator at the end.

Seems to work. 🧐