### PR TITLE
Rename Equals to EqualTo

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/InventoryManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InventoryManager.cs
@@ -128,7 +128,11 @@ public unsafe partial struct InventoryItem : ICreatable {
     public partial void Ctor();
 
     [MemberFunction("8B 42 08 4C 8B C1")]
+    [Obsolete("Renamed to EqualTo")]
     public partial bool Equals(InventoryItem* other);
+
+    [MemberFunction("8B 42 08 4C 8B C1")]
+    public partial bool EqualTo(InventoryItem* other);
 
     /// <summary>Copies the values from the other InventoryItem and, if it's symbolic, resolves its linked item.</summary>
     [MemberFunction("E9 ?? ?? ?? ?? 48 8D 4B 48")]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMiragePrismMiragePlate.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMiragePrismMiragePlate.cs
@@ -57,8 +57,8 @@ public unsafe partial struct AgentMiragePrismMiragePlate {
     }
 }
 
+// TODO: Obsolete: It's the same as CharaViewItem. Remove with AgentMiragePrismMiragePlate.PlateItems.
 [StructLayout(LayoutKind.Explicit, Size = 0x20)]
-[Obsolete("Same as CharaViewItem")]
 public struct MiragePlateItem {
     [FieldOffset(0x00)] public byte EquipType;
     [FieldOffset(0x01)] public byte EquipSlotCategory;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/BannerModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/BannerModule.cs
@@ -114,7 +114,11 @@ public unsafe partial struct BannerModuleEntry {
     // [FieldOffset(0x8F)] public byte Unk8F;
 
     [MemberFunction("0F B7 42 7C 66 39 41 7C")]
+    [Obsolete("Renamed to EqualTo")]
     public partial bool Equals(BannerModuleEntry* other);
+
+    [MemberFunction("0F B7 42 7C 66 39 41 7C")]
+    public partial bool EqualTo(BannerModuleEntry* other);
 
     /// <param name="itemIds">A pointer to 14 Item Ids</param>
     /// <param name="stainIds">A pointer to 14 Stain Ids</param>

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -845,7 +845,7 @@ classes:
       0x1406E08E0: GetMateriaGrade
       0x14071C330: ctor
       0x14071C370: Copy
-      0x14071C530: Equals
+      0x14071C530: EqualTo
       0x14071C5C0: Clear
       0x14071C600: SetItemId
       0x14071C6C0: GetLinkedItem
@@ -5845,7 +5845,7 @@ classes:
     funcs:
       0x14066B5E0: j_ctor
       0x14066B600: ctor
-      0x14066B6C0: Equals
+      0x14066B6C0: EqualTo
       0x14096C860: GenerateChecksum # static
   Client::UI::Misc::CharaView:
     vtbls:


### PR DESCRIPTION
It conflicts with `object.Equals`.