### PR TITLE
Add Utf8String.IndexOf

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
@@ -127,6 +127,9 @@ public unsafe partial struct Utf8String : ICreatable, IDisposable {
     [MemberFunction("E8 ?? ?? ?? ?? 48 8D 4D A7 E8 ?? ?? ?? ?? EB 18")]
     public partial Utf8String* Replace(Utf8String* toFind, Utf8String* replacement);
 
+    [MemberFunction("E8 ?? ?? ?? ?? 80 7D 97 00")]
+    public partial int IndexOf(Utf8String* toFind, int startIdx = 0);
+
     [MemberFunction("44 88 4C 24 ?? 48 89 54 24 ?? 48 89 4C 24 ?? 53 41 54")]
     public partial int FindFirstOf(Utf8String* charsToFind, int startIdx, bool exclude = false);
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1054,6 +1054,7 @@ classes:
       0x14005C310: Replace
       0x14005C950: Compare
       0x14005CEA0: SetSize
+      0x14005D310: IndexOf
       0x14005DC00: FindLastOfImpl
       0x14005E100: FindFirstOfImpl
       0x1406501A0: ToInteger # strtoi for utf8string (str, base)


### PR DESCRIPTION
```cs
var test = Utf8String.FromString("Hello, this is a Test.");
var needle = Utf8String.FromString("Hello");
ImGui.TextUnformatted($"{test->ToString()}");
ImGui.TextUnformatted($"{needle->ToString()} {Utf8StringIndexOf(test, needle)}");
ImGui.TextUnformatted($"{needle->ToString()} {Utf8StringIndexOf(test, needle, 1)}");
needle->SetString("test");
ImGui.TextUnformatted($"{needle->ToString()} {Utf8StringIndexOf(test, needle)}");
needle->SetString("Test");
ImGui.TextUnformatted($"{needle->ToString()} {Utf8StringIndexOf(test, needle)}");
test->Dtor(true);
needle->Dtor(true);
```

![screenshot](https://github.com/aers/FFXIVClientStructs/assets/96642047/354938b1-76a1-4f08-ac74-0aa2414c06d9)

![YEP](https://cdn.frankerfacez.com/emoticon/418189/2)