### PR TITLE
Add ValueType: AtkValues

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkValue.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkValue.cs
@@ -13,6 +13,7 @@ public enum ValueType {
     String8 = 0x8,
     Vector = 0x9,
     Texture = 0xA,
+    AtkValues = 0xB,
     AllocatedString = 0x26,
     AllocatedVector = 0x29
 }
@@ -29,6 +30,7 @@ public unsafe partial struct AtkValue {
     [FieldOffset(0x8)] public byte Byte;
     [FieldOffset(0x8)] public StdVector<AtkValue>* Vector;
     [FieldOffset(0x8)] public Texture* Texture;
+    [FieldOffset(0x8)] public AtkValue* AtkValues;
 
     [MemberFunction("E8 ?? ?? ?? ?? 41 03 ED")]
     [GenerateCStrOverloads]


### PR DESCRIPTION
Found this type `0xB` in the `Component::GUI::AtkUnitBase_FireCallback(int valueCount, AtkValue* values, a4)` function.
It wraps the passed valueCount and values parameters in new AtkValues, and uses type `0x3` (Int) for valueCount and `0xB` for the `AtkValue*`.