### PR TITLE
Pass Vector3 pointers to Raycast functions

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/Camera.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/Camera.cs
@@ -1,6 +1,7 @@
 using FFXIVClientStructs.FFXIV.Client.Graphics.Kernel;
 using FFXIVClientStructs.FFXIV.Common.Component.BGCollision;
 using FFXIVClientStructs.FFXIV.Common.Math;
+using SystemVec3 = System.Numerics.Vector3;
 
 namespace FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 
@@ -43,7 +44,9 @@ public unsafe partial struct Camera {
         var ray = ScreenPointToRay(screenPos);
         var flags = stackalloc int[] { 0x4000, 0x4000, 0, 0 };
         var hit = new RaycastHit();
-        var result = BGCollisionModule.Raycast(ray.Origin, ray.Direction, 100000.0f, &hit, flags);
+        var origin = (SystemVec3)ray.Origin;
+        var direction = (SystemVec3)ray.Direction;
+        var result = BGCollisionModule.Raycast(&origin, &direction, 100000.0f, &hit, flags);
         worldPos = hit.Point;
         return result;
     }

--- a/FFXIVClientStructs/FFXIV/Common/Component/BGCollision/BGCollisionModule.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Component/BGCollision/BGCollisionModule.cs
@@ -42,18 +42,18 @@ public unsafe partial struct BGCollisionModule {
     [FieldOffset(0x8C)] public Vector4 ForcedStreamingSphere; // w is radius; if w<0, the rest of the components are ignored and instead camera position is used as center with radius=120
 
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 41 0F B6 D6")] // ex to avoid generated name collision
-    public partial bool RaycastEx(RaycastHit* hitInfo, Vector3 origin, Vector3 direction, float maxDistance, int layerMask, int* flags);
+    public partial bool RaycastEx(RaycastHit* hitInfo, Vector3* origin, Vector3* direction, float maxDistance, int layerMask, int* flags);
 
     [MemberFunction("E8 ?? ?? ?? ?? 44 0F B6 F0 84 C0 74 ?? 40 38 BD")]
-    public static partial bool Raycast(Vector3 origin, Vector3 direction, float maxDistance, RaycastHit* hitInfo, int* flags);
+    public static partial bool Raycast(Vector3* origin, Vector3* direction, float maxDistance, RaycastHit* hitInfo, int* flags);
 
     [MemberFunction("48 83 EC 48 48 8B 05 ?? ?? ?? ?? 4D 8B D1")]
-    public static partial bool Raycast2(Vector3 origin, Vector3 direction, float maxDistance, RaycastHit* hitInfo, int* flags);
+    public static partial bool Raycast2(Vector3* origin, Vector3* direction, float maxDistance, RaycastHit* hitInfo, int* flags);
 
     public static bool Raycast(Vector3 origin, Vector3 direction, out RaycastHit hitInfo, float maxDistance = 1000000f) {
         var flags = stackalloc int[] { 0x4000, 0, 0x4000, 0 };
         var hit = new RaycastHit();
-        var result = Raycast(origin, direction, maxDistance, &hit, flags);
+        var result = Raycast(&origin, &direction, maxDistance, &hit, flags);
         hitInfo = hit;
         return result;
     }
@@ -61,7 +61,7 @@ public unsafe partial struct BGCollisionModule {
     public static bool Raycast2(Vector3 origin, Vector3 direction, out RaycastHit hitInfo, float maxDistance = 1000000f) {
         var flags = stackalloc int[] { 0x4000, 0, 0x4000, 0 };
         var hit = new RaycastHit();
-        var result = Raycast2(origin, direction, maxDistance, &hit, flags);
+        var result = Raycast2(&origin, &direction, maxDistance, &hit, flags);
         hitInfo = hit;
         return result;
     }


### PR DESCRIPTION
This is a confusing one, because it works, even though it shouldn't.
According to Pohky, C# (the caller) creates a copy of `Vector3` on the stack, because `struct` is a value type and too big to be passed via the register itself. It passes it as a "stack pointer" instead, which happens to be exactly what the game needs - a pointer.
For me, it simply should be a `Vector3*`, because this is what I see in the games assembly - a dereference.
That it gets converted automatically and becomes a pointer is just ridiculous in my opinion, and should not be relied on, and instead the types should be fixed.

![asm](https://github.com/aers/FFXIVClientStructs/assets/96642047/403cddad-70a0-4271-8ab3-27c15460928b)

Discussion in #plugin-dev where I try to understand what is happening (not very useful and basically explained above): https://discord.com/channels/581875019861328007/653504487352303619/1219332724792229900