### PR TITLE
Add ReferencedUtf8String for TextParameter

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/Text/ReferencedUtf8String.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Text/ReferencedUtf8String.cs
@@ -1,0 +1,12 @@
+using FFXIVClientStructs.FFXIV.Client.System.String;
+
+namespace FFXIVClientStructs.FFXIV.Component.Text;
+
+[StructLayout(LayoutKind.Explicit, Size = 0x70)]
+public unsafe partial struct ReferencedUtf8String {
+    [FieldOffset(0)] public Utf8String Utf8String;
+    [FieldOffset(0x68)] public uint RefCount;
+
+    [MemberFunction("E8 ?? ?? ?? ?? C6 45 E8 01")]
+    public static partial void Create(ReferencedUtf8String** targetPtr, Utf8String* source);
+}

--- a/FFXIVClientStructs/FFXIV/Component/Text/TextParameter.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Text/TextParameter.cs
@@ -2,18 +2,31 @@ using FFXIVClientStructs.FFXIV.Client.System.String;
 
 namespace FFXIVClientStructs.FFXIV.Component.Text;
 
-[StructLayout(LayoutKind.Explicit, Size = 0x20)]
-public unsafe struct TextParameter {
+[StructLayout(LayoutKind.Explicit, Size = 0x18)]
+public unsafe partial struct TextParameter {
     [FieldOffset(0)] public int IntValue;
     [FieldOffset(0)] public byte* StringValue;
+    [FieldOffset(0)] public ReferencedUtf8String* ReferencedUtf8StringValue;
+    [Obsolete("Use ReferencedUtf8StringValue")]
     [FieldOffset(0)] public Utf8String* Utf8StringValue;
     [FieldOffset(0x8)] public void* ValuePtr; // a pointer to the value
     [FieldOffset(0x10)] public TextParameterType Type;
+
+    [MemberFunction("E8 ?? ?? ?? ?? EB 11 48 83 F8 02")]
+    public partial void SetReferencedUtf8String(ReferencedUtf8String** ptr);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 FF 45 1F")]
+    public partial void SetString(byte** ptr);
+
+    [MemberFunction("E8 ?? ?? ?? ?? EB 31 85 D2")]
+    public partial void SetInteger(int* ptr);
 }
 
 public enum TextParameterType : sbyte {
     Uninitialized = -1,
     Integer = 0,
+    ReferencedUtf8String = 1,
+    [Obsolete("Use ReferencedUtf8String")]
     Utf8String = 1,
     String = 2
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -83,6 +83,7 @@ functions:
   0x140058500: WinMain
   0x1400581B0: std::string::ctor_FromSubStr #(other, idx, len)
   0x1400582F0: std::string::ctor_FromCharArr #(arr, len)
+  0x14165ABE0: std::_Xlength_error
   0x140185520: std::deque::_Growmap
   0x140059700: GetStdOut
   0x140059710: vsprintf_s
@@ -5789,7 +5790,7 @@ classes:
       0x140131C60: SetInteger
   std::deque<Component::Text::TextParameter>:
     funcs:
-      0x140187200: ResetMap
+      0x140187200: _Reset_map
   Client::System::Data::Bit:
     vtbls:
       - ea: 0x141A18158

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -81,8 +81,9 @@ globals:
 
 functions:
   0x140058500: WinMain
-  0x1400581B0: std:string::ctor_FromSubStr #(other, idx, len)
-  0x1400582F0: std:string::ctor_FromCharArr #(arr, len)
+  0x1400581B0: std::string::ctor_FromSubStr #(other, idx, len)
+  0x1400582F0: std::string::ctor_FromCharArr #(arr, len)
+  0x140185520: std::deque::_Growmap
   0x140059700: GetStdOut
   0x140059710: vsprintf_s
   0x140059770: vswprintf_s
@@ -5762,6 +5763,7 @@ classes:
     vtbls:
       - ea: 0x141A17000
     funcs:
+      0x14063CF50: ctor
       0x14063D6F0: ReadExpression
       0x14063DF80: ReadParameter
   Component::Text::MacroEncoder:
@@ -5777,6 +5779,17 @@ classes:
     vtbls:
       - ea: 0x141A171C0
         base: Component::Text::MacroDecoder
+  Component::Text::ReferencedUtf8String:
+    funcs:
+      0x1403272F0: Create
+  Component::Text::TextParameter:
+    funcs:
+      0x140131D50: SetReferencedUtf8String
+      0x140131CD0: SetString
+      0x140131C60: SetInteger
+  std::deque<Component::Text::TextParameter>:
+    funcs:
+      0x140187200: ResetMap
   Client::System::Data::Bit:
     vtbls:
       - ea: 0x141A18158


### PR DESCRIPTION
`TextParameter` doesn't hold a plain `Utf8String`, but a struct containing the `Utf8String` and a `RefCount`.
I called it `ReferencedUtf8String `, based on [ReferencedClassBase.cs](https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Client/Graphics/ReferencedClassBase.cs).

The game calls the Utf8String.dtor and frees the `ReferencedUtf8String` if RefCount is 0 when setting a new value or cleaning up.

I didn't know where to put it, so I placed it in the same namespace as `TextParameter`.