### PR TITLE
Some AgentHUD additions

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHUD.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHUD.cs
@@ -1,5 +1,7 @@
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
@@ -13,11 +15,11 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 public unsafe partial struct AgentHUD {
     [FieldOffset(0x0)] public AgentInterface AgentInterface;
 
-    //[FieldOffset(0x9C0)] public uint CurrentTargetId;
-    //[FieldOffset(0x9C8)] public int TargetCounter;
-    //[FieldOffset(0x9D0)] public uint TargetPartyMemberId;
-    //[FieldOffset(0x9D8)] public int TargetSwitchToSelfCounter;
-    //[FieldOffset(0x9DC)] public uint CurrentBattleCharaTargetLevel;
+    [FieldOffset(0xAB0)] public uint CurrentTargetId;
+    [FieldOffset(0xAB8)] public int TargetCounter;
+    [FieldOffset(0xAC0)] public uint TargetPartyMemberId;
+    [FieldOffset(0xAC8)] public int TargetSwitchToSelfCounter;
+    [FieldOffset(0x9DC)] public uint CurrentBattleCharaTargetLevel;
 
     [FieldOffset(0xCB8)] public int CompanionSummonTimer;
 
@@ -29,7 +31,23 @@ public unsafe partial struct AgentHUD {
     [FieldOffset(0x12C4)] public fixed uint RaidMemberIds[40];
     [FieldOffset(0x1364)] public int RaidGroupSize;
 
+    [FixedSizeArray<HudPartyMemberEnmity>(10)]
+    [FieldOffset(0x1378)] public fixed byte HudPartyMemberEnmityEntries[0x0C * 10];
+    [FixedSizeArray<Pointer<HudPartyMemberEnmity>>(10)]
+    [FieldOffset(0x13F0)] public fixed byte HudPartyMemberEnmityPtrs[0x8 * 10];
+    [Obsolete("Use HudPartyMemberEnmityEntriesSpan or HudPartyMemberEnmityPtrsSpan")]
     [FieldOffset(0x13F0)] public HudPartyMemberEnmity* PartyEnmityList;
+
+    /// <remarks>
+    /// 0 = mineral deposit and lush vegetation patch<br/>
+    /// 1 = legendary mineral deposit<br/>
+    /// 2 = unspoiled lush vegetation patch<br/>
+    /// </remarks>
+    [FixedSizeArray<HudMiniMapGatheringMarker>(6)]
+    [FieldOffset(0x3B00)] public fixed byte MiniMapGatheringMarkers[0xA8 * 6];
+
+    [FieldOffset(0x4808)] public StdVector<MapMarkerData> MapMarkers;
+    [FieldOffset(0x4820)] public StdVector<Pointer<MapMarkerData>> MapMarkerPtrs;
 
     [MemberFunction("48 8B 81 ?? ?? ?? ?? 44 8B C2 83 E2 1F")]
     public partial bool IsMainCommandEnabled(uint mainCommandId);
@@ -48,7 +66,7 @@ public unsafe partial struct AgentHUD {
 public struct HudPartyMemberEnmity {
     [FieldOffset(0x00)] public uint ObjectId;
     [FieldOffset(0x04)] public int Enmity;
-    [FieldOffset(0x08)] public int Index;
+    [FieldOffset(0x08)] public int Index; // TODO: change to short
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x20)]
@@ -57,4 +75,13 @@ public unsafe struct HudPartyMember {
     [FieldOffset(0x8)] public byte* Name;
     [FieldOffset(0x10)] public ulong ContentId;
     [FieldOffset(0x18)] public uint ObjectId;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0xA8)]
+public struct HudMiniMapGatheringMarker
+{
+    [FieldOffset(0x00)] public Utf8String TooltipText;
+    [FieldOffset(0x68)] public MapMarkerBase MapMarker;
+    [FieldOffset(0xA0)] public ushort RecommendedLevel; // maybe?
+    [FieldOffset(0xA2)] public byte ShouldRender;
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
@@ -22,6 +22,8 @@ public unsafe partial struct RaptureAtkModule {
 
     [FieldOffset(0x11C20)] public RaptureAtkUnitManager RaptureAtkUnitManager;
 
+    [FieldOffset(0x1B934)] public bool IsUiFading; // true whenever FadeMiddleBack is active
+
     [FieldOffset(0x1BBB8)] public int NameplateInfoCount;
     [FieldOffset(0x1BBC0)] public NamePlateInfo NamePlateInfoArray; // 0-50, &NamePlateInfoArray[i]
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
@@ -22,8 +22,6 @@ public unsafe partial struct RaptureAtkModule {
 
     [FieldOffset(0x11C20)] public RaptureAtkUnitManager RaptureAtkUnitManager;
 
-    [FieldOffset(0x1B934)] public bool IsUiFading; // true whenever FadeMiddleBack is active
-
     [FieldOffset(0x1BBB8)] public int NameplateInfoCount;
     [FieldOffset(0x1BBC0)] public NamePlateInfo NamePlateInfoArray; // 0-50, &NamePlateInfoArray[i]
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkUnitManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkUnitManager.cs
@@ -17,6 +17,8 @@ public unsafe partial struct RaptureAtkUnitManager {
 
     [FieldOffset(0x9D00)] public UIModule.UiFlags UiFlags;
 
+    [FieldOffset(0x9D14)] public bool IsUiFading; // true whenever FadeMiddleBack is active
+
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B F8 41 B0 01")]
     [GenerateCStrOverloads]
     public partial AtkUnitBase* GetAddonByName(byte* name, int index = 1);

--- a/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
@@ -281,7 +281,7 @@ public unsafe partial struct UIModule {
     // public partial AkatsukiNoteModule* GetAkatsukiNoteModule();
 
     // [VirtualFunction(61)]
-    // public partial GetVVDNoteModule* GetGetVVDNoteModule();
+    // public partial VVDNoteModule* GetVVDNoteModule();
 
     [VirtualFunction(62)]
     public partial VVDActionModule* GetVVDActionModule();


### PR DESCRIPTION
- Updated and added back in some older offsets
- Obsoleted `PartyEnmityList` in favour of new FixedSizeArray fields
- Added `MiniMapGatheringMarkers` containing markers for 
  - mineral deposit and lush vegetation patch,
  - legendary mineral deposit,
  - unspoiled lush vegetation patch,
  - possibly more in the other 3 entries, but I have not been able to figure out what they are used for.
- Added `MapMarkers` containing map markers for directors, quests, housing, and more?! I'm not quite sure what it all contains.