### PR TITLE
Add Utf8String.ToUpper

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
@@ -121,6 +121,8 @@ public unsafe partial struct Utf8String : ICreatable, IDisposable {
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B C8 EB A3")]
     public partial Utf8String* ToUpper(bool firstCharOnly = false, bool everyWord = false, bool a4 = false, byte* excludeWord = null);
 
+    public Utf8String* ToTitleCase() => ToUpper(true, true);
+
     [MemberFunction("40 53 48 83 EC ?? B8 ?? ?? ?? ?? 48 8B DA 4C 3B C8")]
     public partial Utf8String* SubString(nint destinationAdress, ulong start, ulong length);
 

--- a/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
@@ -119,7 +119,7 @@ public unsafe partial struct Utf8String : ICreatable, IDisposable {
     public partial Utf8String* ToLower();
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B C8 EB A3")]
-    public partial Utf8String* ToUpper(bool firstCharOnly = false, bool everyWord = false, bool a4 = false, byte* excludeWord = null);
+    public partial Utf8String* ToUpper(bool firstCharOnly = false, bool everyWord = false, bool normalizeVowels = false, byte* excludeWord = null);
 
     public Utf8String* ToTitleCase() => ToUpper(true, true);
 

--- a/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
@@ -118,6 +118,9 @@ public unsafe partial struct Utf8String : ICreatable, IDisposable {
     [MemberFunction("45 33 C0 4C 8B C9 4C 39 41")]
     public partial Utf8String* ToLower();
 
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B C8 EB A3")]
+    public partial Utf8String* ToUpper(bool firstCharOnly = false, bool everyWord = false, bool a4 = false, byte* excludeWord = null);
+
     [MemberFunction("40 53 48 83 EC ?? B8 ?? ?? ?? ?? 48 8B DA 4C 3B C8")]
     public partial Utf8String* SubString(nint destinationAdress, ulong start, ulong length);
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1047,6 +1047,7 @@ classes:
       0x14005AFD0: AddChar
       0x14005B020: PrependChar
       0x14005B080: PopBack
+      0x14005B1B0: ToUpper
       0x14005B3A0: ToLower
       0x14005B680: SubStr
       0x14005B6C0: CopySubStrTo


### PR DESCRIPTION
Couldn't find out what a4 does. 🤷‍♂️
Also, `everyWord` is only handled when `firstCharOnly` is true, otherwise the whole text is uppercase anyway.