### PR TITLE
Add Utf8String.Replace

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
@@ -124,12 +124,14 @@ public unsafe partial struct Utf8String : ICreatable, IDisposable {
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B F8 48 3B C3")]
     public partial Utf8String* CopySubStrTo(Utf8String* destination, int start, int length);
 
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8D 4D A7 E8 ?? ?? ?? ?? EB 18")]
+    public partial Utf8String* Replace(Utf8String* toFind, Utf8String* replacement);
+
     [MemberFunction("44 88 4C 24 ?? 48 89 54 24 ?? 48 89 4C 24 ?? 53 41 54")]
     public partial int FindFirstOf(Utf8String* charsToFind, int startIdx, bool exclude = false);
 
     [MemberFunction("44 88 4C 24 ?? 53 57 41 56 48 83 EC ?? 48 83 79")]
     public partial int FindLastOf(Utf8String* toFind, int startIdx, bool exclude = false);
-
 
     [MemberFunction("48 8B 01 0F B6 04")]
     public partial byte GetCharAt(ulong idx);

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1008,6 +1008,7 @@ classes:
       0x14005B680: SubStr
       0x14005B6C0: CopySubStrTo
       0x14005BA30: Append
+      0x14005C310: Replace
       0x14005C950: Compare
       0x14005CEA0: SetSize
       0x14005DC00: FindLastOfImpl


### PR DESCRIPTION
This function replaces text with other text.
It is used to replace attributive placeholders (`[p]`, `[a]`, `[pa]`, `[n]` and `[t]`).
Presumably for plain text only.