### PR TITLE
BoneSimulator: Add Spring field

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Physics/BoneSimulator.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Physics/BoneSimulator.cs
@@ -13,4 +13,5 @@ public unsafe struct BoneSimulator {
     [FieldOffset(0x20)] public Vector3 CharacterPosition;
     [FieldOffset(0x30)] public Vector3 Gravity;
     [FieldOffset(0x40)] public Vector3 Wind;
+    [FieldOffset(0x54)] public float Spring; // Default is ~60, intense jitter happens above that value. Lesser values remove the spring in the bone.
 }


### PR DESCRIPTION
Discovered this when messing around with the bone simulator and think it's worth adding.

This is a weird field, but messing around with it and reading the disassembly it seems to be a "springiness" value. It starts a little lower than 60.0, but anything higher than that results in relentless jitter. Lower values such as 0.0 completely remove the springiness/bounce.