### PR TITLE
Update AgentLobby.LobbyData

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
@@ -1,5 +1,6 @@
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Network;
+using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Component.Excel;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
@@ -49,6 +50,14 @@ public unsafe partial struct LobbyData {
     [FieldOffset(0x8)] public LobbyUIClient LobbyUIClient;
 
     [FieldOffset(0x858)] public StdVector<Pointer<CharaSelectCharacterEntry>> CharaSelectEntries;
+
+    [FieldOffset(0x878)] public ulong ContentId;
+    [FieldOffset(0x880)] public Utf8String HomeWorldName;
+    [FieldOffset(0x8E8)] public Utf8String HomeWorldName2;
+    [FieldOffset(0x950)] public Utf8String CurrentWorldName;
+
+    [FieldOffset(0x9BC)] public ushort CurrentWorldId;
+    [FieldOffset(0x9BE)] public ushort HomeWorldId;
 
     [MemberFunction("40 53 56 41 57 48 83 EC 20 33 DB")]
     public partial CharaSelectCharacterEntry* GetCharacterEntryFromServer(byte index, long contentId);

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -83,6 +83,10 @@ functions:
   0x1400A8990: Client::UI::GetUIColor # (idx, &color, &edgeColor)
   0x1400A89D0: Client::UI::GetNumberAsBoxedChar # (uint) accepts numbers 0-30
   0x1400A8A80: Client::UI::GetNumberAsDigitChars # (uint) accepts numbers 0-999
+  0x1400AAEF0: IsHomeWorldId
+  0x1400AAF50: IsCurrentWorldId
+  0x1400AAFE0: GetHomeWorldId
+  0x1400AB030: GetCurrentWorldId
   0x140181DF0: GetTime
   0x1401C03B0: j_SleepEx
   0x1401C03C0: j_Sleep


### PR DESCRIPTION
I came across these functions and had some stuff in ReClass that aligned.
This data is for the currently logged in character.
Not sure why there are two HomeWorldName fields though.