### PR TITLE
Update InfoProxyLetter

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyLetter.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyLetter.cs
@@ -5,22 +5,29 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Info;
 [StructLayout(LayoutKind.Explicit, Size = 0x5250)]
 public unsafe partial struct InfoProxyLetter {
     [FieldOffset(0x00)] public InfoProxyPageInterface InfoProxyPageInterface;
+    [FieldOffset(0x20)] public uint NumOfDeniedLetters;
+    [FieldOffset(0x24)] public ushort NumAttachments;
+    [Obsolete("Use NumAttachments")]
     [FieldOffset(0x24)] public byte NumAtachments;
-    [FieldOffset(0x27)] public byte NumLettersFromFriends;
+    [FieldOffset(0x26)] public byte NumNewLetters;
+    [FieldOffset(0x27)] public byte NumLettersFromFriends; // 100 max
+    [FieldOffset(0x28)] public byte NumLettersFromPurchases; // 20 max
+    [FieldOffset(0x29)] public byte NumLettersFromGameMasters; // 10 max
+    [FieldOffset(0x2A)] public bool HasLettersFromGameMasters;
+    [FieldOffset(0x2B)] public bool HasLettersFromSupportDesk;
     [FieldOffset(0x28)] public byte NumPurchases;
     [FixedSizeArray<Letter>(130)]
-    [FieldOffset(0x30)] public fixed byte Letters[130 * 0xa0];
+    [FieldOffset(0x30)] public fixed byte Letters[130 * 0xA0];
     //0xCC0 After
     [FieldOffset(0x5178)] public Utf8String UnkString0;
     [FieldOffset(0x51E0)] public Utf8String UnkString1;
-
 
     [StructLayout(LayoutKind.Explicit, Size = 0xA0)]
     public unsafe partial struct Letter {
         [FieldOffset(0x00)] public long SenderContentID;// 0xFFFFFFFF for Store
         [FieldOffset(0x08)] public uint Timestamp;
         [FixedSizeArray<ItemAttachment>(5)]
-        [FieldOffset(0x0C)] public fixed byte Attachments[40];
+        [FieldOffset(0x0C)] public fixed byte Attachments[0x08 * 5];
         [FieldOffset(0x38)] public uint Gil;
         [FieldOffset(0x3C)] public bool Read;
 

--- a/FFXIVClientStructs/FFXIV/Component/Text/MacroDecoder.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Text/MacroDecoder.cs
@@ -14,52 +14,66 @@ public unsafe partial struct MacroDecoder {
 // GlobalParameters
 // Note that the StdDeque (and this list) is zero-based, so you need to subtract 1 from gnum/gstr.
 //
-// |-------|---------------|----------------------------------------------------------|
-// | Index | Type          | Label                                                    |
-// |-------|---------------|----------------------------------------------------------|
-// |     0 | Utf8String    | Player Name                                              |
-// |     1 | String        | Log Message Name 1                                       |
-// |     2 | String        | Log Message Name 2                                       |
-// |     3 | Integer       | Player Sex                                               |
-// |    10 | Integer       | Eorzea Time Hours                                        |
-// |    11 | Integer       | Eorzea Time Minutes                                      |
-// |    12 | Integer       | Log Text Colors - Chat 1 - Say                           |
-// |    13 | Integer       | Log Text Colors - Chat 1 - Shout                         |
-// |    14 | Integer       | Log Text Colors - Chat 1 - Tell                          |
-// |    15 | Integer       | Log Text Colors - Chat 1 - Party                         |
-// |    16 | Integer       | Log Text Colors - Chat 1 - Alliance                      |
-// | 17-24 | Integer       | Log Text Colors - Chat 2 - LS1-8                         |
-// |    25 | Integer       | Log Text Colors - Chat 2 - Free Company                  |
-// |    26 | Integer       | Log Text Colors - Chat 2 - PvP Team                      |
-// | 29,30 | Integer       | Log Text Colors - Chat 1 - Emotes                        |
-// |    31 | Integer       | Log Text Colors - Chat 1 - Yell                          |
-// |    34 | Integer       | Log Text Colors - Chat 2 - CWLS1                         |
-// |    27 | Integer       | Log Text Colors - General - PvP Team Announcements       |
-// |    28 | Integer       | Log Text Colors - Chat 2 - Novice Network                |
-// |    32 | Integer       | Log Text Colors - General - Free Company Announcements   |
-// |    33 | Integer       | Log Text Colors - General - Novice Network Announcements |
-// |    35 | Integer       | Log Text Colors - Battle - Damage Dealt                  |
-// |    36 | Integer       | Log Text Colors - Battle - Missed Attacks                |
-// |    37 | Integer       | Log Text Colors - Battle - Actions                       |
-// |    38 | Integer       | Log Text Colors - Battle - Items                         |
-// |    39 | Integer       | Log Text Colors - Battle - Healing                       |
-// |    40 | Integer       | Log Text Colors - Battle - Enchanting Effects            |
-// |    41 | Integer       | Log Text Colors - Battle - Enfeebing Effects             |
-// |    42 | Integer       | Log Text Colors - General - Echo                         |
-// |    43 | Integer       | Log Text Colors - General - System Messages              |
-// |    54 | Utf8String    | Companion Name                                           |
-// |    56 | Integer       | Log Text Colors - General - Battle System Messages       |
-// |    57 | Integer       | Log Text Colors - General - Gathering System Messages    |
-// |    58 | Integer       | Log Text Colors - General - Error Messages               |
-// |    59 | Integer       | Log Text Colors - General - NPC Dialogue                 |
-// |    60 | Integer       | Log Text Colors - General - Item Drops                   |
-// |    61 | Integer       | Log Text Colors - General - Level Up                     |
-// |    62 | Integer       | Log Text Colors - General - Loot                         |
-// |    63 | Integer       | Log Text Colors - General - Synthesis                    |
-// |    64 | Integer       | Log Text Colors - General - Gathering                    |
-// |    67 | Integer       | Player ClassJobId                                        |
-// |    68 | Integer       | Player Level                                             |
-// |    70 | Integer       | Player Race                                              |
-// |    77 | Integer       | Client/Plattform?                                        |
-// |    82 | Integer       | Datacenter Region (see WorldDCGroupType sheet)           |
-// |-------|---------------|----------------------------------------------------------|
+// |-------|----------------------|----------------------------------------------------------|
+// | Index | Type                 | Label                                                    |
+// |-------|----------------------|----------------------------------------------------------|
+// |     0 | ReferencedUtf8String | Player Name                                              |
+// |     1 | String               | Log Message Name 1                                       |
+// |     2 | String               | Log Message Name 2                                       |
+// |     3 | Integer              | Player Sex                                               |
+// |    10 | Integer              | Eorzea Time Hours                                        |
+// |    11 | Integer              | Eorzea Time Minutes                                      |
+// |    12 | Integer              | Log Text Colors - Chat 1 - Say                           |
+// |    13 | Integer              | Log Text Colors - Chat 1 - Shout                         |
+// |    14 | Integer              | Log Text Colors - Chat 1 - Tell                          |
+// |    15 | Integer              | Log Text Colors - Chat 1 - Party                         |
+// |    16 | Integer              | Log Text Colors - Chat 1 - Alliance                      |
+// |    17 | Integer              | Log Text Colors - Chat 2 - LS1                           |
+// |    18 | Integer              | Log Text Colors - Chat 2 - LS2                           |
+// |    19 | Integer              | Log Text Colors - Chat 2 - LS3                           |
+// |    20 | Integer              | Log Text Colors - Chat 2 - LS4                           |
+// |    21 | Integer              | Log Text Colors - Chat 2 - LS5                           |
+// |    22 | Integer              | Log Text Colors - Chat 2 - LS6                           |
+// |    23 | Integer              | Log Text Colors - Chat 2 - LS7                           |
+// |    24 | Integer              | Log Text Colors - Chat 2 - LS8                           |
+// |    25 | Integer              | Log Text Colors - Chat 2 - Free Company                  |
+// |    26 | Integer              | Log Text Colors - Chat 2 - PvP Team                      |
+// |    27 | Integer              | Log Text Colors - General - PvP Team Announcements       |
+// |    28 | Integer              | Log Text Colors - Chat 2 - Novice Network                |
+// |    29 | Integer              | Log Text Colors - Chat 1 - Emotes (Personal Emotes)      |
+// |    30 | Integer              | Log Text Colors - Chat 1 - Emotes                        |
+// |    32 | Integer              | Log Text Colors - General - Free Company Announcements   |
+// |    33 | Integer              | Log Text Colors - General - Novice Network Announcements |
+// |    34 | Integer              | Log Text Colors - Chat 2 - CWLS1                         |
+// |    35 | Integer              | Log Text Colors - Battle - Damage Dealt                  |
+// |    36 | Integer              | Log Text Colors - Battle - Missed Attacks                |
+// |    37 | Integer              | Log Text Colors - Battle - Actions                       |
+// |    38 | Integer              | Log Text Colors - Battle - Items                         |
+// |    39 | Integer              | Log Text Colors - Battle - Healing                       |
+// |    40 | Integer              | Log Text Colors - Battle - Enchanting Effects            |
+// |    41 | Integer              | Log Text Colors - Battle - Enfeebing Effects             |
+// |    42 | Integer              | Log Text Colors - General - Echo                         |
+// |    43 | Integer              | Log Text Colors - General - System Messages              |
+// |    54 | ReferencedUtf8String | Companion Name                                           |
+// |    56 | Integer              | Log Text Colors - General - Battle System Messages       |
+// |    57 | Integer              | Log Text Colors - General - Gathering System Messages    |
+// |    58 | Integer              | Log Text Colors - General - Error Messages               |
+// |    59 | Integer              | Log Text Colors - General - NPC Dialogue                 |
+// |    60 | Integer              | Log Text Colors - General - Item Drops                   |
+// |    61 | Integer              | Log Text Colors - General - Level Up                     |
+// |    62 | Integer              | Log Text Colors - General - Loot                         |
+// |    63 | Integer              | Log Text Colors - General - Synthesis                    |
+// |    64 | Integer              | Log Text Colors - General - Gathering                    |
+// |    67 | Integer              | Player ClassJobId                                        |
+// |    68 | Integer              | Player Level                                             |
+// |    70 | Integer              | Player Race                                              |
+// |    77 | Integer              | Client/Plattform?                                        |
+// |    82 | Integer              | Datacenter Region (see WorldDCGroupType sheet)           |
+// |    83 | Integer              | Log Text Colors - Chat 2 - CWLS2                         |
+// |    84 | Integer              | Log Text Colors - Chat 2 - CWLS3                         |
+// |    85 | Integer              | Log Text Colors - Chat 2 - CWLS4                         |
+// |    86 | Integer              | Log Text Colors - Chat 2 - CWLS5                         |
+// |    87 | Integer              | Log Text Colors - Chat 2 - CWLS6                         |
+// |    88 | Integer              | Log Text Colors - Chat 2 - CWLS7                         |
+// |    89 | Integer              | Log Text Colors - Chat 2 - CWLS8                         |
+// |-------|----------------------|----------------------------------------------------------|

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3073,6 +3073,14 @@ classes:
         base: Client::UI::Info::InfoProxyPageInterface
     funcs:
       0x14010BE00: ctor
+      0x14010CA70: GetNumOfDeniedLetters
+      0x14010CA80: GetNumAttachments
+      0x14010CA90: GetNumNewLetters
+      0x14010CAA0: GetLetterBoxUsage
+      0x14010CAC0: GetNumLettersFromPurchases
+      0x14010CAD0: GetNumLettersFromGameMasters
+      0x14010CAE0: HasLettersFromGameMasters
+      0x14010CAF0: HasLettersFromSupportDesk
       0x14017C7A0: Finalize
   Client::UI::Info::InfoProxySearch:
     vtbls:
@@ -6957,6 +6965,7 @@ classes:
       0x140C06330: IsMainCommandEnabled
       0x140C06360: SetMainCommandEnabledState
       0x140C0A6B0: UpdateParty
+      0x140C0BEF0: UpdateDTR
       0x140C0E6F0: UpdateHotBar
       0x140C1BE70: OpenContextMenuFromTarget
       0x140C1ECC0: GetMainCommandString  # MainCommand exd


### PR DESCRIPTION
Adds fields to get the number of letters, as shown in the DTR bar.
Found at `BA ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B D8 48 85 C0 0F 84 ?? ?? ?? ?? 48 8B C8`.

- Not sure if `HasLettersFromGameMasters` and `HasLettersFromSupportDesk` are actually boolean, but it looks like it based on the DTR bar.
- Not sure if `NumNewLetters` is actually for new/unread letters.
- `NumLettersFromPurchases` was just a guess, because it was the last field and tab that was missing, and fits perfectly.
- Fixed type and typo for `NumAttachments`.
- Not tested with real letters, because I have nobody to send me any letters. ☹️ 
- Sneaked in a GlobalParameters update. 🙊