### PR TITLE
Environment Manager + Cursor 

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Sound/SoundManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Sound/SoundManager.cs
@@ -6,6 +6,10 @@ namespace FFXIVClientStructs.FFXIV.Client.Sound;
 //   Client::System::Resource::ResourceEventListener
 //   Client::System::Threading::Thread
 //ctor "E8 ?? ?? ?? ?? EB ?? 48 8B C6 BA ?? ?? ?? ?? 48 89 87 ?? ?? ?? ?? 49 8B CF"
+/// <summary>
+/// This class is the low level handler for sound related functions and abstracts from the operating system.
+/// The functions in this class are not intended by SE to be used directly and do not have proper checks for correct values.
+/// </summary>
 [StructLayout(LayoutKind.Explicit, Size = 0x1C88)]
 public unsafe partial struct SoundManager {
     [FieldOffset(0x0000)] public nint ResourceEventListener;
@@ -31,14 +35,26 @@ public unsafe partial struct SoundManager {
 
     [FieldOffset(0x02C8)] public nint EventHandle;
 
+    /// <summary>
+    /// Calculates effective volume
+    /// </summary>
+    /// <param name="channel">The specific sound channel. This is different from the channels visible to the user</param>
+    /// <returns>Volume in the ange 0-1</returns>
     [MemberFunction("F3 0F 10 0D ?? ?? ?? ?? 48 63 C2")]
     public partial float GetEffectiveVolume(int channel);
 
+    ///<inheritdoc cref="GetEffectiveVolume(int)"/>
     public float GetEffectiveVolume(SoundChannel channel) => GetEffectiveVolume((int)channel);
 
+    /// <summary>
+    /// Sets channel volume
+    /// </summary>
+    /// <param name="channel">The specific sound channel. This is different from the channels visible to the user</param>
+    /// <param name="volume">Volume in the ange 0-1</param>
     [MemberFunction("E8 ?? ?? ?? ?? FF C7 D1 EB 75 ?? 48 8B 74 24")]
     public partial void SetVolume(int channel, float volume, int p3 = 100);
 
+    ///<inheritdoc cref="SetVolume(int,float,int)"/>
     public void SetVolume(SoundChannel channel, float volume, int p3 = 100) => SetVolume((int)channel, volume, p3);
 
     public enum SoundChannel : int {

--- a/FFXIVClientStructs/FFXIV/Client/Sound/SoundManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Sound/SoundManager.cs
@@ -18,7 +18,9 @@ public unsafe partial struct SoundManager {
     [FieldOffset(0x00D4)] public fixed float UnkVolume3[0x13]; // All are 1.0f
     [FieldOffset(0x0120)] public fixed float UnkVolume4[0x13]; // All are 1.0f
     [FieldOffset(0x016C)] public fixed bool ChannelMutedArray[0x13];
-    [FieldOffset(0x017F)] public fixed bool ChannelAlwayOn[0x13];
+    [FieldOffset(0x017F)] public fixed bool ChannelAlwaysOn[0x13];
+    [Obsolete("Use ChannelAlwaysOn")] [FieldOffset(0x017F)]
+    public fixed bool ChannelAlwayOn[0x13];
 
     [FieldOffset(0x01C9)] public bool MasterEnabled;
     [FieldOffset(0x01CA)] public bool IsSoundAlways;
@@ -27,7 +29,7 @@ public unsafe partial struct SoundManager {
 
     [FieldOffset(0x02A0)] public nint CriticalSection;
 
-    [FieldOffset(0x2C8)] public nint EventHandle;
+    [FieldOffset(0x02C8)] public nint EventHandle;
 
     [MemberFunction("F3 0F 10 0D ?? ?? ?? ?? 48 63 C2")]
     public partial float GetEffectiveVolume(int channel);

--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/EnvironmentManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/EnvironmentManager.cs
@@ -6,4 +6,6 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Framework;
 public struct EnvironmentManager {
     [FieldOffset(0x000)] public Task Task;
     [FieldOffset(0x038)] public ChangeEventInterface ChangeEventInterface;
+
+    [FieldOffset(0x084)] public int CutsceneMovieVoice; //Cutscene Audio Language (-1 = ClientLanguage) 
 }

--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/EnvironmentManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/EnvironmentManager.cs
@@ -2,17 +2,47 @@ using FFXIVClientStructs.FFXIV.Common.Configuration;
 
 namespace FFXIVClientStructs.FFXIV.Client.System.Framework;
 
+//Client::System::Framework::EnvironmentManager:
+//  Client::System::Framework::Task
+//  Common::Configuration::ConfigBase::ChangeEventInterface
+//ctor "E8 ?? ?? ?? ?? EB ?? 48 8B C6 BA ?? ?? ?? ?? 48 89 87 ?? ?? ?? ?? 44 8B C2"
+/// <summary>
+/// This class is a high level abstraction of sound and window systems. And handles sanity checks before propagating values to the more low-level classes respectively
+/// </summary>
 [StructLayout(LayoutKind.Explicit, Size = 0x698)]
 public partial struct EnvironmentManager {
     [FieldOffset(0x000)] public Task Task;
     [FieldOffset(0x038)] public ChangeEventInterface ChangeEventInterface;
+    /// <summary>
+    ///Cutscene Audio Language (-1 indicates to use ClientLanguage) 
+    /// </summary>
+    [FieldOffset(0x084)] public int CutsceneMovieVoice;
 
-    [FieldOffset(0x084)] public int CutsceneMovieVoice; //Cutscene Audio Language (-1 = ClientLanguage) 
-
-
+    /// <summary>
+    /// Sets the volume if volume is in the allowed range
+    /// </summary>
+    /// <param name="channel">Indicates which volume to set</param>
+    /// <param name="volume">Volume in range 0-100, -1 indicates to read the configuration value</param>
+    /// <param name="saveToConfig">Wether the new volume should be written to system configuration</param>
     [MemberFunction("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 41 8B F8 41 0F B6 F1")]
-    public partial void SetVolume(uint type, uint volume, bool saveToConfig);
+    public partial void SetVolume(uint channel, int volume, bool saveToConfig);
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 8F ?? ?? ?? ?? 41 B1 ?? 41 83 C8")]
-    public partial void SetMasterVolume(uint volume, bool saveToConfig);
+    public partial void SetMasterVolume(int volume, bool saveToConfig);
+
+    ///<inheritdoc cref="SetVolume(uint,int,bool)"/>
+    public void SetVolume(SoundChannel channel, int volume, bool saveToConfig) => SetVolume((uint)channel, volume, saveToConfig);
+
+    /// <summary>
+    /// Each value represents one volume slider in the system configuration, expect master volume.<br/>
+    /// </summary>
+    public enum SoundChannel : uint {
+        BGM = 0,
+        SoundEffects = 1,
+        Voice = 2,
+        Environment = 3,
+        System = 4,
+        Perform = 5,
+        All = 6
+    }
 }

--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/EnvironmentManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/EnvironmentManager.cs
@@ -3,9 +3,16 @@ using FFXIVClientStructs.FFXIV.Common.Configuration;
 namespace FFXIVClientStructs.FFXIV.Client.System.Framework;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x698)]
-public struct EnvironmentManager {
+public partial struct EnvironmentManager {
     [FieldOffset(0x000)] public Task Task;
     [FieldOffset(0x038)] public ChangeEventInterface ChangeEventInterface;
 
     [FieldOffset(0x084)] public int CutsceneMovieVoice; //Cutscene Audio Language (-1 = ClientLanguage) 
+
+
+    [MemberFunction("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 41 8B F8 41 0F B6 F1")]
+    public partial void SetVolume(uint type, uint volume, bool saveToConfig);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 8F ?? ?? ?? ?? 41 B1 ?? 41 83 C8")]
+    public partial void SetMasterVolume(uint volume, bool saveToConfig);
 }

--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
@@ -22,8 +22,9 @@ public unsafe partial struct Framework {
     [FieldOffset(0x0460)] public DevConfig DevConfig;
     [FieldOffset(0x0570)] public SavedAppearanceManager* SavedAppearanceData;
     [FieldOffset(0x0580)] public byte ClientLanguage;
+    [FieldOffset(0x0581)] public char Region;
     [FieldOffset(0x0588)] public Cursor* Cursor;
-
+    [FieldOffset(0x0590)] public nint CallerWindow;
     [FieldOffset(0x0598)] public FileAccessPath ConfigPath;
     [FieldOffset(0x07A8)] public GameWindow* GameWindow;
     //584 byte
@@ -36,19 +37,23 @@ public unsafe partial struct Framework {
     [FieldOffset(0x1670)] public NetworkModuleProxy* NetworkModuleProxy;
     [FieldOffset(0x1678)] public bool IsNetworkModuleInitialized;
     [FieldOffset(0x1679)] public bool EnableNetworking;
-    [FieldOffset(0x1680)] public long ServerTime;  // TODO: change to uint
+    [FieldOffset(0x1680)] public long ServerTime; // TODO: change to uint
     [FieldOffset(0x1688)] public long PerformanceCounterInMilliSeconds;
     [FieldOffset(0x1688)] public long PerformanceCounterInMicroSeconds;
     [FieldOffset(0x1698)] public uint TimerResolutionMillis;
     [FieldOffset(0x16A0)] public long PerformanceCounterFrequency;
     [FieldOffset(0x16A8)] public long PerformanceCounterValue;
-    [FieldOffset(0x16F8)] public TaskManager TaskManager;
     [FieldOffset(0x16B8)] public float FrameDeltaTime;
+    [FieldOffset(0x16C0)] public float FrameDeltaTimeOverride;
     [FieldOffset(0x16C8)] public uint FrameCounter;
+    [FieldOffset(0x16F8)] public TaskManager TaskManager;
     [FieldOffset(0x1768)] public ClientTime ClientTime;
-    [FieldOffset(0x1770), Obsolete("Use ClientTime.EorzeaTime")] public long EorzeaTime;
-    [FieldOffset(0x1798), Obsolete("Use ClientTime.EorzeaTimeOverride")] public long EorzeaTimeOverride;
-    [FieldOffset(0x17A0), Obsolete("Use ClientTime.IsEorzeaTimeOverridden")] public bool IsEorzeaTimeOverridden;
+    [FieldOffset(0x1770)] [Obsolete("Use ClientTime.EorzeaTime")]
+    public long EorzeaTime;
+    [FieldOffset(0x1798)] [Obsolete("Use ClientTime.EorzeaTimeOverride")]
+    public long EorzeaTimeOverride;
+    [FieldOffset(0x17A0)] [Obsolete("Use ClientTime.IsEorzeaTimeOverridden")]
+    public bool IsEorzeaTimeOverridden;
     [FieldOffset(0x17C4)] public float FrameRate;
     [FieldOffset(0x17D0)] public bool WindowInactive;
 

--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
@@ -22,7 +22,7 @@ public unsafe partial struct Framework {
     [FieldOffset(0x0460)] public DevConfig DevConfig;
     [FieldOffset(0x0570)] public SavedAppearanceManager* SavedAppearanceData;
     [FieldOffset(0x0580)] public byte ClientLanguage;
-    [FieldOffset(0x0581)] public char Region;
+    [FieldOffset(0x0581)] public byte Region;
     [FieldOffset(0x0588)] public Cursor* Cursor;
     [FieldOffset(0x0590)] public nint CallerWindow;
     [FieldOffset(0x0598)] public FileAccessPath ConfigPath;

--- a/FFXIVClientStructs/FFXIV/Client/System/Input/Cursor.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Input/Cursor.cs
@@ -7,13 +7,23 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Input;
 [StructLayout(LayoutKind.Explicit, Size = 0x378)]
 public unsafe partial struct Cursor {
     [FieldOffset(0x000)] public void* vtbl;
+
     [FieldOffset(0x009)] public bool UseSoftwareCursor;
+    [FieldOffset(0x00A)] public byte SoftwareCursorScale;
     [FieldOffset(0x00B)] public bool IsCursorVisible;
     [FieldOffset(0x00C)] public bool MouseNotCpatured;
     [FieldOffset(0x00D)] public bool IsCursorOutsideViewPort;
+
     [FieldOffset(0x010)] public uint ActiveCursorType; //Hand,Cursor, Cross, etc
+
     [FieldOffset(0x1B0)] public fixed ulong CursorHandles[16]; //HCURSOR (winuser.h)
+
     [FixedSizeArray<Pointer<byte>>(16)]
     [FieldOffset(0x238)] public fixed byte CursorNames[8 * 16];
+    [FieldOffset(0x2C0)] public int HardwareCursorSize;
     [FieldOffset(0x2C8)] public TextureResourceHandle* SoftwareCursorTexture;
+
+    [FieldOffset(0x368)] public bool ShowSoftwareCursorTrajectory;
+
+    [FieldOffset(0x370)] public bool UseOsHardwareCursor;
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -6,9 +6,11 @@ globals:
   0x1419BE6C0: g_UIColorTable
   0x141A076B8: g_HUDScaleTable
   0x141FDD380: g_ClientInstanceLimit
+  0x141FE1D48: g_LanguageCharArr # byte[] no pointer
   0x142169868: g_Client::Game::Control::InputManager_MouseButtonHoldState
   0x14217FC30: g_StackCookie
   0x14217FC38: g_InverseStackCookie
+  0x14219D370: g_ThreadLocalPerformanceFrequency
   0x14219D4A0: g_OSVersion
   0x1421A4360: g_CurrentCharaSelectCharacter # Client::Game::Character::Character*
   0x1421A4570: g_CharaSelectCharacterList # see Client::UI::Agent::AgentLobby::CharaSelectCharacterList
@@ -74,14 +76,17 @@ functions:
   0x1400654E0: IsMacClient
   0x1400951B0: CheckOsTypeAndVersion
   0x140067500: GetMyDocumntsFolder #as UTF8String
+  0x140096470: GetPerformanceFrequency
   0x1400976D0: CreateDirectoryRecursive
   0x1400A6BD0: GetCurrentUnixTimestamp # in seconds
   0x1400A6D00: Client::UI::PlaySoundEffect # this is a static function in the UI namespace, arg1 is the SE
   0x1400A8990: Client::UI::GetUIColor # (idx, &color, &edgeColor)
   0x1400A89D0: Client::UI::GetNumberAsBoxedChar # (uint) accepts numbers 0-30
   0x1400A8A80: Client::UI::GetNumberAsDigitChars # (uint) accepts numbers 0-999
+  0x140181DF0: GetTime
   0x1401C03B0: j_SleepEx
   0x1401C03C0: j_Sleep
+  0x14021ADB0: GetCharForLanguage
   0x1402ECEC0: CountdownPointer
   0x1403189C0: CleanupCharaSelectCharacters
   0x140335520: std::vector_SetSize
@@ -1739,7 +1744,6 @@ classes:
       - ea: 0x1419B2C78
         base: Common::Configuration::SystemConfig
     funcs:
-      0x140069970: RegisterChangeEvent
       0x14007A3F0: BuildConfigList
   Client::System::Configuration::DevConfig:
     vtbls:
@@ -1792,6 +1796,8 @@ classes:
       0x140095A60: TeardownSteamApi
       0x140095AC0: IsSteamApiInitialized
       0x140095F20: Finalize
+      0x140097020: InitGamePath
+      0x140097250: InitSqPackPath
       0x140097390: GetSavePath
   Component::Excel::ExcelModuleInterface:
     vtbls:
@@ -3605,6 +3611,7 @@ classes:
       0x140355230: Initialize
       0x140355FA0: CreateTexture2D
       0x140356AB0: CreateConstantBuffer
+      0x140356F10: PreTick
       0x140357180: PostTick
   Client::Graphics::Kernel::Context:
     funcs:
@@ -4111,9 +4118,13 @@ classes:
       0x1404B73A0: nullsub_1
       0x1404B73D0: LoadDataFiles
   Client::System::Task::SpursJobEntityWorkerThread:
+    instances:
+      - ea: 0x1421B9AC0
     vtbls:
       - ea: 0x141A02758
         base: Client::System::Threading::Thread
+    funcs:
+      0x1404bdb10: ctor
   Common::Lua::LuaState:
     vtbls:
       - ea: 0x141A030E8
@@ -5298,6 +5309,7 @@ classes:
       0x140629B80: Finalize
       0x14062A2B0: Update
       0x14062A730: HandleInputUpdate
+      0x14062A800: ShouldLimitFps
   Client::UI::Misc::PvpSetModule:
     vtbls:
       - ea: 0x141A1E990
@@ -5518,6 +5530,7 @@ classes:
       0x140667680: ctor
       0x140667A40: SetValueByIndex
       0x140667C10: GetValueByIndex
+      0x140669140: Update
   Client::UI::Misc::FieldMarkerModule:
     vtbls:
       - ea: 0x141A1ED50
@@ -5571,6 +5584,7 @@ classes:
       0x140676E10: FormatAddonText3
       0x140677470: FormatAddonText4
       0x140679B20: FormatTimeSpan
+      0x14067B150: Update
       0x14067BA60: FormatAddonTextApply
   Client::UI::Misc::RaptureLogModule:
     vtbls:
@@ -5578,6 +5592,7 @@ classes:
         base: Component::Log::LogModule
     funcs:
       0x14067F7D0: ctor
+      0x14067FF60: Update
       0x14067FA90: Finalize
       0x140681090: PrintMessage
       0x1406840B0: PrintString  # (this, stringPtr)
@@ -5713,6 +5728,7 @@ classes:
         base: Client::UI::Misc::UserFileManager::UserFileEvent
     funcs:
       0x1406A1B20: ctor
+      0x1406A1D00: Update
       0x1406A1D50: GetGearset
       0x1406A1D70: IsValidGearset
       0x1406A1EF0: EquipGearset
@@ -5735,6 +5751,7 @@ classes:
         base: Client::UI::Misc::UserFileManager::UserFileEvent
     funcs:
       0x1406A7110: ctor
+      0x1406A8D30: Update
       0x1406A72D0: Finalize
       0x1406A9120: SearchForItem
   Client::UI::Misc::GoldSaucerModule:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1665,7 +1665,8 @@ classes:
       0x14008EED0: InitSoundManagerConfig #static
       0x14008F110: InitEqualizerType #static
       0x14008F1E0: InitSpatialAudio #static
-      0x14008f270: InitCursor #static
+      0x14008F270: InitCursor #static
+      0x140090470: GetConfigOptionForSoundType #static
   Client::Sound::SoundManager: #base: Client::System::Common::NonCopyable
     instances:
       - ea: 0x1421A4318

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2528,10 +2528,18 @@ classes:
       5: SetCursorVisibility
       8: SetUseSoftwareCursor
       9: GetUseSoftwareCursor
+      10: SetUseOsHardwareCursor
+      11: GetUseOsHardwareCursor
+      12: SetSoftwareCursorScale
+      13: GetSoftwareCursorScale
       14: IsCursorVisible
+      19: SetShowSoftwareCursorTrajectory
       21: IsMouseNotCaptured
+      22: UnloadSoftwareCursor
+      23: LoadCursor #(this, type, name)
     funcs:
       0x140086790: ctor
+      0x140086F90: SetHardwareCursorSize
   Component::Shell::ShellCommandModule:
     vtbls:
       - ea: 0x1419B3878

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1667,6 +1667,7 @@ classes:
       0x14008F1E0: InitSpatialAudio #static
       0x14008F270: InitCursor #static
       0x140090470: GetConfigOptionForSoundType #static
+      0x1400904F0: SetVolumeUnchecked #static
   Client::Sound::SoundManager: #base: Client::System::Common::NonCopyable
     instances:
       - ea: 0x1421A4318

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1638,12 +1638,29 @@ classes:
         base: Common::Configuration::ConfigBase::ChangeEventInterface
     funcs:
       0x14008CEB0: ctor
+      0x14008CFD0: Destroy
+      0x14008D530: Initialize
+      0x14008D630: SetLanguage
+      0x14008D6A0: GetCutsceneLanguage
+      0x14008D780: SetCutsceneLanguage
+      0x14008D790: GetClientLanguage #static
+      0x14008D910: GetWindowMode #static
       0x14008E2F0: GetWindowRectFromConfig
       0x14008E420: OpenGameWindow
       0x14008E670: GetVirtualScreenResolution
-      0x14008E6C0: SetFramerateCapByConfigOption
+      0x14008E6C0: SetFpsCap
+      0x14008E710: GetFpsCap #static
+      0x14008E940: SetWindowSize
       0x14008EBA0: SetMasterVolume #(this, volume(0-100), saveToConfig)
+      0x14008EC70: GetMasterVolume #static
+      0x14008ECA0: SetVolume #(type 6=all, volume, saveToConfig)
+      0x14008EDD0: GetVolume
       0x14008EE00: SetMicPosition
+      0x14008EEA0: GetMicPosition #static
+      0x14008EED0: InitSoundManagerConfig #static
+      0x14008F110: InitEqualizerType #static
+      0x14008F1E0: InitSpatialAudio #static
+      0x14008f270: InitCursor #static
   Client::Sound::SoundManager: #base: Client::System::Common::NonCopyable
     instances:
       - ea: 0x1421A4318


### PR DESCRIPTION
As to prior questions: The volume setters in EnvironmentManager are to my understanding the intended API to use for volume changes (permanent and temporary) 
Has been discussed in the [discord](https://discord.com/channels/581875019861328007/653504487352303619/1201162708528152666) ~~@KazWolfe Maybe you can propose a wrapper function that makes this most easy to use~~ 
Note: I included some generic functions/fields that I found on the way, and I deemed safe to include