### PR TITLE
Add Control.GetLocalPlayer

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
@@ -13,4 +13,7 @@ public unsafe partial struct Control {
 
     [StaticAddress("4C 8D 35 ?? ?? ?? ?? 85 D2", 3)]
     public static partial Control* Instance();
+
+    [StaticAddress("48 89 05 ?? ?? ?? ?? 48 8B 49 08", 3, true)]
+    public static partial BattleChara* GetLocalPlayer(); // g_LocalPlayer
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -27,8 +27,8 @@ globals:
   0x1421C5D08: g_animationFactorRemainder
   0x1421C5D0C: g_animationFactor #percentage of a 30fps frame rendered this frame
   0x1421C8BE0: g_PerformanceFrequency
-  0x1421D3268: g_LocalPlayerObjectID
-  0x1421D3270: g_LocalPlayer
+  0x1421D3268: g_Client::Game::Control::Control_LocalPlayerObjectID
+  0x1421D3270: g_Client::Game::Control::Control_LocalPlayer
   0x1421F94B0: g_LastTextCommand
   0x1421F9840: g_CharacterManager_BattleCharaMemoryPtr
   0x1421F9848: g_CharacterManager_CompanionMemoryPtr


### PR DESCRIPTION
It kinda bugs me that we only have access to the local player character via a `LocalPlayer` field in `Control` or via index 0 of the ObjectList/BattleCharaList, which is why I added a more direct StaticAddress function to access `g_LocalPlayer` with `CharacterManager.GetLocalPlayer()`.
The sig is exactly where it sets the `g_LocalPlayer` variable in `CharacterManager`, so I thought this is fitting in there.