### PR TITLE
Update GHA to automate a bit more of checks

### DIFF
--- a/.github/workflows/cexporter.yaml
+++ b/.github/workflows/cexporter.yaml
@@ -20,6 +20,36 @@ jobs:
       - name: Run CExporter
         working-directory: ./ida
         run: dotnet run --project CExporter/CExporter.csproj -c Release
+      - name: Check error txt file for content
+        id: check_error
+        run: |
+          if [ -s ./ida/errors.txt ]; then
+            echo "error=true" >> $GITHUB_OUTPUT
+          else
+            echo "error=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Upload error txt to comment
+        if: steps.check_error.outputs.error == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const content = fs.readFileSync('./ida/errors.txt', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: content
+            });
+            github.rest.issues.addLabels({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["requested changes"]
+            })
+      - name: Exit with error
+        if: steps.check_error.outputs.error == 'true'
+        run: exit 1
       - name: Tar CExport
         run: tar -czvf CExport.tar.gz ./ida/*.h
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/cexporter.yaml
+++ b/.github/workflows/cexporter.yaml
@@ -1,7 +1,11 @@
 name: CExporter Check
 
 on:
-  pull_request:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
     branches:
       - main
     paths:

--- a/.github/workflows/pr-breaking-change-check.yaml
+++ b/.github/workflows/pr-breaking-change-check.yaml
@@ -1,7 +1,11 @@
 name: Breaking Change Check
 
 on:
-  pull_request:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
     branches:
       - main
     paths:

--- a/.github/workflows/pr-breaking-change-check.yaml
+++ b/.github/workflows/pr-breaking-change-check.yaml
@@ -29,7 +29,7 @@ jobs:
       run: |
         dotnet tool install -g Microsoft.DotNet.ApiCompat.Tool
         testout=$(apicompat -l ida/cs-main/FFXIVClientStructs.dll -r ida/cs-pr/FFXIVClientStructs.dll)
-        if [ "$testout" != "" ]; then
+        if [ "$testout" != "APICompat ran successfully without finding any breaking changes." ]; then
           echo "Breaking changes detected"
           echo "breaking=true" >> $GITHUB_OUTPUT
         else

--- a/.github/workflows/pr-breaking-change-check.yaml
+++ b/.github/workflows/pr-breaking-change-check.yaml
@@ -1,0 +1,49 @@
+name: Breaking Change Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'FFXIVClientStructs/**/*.cs'
+  
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.base_ref }}
+    - name: Install dependencies for main branch
+      run: dotnet restore
+    - name: Build main branch
+      run: dotnet build FFXIVClientStructs/FFXIVClientStructs.csproj --output ida/cs-main/
+    - name: Switch to PR branch
+      run: git checkout ${{ github.head_ref }}
+    - name: Install dependencies for PR branch
+      run: dotnet restore
+    - name: Build PR branch
+      run: dotnet build FFXIVClientStructs/FFXIVClientStructs.csproj --output ida/cs-pr/
+    - name: Check for breaking changes
+      id: breaking_changes
+      run: |
+        dotnet tool install -g Microsoft.DotNet.ApiCompat.Tool
+        testout=$(apicompat -l ida/cs-main/FFXIVClientStructs.dll -r ida/cs-pr/FFXIVClientStructs.dll)
+        if [ "$testout" != "" ]; then
+          echo "Breaking changes detected"
+          echo "breaking=true" >> $GITHUB_OUTPUT
+        else
+          echo "No breaking changes detected"
+          echo "breaking=false" >> $GITHUB_OUTPUT
+        fi
+    - name: Add tag to PR
+      if: steps.breaking_changes.outputs.breaking == 'true'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.issues.addLabels({
+            issue_number: context.payload.pull_request.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ["breaking change"]
+          })


### PR DESCRIPTION
Updated CExporter action to comment with what is wrong and add the requested changes label.
Added ABI check between target and source branches of pr and automatically assign tag if breakage happens.

### Notes
These currently won't work due to some weirdness about how permissions are handled, and it's only getting read instead of write access.
Both actions only add but never remove the tags that have been added if a workflow finds something that needs to be changed or there is an ABI break, but then it's fixed later.