### PR TITLE
Fix tm days being off by 1

### DIFF
--- a/FFXIVClientStructs/STD/Tm.cs
+++ b/FFXIVClientStructs/STD/Tm.cs
@@ -28,10 +28,10 @@ public unsafe struct Tm {
         tm_sec = dateTime.Second;
         tm_min = dateTime.Minute;
         tm_hour = dateTime.Hour;
-        tm_mday = dateTime.Day - 1;
+        tm_mday = dateTime.Day;
         tm_mon = dateTime.Month - 1;
         tm_year = dateTime.Year - 1900;
-        tm_wday = (int)dateTime.DayOfWeek - 1;
+        tm_wday = (int)dateTime.DayOfWeek;
         tm_yday = dateTime.DayOfYear - 1;
         tm_isdst = dateTime.IsDaylightSavingTime() ? 1 : 0;
     }
@@ -43,7 +43,7 @@ public unsafe struct Tm {
         => new(
             tm_year + 1900,
             tm_mon + 1,
-            tm_mday + 1,
+            tm_mday,
             tm_hour,
             tm_min,
             tm_sec


### PR DESCRIPTION
Seems like I f*d it up. Is this correct now?

**tm_mday**: day of the month – [1, 31]
**[DateTime.Day](https://learn.microsoft.com/en-us/dotnet/api/system.datetime.day?view=net-8.0)**: The day component, expressed as a value between 1 and 31.

**tm_wday**: days since Sunday – [​0​, 6]
**[DateTime.DayOfWeek](https://learn.microsoft.com/en-us/dotnet/api/system.dayofweek?view=net-8.0)**: Sunday 0 - Saturday 6

https://en.cppreference.com/w/cpp/chrono/c/tm