### PR TITLE
Add PlayerState.ActiveFestivalIds/ActiveFestivalPhases

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
@@ -5,9 +5,9 @@ public unsafe partial struct GameMain {
     [StaticAddress("48 8D 0D ?? ?? ?? ?? 38 05", 3)]
     public static partial GameMain* Instance();
 
-    [FieldOffset(0x0)] public fixed uint ActiveFestivals[4];
+    [FieldOffset(0x0)] public fixed uint ActiveFestivals[4]; // TODO: add FixedSizeArray with a struct that splits it into two ushorts, Id and Phase
 
-    [FieldOffset(0x40)] public fixed uint QueuedFestivals[4];
+    [FieldOffset(0x40)] public fixed uint QueuedFestivals[4]; // TODO: add FixedSizeArray with a struct that splits it into two ushorts, Id and Phase
 
     [FieldOffset(0xAD8)] public JobGaugeManager JobGaugeManager;
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -43,6 +43,8 @@ public unsafe partial struct PlayerState {
     [FieldOffset(0x155)] public byte FirstClass;
     [FieldOffset(0x156)] public byte StartTown;
     [FieldOffset(0x157)] public byte QuestSpecialFlags;
+    [FieldOffset(0x158)] public fixed ushort ActiveFestivalIds[4];
+    [FieldOffset(0x160)] public fixed ushort ActiveFestivalPhases[4];
 
     [FieldOffset(0x170)] public int BaseStrength;
     [FieldOffset(0x174)] public int BaseDexterity;


### PR DESCRIPTION
The lua function `IsOpenedFestival` (1408ED2E0) reads active festival ids from PlayerState. I assume the phases come right after, but can't tell for sure just yet. ~~Moogle Treasure Trove: The Second Hunt for Genisis should theoretically use the second phase of the same event. I'll leave this draft here until I can confirm it.~~

That said, `GameMain.ActiveFestivals` is not a `uint` array. Each festival entry has a ushort Id and a ushort Phase. Multiple xrefs confirm this, including the lua function `GetFestivalPhase` (1407D9ED0).   Sadly I can't add the FixedSizeArrayAttribute, because that only works on fixed byte arrays. I assume `GameMain.QueuedFestivals` has the same structure.
