### PR TITLE
Add RaptureTextModule.FormatName and helpers

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
@@ -44,6 +44,8 @@ public unsafe partial struct RaptureTextModule {
 
     public enum NameFormatterIdConverter : uint
     {
+        None = 0,
+
         // ObjStr
         ObjStr_BNpcName = 2,
         ObjStr_ENpcResident = 3,
@@ -55,9 +57,6 @@ public unsafe partial struct RaptureTextModule {
         ObjStr_Companion = 9,
         // 10-11 unused
         // ObjStr_Item = 12, // does not work?
-
-        // Item
-        Item = 0,
 
         // ActStr
         ActStr_Trait = 0,
@@ -84,7 +83,7 @@ public unsafe partial struct RaptureTextModule {
     public static partial byte* FormatName(NameFormatterPlaceholder placeholder, uint id, NameFormatterIdConverter idConverter, int intParam2 = 1);
     
     public static byte* GetItemName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.Item, id, NameFormatterIdConverter.Item, intParam2);
+        => FormatName(NameFormatterPlaceholder.Item, id, NameFormatterIdConverter.None, intParam2);
 
     public static byte* GetBNpcName(uint id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_BNpcName, intParam2);

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
@@ -34,4 +34,112 @@ public unsafe partial struct RaptureTextModule {
     /// <returns>string containing one of 23h, 59m, 59s</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 4C 8B C0 48 8B 4D 88")]
     public partial byte* FormatTimeSpan(uint seconds, bool alternativeMinutesGlyph = false);
+
+    public enum NameFormatterPlaceholder : int
+    {
+        ObjStr = 0,
+        Item = 1,   // bypasses IdConverter
+        ActStr = 2,
+    }
+
+    public enum NameFormatterIdConverter : uint
+    {
+        // ObjStr
+        ObjStr_BNpcName = 2,
+        ObjStr_ENpcResident = 3,
+        ObjStr_Treasure = 4,
+        ObjStr_Aetheryte = 5,
+        ObjStr_GatheringPointName = 6,
+        ObjStr_EObjName = 7,
+        // ObjStr_Mount = 8, // does not work?
+        ObjStr_Companion = 9,
+        // 10-11 unused
+        // ObjStr_Item = 12, // does not work?
+
+        // Item
+        Item = 0,
+
+        // ActStr
+        ActStr_Trait = 0,
+        ActStr_Action = 1,
+        // ActStr_Item = 2, // does not work?
+        // ActStr_EventItem = 3, // does not work?
+        ActStr_EventAction = 4,
+        // ActStr_EObjName = 5, // does not work?
+        ActStr_GeneralAction = 5,
+        ActStr_BuddyAction = 6,
+        ActStr_MainCommand = 7,
+        // ActStr_Companion = 8, // unresolved, use ObjStr_Companion
+        ActStr_CraftAction = 9,
+        ActStr_Action2 = 10,
+        ActStr_PetAction = 11,
+        ActStr_CompanyAction = 12,
+        ActStr_Mount = 13,
+        // 14-18 unused
+        ActStr_BgcArmyAction = 19,
+        ActStr_Ornament = 20,
+    }
+
+    [MemberFunction("E9 ?? ?? ?? ?? 48 8D 47 30")]
+    public static partial byte* FormatName(NameFormatterPlaceholder placeholder, uint id, NameFormatterIdConverter idConverter, int intParam2 = 1);
+    
+    public static byte* GetItemName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.Item, id, NameFormatterIdConverter.Item, intParam2);
+
+    public static byte* GetBNpcName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_BNpcName, intParam2);
+
+    public static byte* GetENpcResidentName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_ENpcResident, intParam2);
+
+    public static byte* GetTreasureName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_Treasure, intParam2);
+
+    public static byte* GetAetheryteName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_Aetheryte, intParam2);
+
+    public static byte* GetGatheringPointName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_GatheringPointName, intParam2);
+
+    public static byte* GetEObjName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_EObjName, intParam2);
+
+    public static byte* GetCompanionName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_Companion, intParam2);
+
+    public static byte* GetTraitName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_Trait, intParam2);
+
+    public static byte* GetActionName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_Action, intParam2);
+
+    public static byte* GetEventActionName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_EventAction, intParam2);
+
+    public static byte* GetGeneralActionName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_GeneralAction, intParam2);
+
+    public static byte* GetBuddyActionName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_BuddyAction, intParam2);
+
+    public static byte* GetMainCommandName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_MainCommand, intParam2);
+
+    public static byte* GetCraftActionName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_CraftAction, intParam2);
+
+    public static byte* GetPetActionName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_PetAction, intParam2);
+
+    public static byte* GetCompanyActionName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_CompanyAction, intParam2);
+
+    public static byte* GetMountName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_Mount, intParam2);
+
+    public static byte* GetBgcArmyActionName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_BgcArmyAction, intParam2);
+
+    public static byte* GetOrnamentName(uint id, int intParam2 = 1)
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_Ornament, intParam2);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
@@ -35,50 +35,6 @@ public unsafe partial struct RaptureTextModule {
     [MemberFunction("E8 ?? ?? ?? ?? 4C 8B C0 48 8B 4D 88")]
     public partial byte* FormatTimeSpan(uint seconds, bool alternativeMinutesGlyph = false);
 
-    public enum NameFormatterPlaceholder : int
-    {
-        ObjStr = 0,
-        Item = 1,   // bypasses IdConverter
-        ActStr = 2,
-    }
-
-    public enum NameFormatterIdConverter : uint
-    {
-        None = 0,
-
-        // ObjStr
-        ObjStr_BNpcName = 2,
-        ObjStr_ENpcResident = 3,
-        ObjStr_Treasure = 4,
-        ObjStr_Aetheryte = 5,
-        ObjStr_GatheringPointName = 6,
-        ObjStr_EObjName = 7,
-        // ObjStr_Mount = 8, // does not work?
-        ObjStr_Companion = 9,
-        // 10-11 unused
-        // ObjStr_Item = 12, // does not work?
-
-        // ActStr
-        ActStr_Trait = 0,
-        ActStr_Action = 1,
-        // ActStr_Item = 2, // does not work?
-        // ActStr_EventItem = 3, // does not work?
-        ActStr_EventAction = 4,
-        // ActStr_EObjName = 5, // does not work?
-        ActStr_GeneralAction = 5,
-        ActStr_BuddyAction = 6,
-        ActStr_MainCommand = 7,
-        // ActStr_Companion = 8, // unresolved, use ObjStr_Companion
-        ActStr_CraftAction = 9,
-        ActStr_Action2 = 10,
-        ActStr_PetAction = 11,
-        ActStr_CompanyAction = 12,
-        ActStr_Mount = 13,
-        // 14-18 unused
-        ActStr_BgcArmyAction = 19,
-        ActStr_Ornament = 20,
-    }
-
     [MemberFunction("E9 ?? ?? ?? ?? 48 8D 47 30")]
     public static partial byte* FormatName(NameFormatterPlaceholder placeholder, uint id, NameFormatterIdConverter idConverter, int intParam2 = 1);
     
@@ -141,4 +97,48 @@ public unsafe partial struct RaptureTextModule {
 
     public static byte* GetOrnamentName(uint id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_Ornament, intParam2);
+
+    public enum NameFormatterPlaceholder : int
+    {
+        ObjStr = 0,
+        Item = 1,   // bypasses IdConverter
+        ActStr = 2,
+    }
+
+    public enum NameFormatterIdConverter : uint
+    {
+        None = 0,
+
+        // ObjStr
+        ObjStr_BNpcName = 2,
+        ObjStr_ENpcResident = 3,
+        ObjStr_Treasure = 4,
+        ObjStr_Aetheryte = 5,
+        ObjStr_GatheringPointName = 6,
+        ObjStr_EObjName = 7,
+        // ObjStr_Mount = 8, // does not work?
+        ObjStr_Companion = 9,
+        // 10-11 unused
+        // ObjStr_Item = 12, // does not work?
+
+        // ActStr
+        ActStr_Trait = 0,
+        ActStr_Action = 1,
+        // ActStr_Item = 2, // does not work?
+        // ActStr_EventItem = 3, // does not work?
+        ActStr_EventAction = 4,
+        // ActStr_EObjName = 5, // does not work?
+        ActStr_GeneralAction = 5,
+        ActStr_BuddyAction = 6,
+        ActStr_MainCommand = 7,
+        // ActStr_Companion = 8, // unresolved, use ObjStr_Companion
+        ActStr_CraftAction = 9,
+        ActStr_Action2 = 10,
+        ActStr_PetAction = 11,
+        ActStr_CompanyAction = 12,
+        ActStr_Mount = 13,
+        // 14-18 unused
+        ActStr_BgcArmyAction = 19,
+        ActStr_Ornament = 20,
+    }
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
@@ -102,46 +102,46 @@ public unsafe partial struct RaptureTextModule {
 
     public static byte* GetOrnamentName(uint id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_Ornament, intParam2);
+}
 
-    public enum NameFormatterPlaceholder : int {
-        ObjStr = 0,
-        Item = 1,   // bypasses IdConverter
-        ActStr = 2,
-    }
+public enum NameFormatterPlaceholder : int {
+    ObjStr = 0,
+    Item = 1,   // bypasses IdConverter
+    ActStr = 2,
+}
 
-    public enum NameFormatterIdConverter : uint {
-        None = 0,
+public enum NameFormatterIdConverter : uint {
+    None = 0,
 
-        // ObjStr
-        ObjStr_BNpcName = 2,
-        ObjStr_ENpcResident = 3,
-        ObjStr_Treasure = 4,
-        ObjStr_Aetheryte = 5,
-        ObjStr_GatheringPointName = 6,
-        ObjStr_EObjName = 7,
-        // ObjStr_Mount = 8, // does not work?
-        ObjStr_Companion = 9,
-        // 10-11 unused
-        // ObjStr_Item = 12, // does not work?
+    // ObjStr
+    ObjStr_BNpcName = 2,
+    ObjStr_ENpcResident = 3,
+    ObjStr_Treasure = 4,
+    ObjStr_Aetheryte = 5,
+    ObjStr_GatheringPointName = 6,
+    ObjStr_EObjName = 7,
+    // ObjStr_Mount = 8, // does not work?
+    ObjStr_Companion = 9,
+    // 10-11 unused
+    // ObjStr_Item = 12, // does not work?
 
-        // ActStr
-        ActStr_Trait = 0,
-        ActStr_Action = 1,
-        // ActStr_Item = 2, // does not work?
-        // ActStr_EventItem = 3, // does not work?
-        ActStr_EventAction = 4,
-        // ActStr_EObjName = 5, // does not work?
-        ActStr_GeneralAction = 5,
-        ActStr_BuddyAction = 6,
-        ActStr_MainCommand = 7,
-        // ActStr_Companion = 8, // unresolved, use ObjStr_Companion
-        ActStr_CraftAction = 9,
-        ActStr_Action2 = 10,
-        ActStr_PetAction = 11,
-        ActStr_CompanyAction = 12,
-        ActStr_Mount = 13,
-        // 14-18 unused
-        ActStr_BgcArmyAction = 19,
-        ActStr_Ornament = 20,
-    }
+    // ActStr
+    ActStr_Trait = 0,
+    ActStr_Action = 1,
+    // ActStr_Item = 2, // does not work?
+    // ActStr_EventItem = 3, // does not work?
+    ActStr_EventAction = 4,
+    // ActStr_EObjName = 5, // does not work?
+    ActStr_GeneralAction = 5,
+    ActStr_BuddyAction = 6,
+    ActStr_MainCommand = 7,
+    // ActStr_Companion = 8, // unresolved, use ObjStr_Companion
+    ActStr_CraftAction = 9,
+    ActStr_Action2 = 10,
+    ActStr_PetAction = 11,
+    ActStr_CompanyAction = 12,
+    ActStr_Mount = 13,
+    // 14-18 unused
+    ActStr_BgcArmyAction = 19,
+    ActStr_Ornament = 20,
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
@@ -47,61 +47,61 @@ public unsafe partial struct RaptureTextModule {
         => FormatName(NameFormatterPlaceholder.Item, id, NameFormatterIdConverter.None, intParam2);
 
     public static byte* GetBNpcName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_BNpcName, intParam2);
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.BNpcName, intParam2);
 
     public static byte* GetENpcResidentName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_ENpcResident, intParam2);
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ENpcResident, intParam2);
 
     public static byte* GetTreasureName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_Treasure, intParam2);
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.Treasure, intParam2);
 
     public static byte* GetAetheryteName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_Aetheryte, intParam2);
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.Aetheryte, intParam2);
 
     public static byte* GetGatheringPointName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_GatheringPointName, intParam2);
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.GatheringPointName, intParam2);
 
     public static byte* GetEObjName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_EObjName, intParam2);
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.EObjName, intParam2);
 
     public static byte* GetCompanionName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ObjStr_Companion, intParam2);
+        => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.Companion, intParam2);
 
     public static byte* GetTraitName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_Trait, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.Trait, intParam2);
 
     public static byte* GetActionName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_Action, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.Action, intParam2);
 
     public static byte* GetEventActionName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_EventAction, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.EventAction, intParam2);
 
     public static byte* GetGeneralActionName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_GeneralAction, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.GeneralAction, intParam2);
 
     public static byte* GetBuddyActionName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_BuddyAction, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.BuddyAction, intParam2);
 
     public static byte* GetMainCommandName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_MainCommand, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.MainCommand, intParam2);
 
     public static byte* GetCraftActionName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_CraftAction, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.CraftAction, intParam2);
 
     public static byte* GetPetActionName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_PetAction, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.PetAction, intParam2);
 
     public static byte* GetCompanyActionName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_CompanyAction, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.CompanyAction, intParam2);
 
     public static byte* GetMountName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_Mount, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.Mount, intParam2);
 
     public static byte* GetBgcArmyActionName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_BgcArmyAction, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.BgcArmyAction, intParam2);
 
     public static byte* GetOrnamentName(uint id, int intParam2 = 1)
-        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_Ornament, intParam2);
+        => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.Ornament, intParam2);
 }
 
 public enum NameFormatterPlaceholder : int {
@@ -114,34 +114,34 @@ public enum NameFormatterIdConverter : uint {
     None = 0,
 
     // ObjStr
-    ObjStr_BNpcName = 2,
-    ObjStr_ENpcResident = 3,
-    ObjStr_Treasure = 4,
-    ObjStr_Aetheryte = 5,
-    ObjStr_GatheringPointName = 6,
-    ObjStr_EObjName = 7,
-    // ObjStr_Mount = 8, // does not work?
-    ObjStr_Companion = 9,
+    BNpcName = 2,
+    ENpcResident = 3,
+    Treasure = 4,
+    Aetheryte = 5,
+    GatheringPointName = 6,
+    EObjName = 7,
+    // Mount = 8, // does not work?
+    Companion = 9,
     // 10-11 unused
-    // ObjStr_Item = 12, // does not work?
+    // Item = 12, // does not work?
 
     // ActStr
-    ActStr_Trait = 0,
-    ActStr_Action = 1,
-    // ActStr_Item = 2, // does not work?
-    // ActStr_EventItem = 3, // does not work?
-    ActStr_EventAction = 4,
-    // ActStr_EObjName = 5, // does not work?
-    ActStr_GeneralAction = 5,
-    ActStr_BuddyAction = 6,
-    ActStr_MainCommand = 7,
-    // ActStr_Companion = 8, // unresolved, use ObjStr_Companion
-    ActStr_CraftAction = 9,
-    ActStr_Action2 = 10,
-    ActStr_PetAction = 11,
-    ActStr_CompanyAction = 12,
-    ActStr_Mount = 13,
+    Trait = 0,
+    Action = 1,
+    // Item = 2, // does not work?
+    // EventItem = 3, // does not work?
+    EventAction = 4,
+    // EObjName = 5, // does not work?
+    GeneralAction = 5,
+    BuddyAction = 6,
+    MainCommand = 7,
+    // Companion = 8, // unresolved, use Companion
+    CraftAction = 9,
+    Action2 = 10,
+    PetAction = 11,
+    CompanyAction = 12,
+    Mount = 13,
     // 14-18 unused
-    ActStr_BgcArmyAction = 19,
-    ActStr_Ornament = 20,
+    BgcArmyAction = 19,
+    Ornament = 20,
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
@@ -35,9 +35,14 @@ public unsafe partial struct RaptureTextModule {
     [MemberFunction("E8 ?? ?? ?? ?? 4C 8B C0 48 8B 4D 88")]
     public partial byte* FormatTimeSpan(uint seconds, bool alternativeMinutesGlyph = false);
 
+    /// <remarks> Singular only. The usage of intParam2 is unknown. </remarks>
+    /// <returns>
+    /// A pointer to a null terminated string containing the formatted name.<br/>
+    /// It was observed, that it can return a nullptr when the excel page was not loaded. Try calling it again in subsequent frames.
+    /// </returns>
     [MemberFunction("E9 ?? ?? ?? ?? 48 8D 47 30")]
     public static partial byte* FormatName(NameFormatterPlaceholder placeholder, uint id, NameFormatterIdConverter idConverter, int intParam2 = 1);
-    
+
     public static byte* GetItemName(uint id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.Item, id, NameFormatterIdConverter.None, intParam2);
 
@@ -98,15 +103,13 @@ public unsafe partial struct RaptureTextModule {
     public static byte* GetOrnamentName(uint id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.ActStr_Ornament, intParam2);
 
-    public enum NameFormatterPlaceholder : int
-    {
+    public enum NameFormatterPlaceholder : int {
         ObjStr = 0,
         Item = 1,   // bypasses IdConverter
         ActStr = 2,
     }
 
-    public enum NameFormatterIdConverter : uint
-    {
+    public enum NameFormatterIdConverter : uint {
         None = 0,
 
         // ObjStr

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
@@ -41,66 +41,66 @@ public unsafe partial struct RaptureTextModule {
     /// It was observed, that it can return a nullptr when the excel page was not loaded. Try calling it again in subsequent frames.
     /// </returns>
     [MemberFunction("E9 ?? ?? ?? ?? 48 8D 47 30")]
-    public static partial byte* FormatName(NameFormatterPlaceholder placeholder, uint id, NameFormatterIdConverter idConverter, int intParam2 = 1);
+    public static partial byte* FormatName(NameFormatterPlaceholder placeholder, int id, NameFormatterIdConverter idConverter, int intParam2 = 1);
 
-    public static byte* GetItemName(uint id, int intParam2 = 1)
+    public static byte* GetItemName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.Item, id, NameFormatterIdConverter.None, intParam2);
 
-    public static byte* GetBNpcName(uint id, int intParam2 = 1)
+    public static byte* GetBNpcName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.BNpcName, intParam2);
 
-    public static byte* GetENpcResidentName(uint id, int intParam2 = 1)
+    public static byte* GetENpcResidentName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.ENpcResident, intParam2);
 
-    public static byte* GetTreasureName(uint id, int intParam2 = 1)
+    public static byte* GetTreasureName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.Treasure, intParam2);
 
-    public static byte* GetAetheryteName(uint id, int intParam2 = 1)
+    public static byte* GetAetheryteName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.Aetheryte, intParam2);
 
-    public static byte* GetGatheringPointName(uint id, int intParam2 = 1)
+    public static byte* GetGatheringPointName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.GatheringPointName, intParam2);
 
-    public static byte* GetEObjName(uint id, int intParam2 = 1)
+    public static byte* GetEObjName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.EObjName, intParam2);
 
-    public static byte* GetCompanionName(uint id, int intParam2 = 1)
+    public static byte* GetCompanionName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ObjStr, id, NameFormatterIdConverter.Companion, intParam2);
 
-    public static byte* GetTraitName(uint id, int intParam2 = 1)
+    public static byte* GetTraitName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.Trait, intParam2);
 
-    public static byte* GetActionName(uint id, int intParam2 = 1)
+    public static byte* GetActionName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.Action, intParam2);
 
-    public static byte* GetEventActionName(uint id, int intParam2 = 1)
+    public static byte* GetEventActionName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.EventAction, intParam2);
 
-    public static byte* GetGeneralActionName(uint id, int intParam2 = 1)
+    public static byte* GetGeneralActionName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.GeneralAction, intParam2);
 
-    public static byte* GetBuddyActionName(uint id, int intParam2 = 1)
+    public static byte* GetBuddyActionName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.BuddyAction, intParam2);
 
-    public static byte* GetMainCommandName(uint id, int intParam2 = 1)
+    public static byte* GetMainCommandName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.MainCommand, intParam2);
 
-    public static byte* GetCraftActionName(uint id, int intParam2 = 1)
+    public static byte* GetCraftActionName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.CraftAction, intParam2);
 
-    public static byte* GetPetActionName(uint id, int intParam2 = 1)
+    public static byte* GetPetActionName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.PetAction, intParam2);
 
-    public static byte* GetCompanyActionName(uint id, int intParam2 = 1)
+    public static byte* GetCompanyActionName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.CompanyAction, intParam2);
 
-    public static byte* GetMountName(uint id, int intParam2 = 1)
+    public static byte* GetMountName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.Mount, intParam2);
 
-    public static byte* GetBgcArmyActionName(uint id, int intParam2 = 1)
+    public static byte* GetBgcArmyActionName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.BgcArmyAction, intParam2);
 
-    public static byte* GetOrnamentName(uint id, int intParam2 = 1)
+    public static byte* GetOrnamentName(int id, int intParam2 = 1)
         => FormatName(NameFormatterPlaceholder.ActStr, id, NameFormatterIdConverter.Ornament, intParam2);
 }
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5138,6 +5138,7 @@ classes:
       - ea: 0x141A1C170
         base: Component::Excel::ExcelLanguageEvent
     funcs:
+      0x1400A63D0: FormatName # static
       0x14066F800: ctor
       0x1406704A0: Finalize
       0x140671120: GetAddonText


### PR DESCRIPTION
I figured most people struggle with getting properly formatted names, especially for languages other than english.
This global, static function seems to be a helper to get the correct parameters for FormatAddonText to format a variety of names (Items, BNpcNames, ActionNames etc.).
Unfortunately, there is no support for plural forms, since adjusting `intParam2` (passed to FormatAddonText) doesn't seem to change anything.
I added helper functions with combinations that worked in my testing.

Like I said, it's a global function, and locaded very early on in the exe. It's probably not part of RaptureTextModule, but I didn't know where else to put it and since it uses RaptureTextModule, I thought it might fit there.