### PR TITLE
Fix and obsolete some old OnSetup vfs in addons

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonBank.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonBank.cs
@@ -11,6 +11,6 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 public unsafe partial struct AddonBank {
     [FieldOffset(0x0)] public AtkUnitBase AtkUnitBase;
 
-    [VirtualFunction(47)]
+    [VirtualFunction(48), Obsolete("Use AtkUnitBase.OnSetup")]
     public partial void OnSetup(uint a2, AtkValue* atkValues);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonRetainerList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonRetainerList.cs
@@ -11,6 +11,6 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 public unsafe partial struct AddonRetainerList {
     [FieldOffset(0x0)] public AtkUnitBase AtkUnitBase;
 
-    [VirtualFunction(47)]
+    [VirtualFunction(48), Obsolete("Use AtkUnitBase.OnSetup")]
     public partial void OnSetup(uint a2, AtkValue* atkValues);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonRetainerTaskAsk.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonRetainerTaskAsk.cs
@@ -13,7 +13,6 @@ public unsafe partial struct AddonRetainerTaskAsk {
     [FieldOffset(0x2A8)] public AtkComponentButton* AssignButton;
     [FieldOffset(0x2B0)] public AtkComponentButton* ReturnButton;
 
-    //[MemberFunction("40 53 48 83 EC 30 48 8B D9 83 FA 03 7C 53 49 8B C8 E8 ?? ?? ?? ??")]
-    [VirtualFunction(47)]
+    [VirtualFunction(48), Obsolete("Use AtkUnitBase.OnSetup")]
     public partial void OnSetup(uint a2, AtkValue* atkValues);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonRetainerTaskList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonRetainerTaskList.cs
@@ -11,7 +11,6 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 public unsafe partial struct AddonRetainerTaskList {
     [FieldOffset(0x0)] public AtkUnitBase AtkUnitBase;
 
-    //[MemberFunction("48 89 5C 24 ?? 55 56 57 48 81 EC 10 01 00 00 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 ?? ?? ?? ?? ?? 8B DA 49 8B F0 BA 03 00 00 00 48 8B F9 E8 ?? ?? ?? ??")]
-    [VirtualFunction(47)]
+    [VirtualFunction(48), Obsolete("Use AtkUnitBase.OnSetup")]
     public partial void OnSetup(uint a2, AtkValue* atkValues);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonRetainerTaskResult.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonRetainerTaskResult.cs
@@ -13,7 +13,6 @@ public unsafe partial struct AddonRetainerTaskResult {
     [FieldOffset(0x240)] public AtkComponentButton* ReassignButton;
     [FieldOffset(0x248)] public AtkComponentButton* ConfirmButton;
 
-    //[MemberFunction("48 89 5C 24 ?? 55 56 57 48 83 EC 40 8B F2 49 8B F8 BA ?? ?? ?? ?? 48 8B D9 E8 ?? ?? ?? ??")]
-    [VirtualFunction(47)]
+    [VirtualFunction(48), Obsolete("Use AtkUnitBase.OnSetup")]
     public partial void OnSetup(uint a2, AtkValue* atkValues);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonSelectString.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonSelectString.cs
@@ -12,8 +12,7 @@ public unsafe partial struct AddonSelectString {
     [FieldOffset(0x0)] public AtkUnitBase AtkUnitBase;
     [FieldOffset(0x220)] public PopupMenuDerive PopupMenu;
 
-    //[MemberFunction("40 53 56 57 41 54 41 55 41 57 48 83 EC 48 4D 8B F8 44 8B E2 48 8B F1 E8 ?? ?? ?? ??")]
-    [VirtualFunction(47)]
+    [VirtualFunction(48), Obsolete("Use AtkUnitBase.OnSetup")]
     public partial void OnSetup(uint a2, AtkValue* atkValues);
 
     [StructLayout(LayoutKind.Explicit, Size = 0x70)]


### PR DESCRIPTION
I found these old `OnSetup` vfuncs at index 47 instead of 48 using the new vtable export by @wolfcomp (#799). 🙂

The index changed with 6.5, but was only updated in AtkUnitBase itself (36553031262d4ffc9ec4fc3945e7341db1cde577).

I fixed the index and added an obsolete attribute.