### PR TITLE
CExporter: export internal fields

### DIFF
--- a/ida/CExporter/Exporter.cs
+++ b/ida/CExporter/Exporter.cs
@@ -175,7 +175,7 @@ public abstract class ExporterBase {
     }
 
     private List<UnionLayout> GetStructLayout(Type type) {
-        var fields = type.GetFields()
+        var fields = type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             .Where(fieldInfo => !Attribute.IsDefined(fieldInfo, typeof(ObsoleteAttribute)))
             .Where(fieldInfo => !Attribute.IsDefined(fieldInfo, typeof(CExportIgnoreAttribute)))
             .Where(fieldInfo => !fieldInfo.IsLiteral) // not constants


### PR DESCRIPTION
This little change makes it so that CExporter can export non-public fields.