### PR TITLE
Propagate [Obsolete] attribute to generated properties and methods

### DIFF
--- a/FFXIVClientStructs.InteropSourceGenerators/AttributePropagationProvider.cs
+++ b/FFXIVClientStructs.InteropSourceGenerators/AttributePropagationProvider.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Immutable;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace FFXIVClientStructs.InteropSourceGenerators;
+
+public class AttributePropagationProvider(ISymbol symbol) {
+
+    private static readonly ImmutableArray<string> AttributesToPropagate = ImmutableArray.Create(["global::System.ObsoleteAttribute"]);
+    
+    public string Output => Build();
+
+    private string Build() {
+        StringBuilder output = new StringBuilder();
+        
+        foreach (var attribute in symbol.GetAttributes()) {
+            if(attribute.AttributeClass is null) continue;
+            string attributeText = attribute.AttributeClass.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)[..^9];
+            string fullyClassifiedTypeNAme = attribute.AttributeClass.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            if(!AttributesToPropagate.Contains(fullyClassifiedTypeNAme)) continue;
+            output.Append($"[{attributeText}");
+            bool hasArguments = attribute.ConstructorArguments.Any() || attribute.NamedArguments.Any();
+            if (hasArguments) output.Append("(");
+            if (attribute.ConstructorArguments.Any()) {
+                output.Append(string.Join(", ",attribute.ConstructorArguments.Map(FormatArgument)));
+                if (attribute.NamedArguments.Any())
+                    output.Append(", ");
+            }
+            if (attribute.NamedArguments.Any()) {
+                output.Append(string.Join(", ", attribute.NamedArguments.Map(arg => $"{arg.Key} = {FormatArgument(arg.Value)}")));
+            }
+            if (hasArguments) output.Append(")");
+            output.Append("]");
+        }
+        
+        return output.ToString();
+    }
+    private static string FormatArgument(TypedConstant arg) => arg.Type?.Name switch {
+        "String"  => $"\"{arg.Value}\"",
+        _ => $"{arg.Value}"
+    };
+}

--- a/FFXIVClientStructs.InteropSourceGenerators/FixedSizeArrayGenerator.cs
+++ b/FFXIVClientStructs.InteropSourceGenerators/FixedSizeArrayGenerator.cs
@@ -58,7 +58,7 @@ internal sealed class FixedSizeArrayGenerator : IIncrementalGenerator {
         });
     }
 
-    internal sealed record FixedSizeArrayInfo(string FieldName, string TypeName, int Count) {
+    internal sealed record FixedSizeArrayInfo(string FieldName, string TypeName, int Count, string Attributes) {
         public static Validation<DiagnosticInfo, FixedSizeArrayInfo> GetFromRoslyn(IFieldSymbol fieldSymbol) {
             Validation<DiagnosticInfo, IFieldSymbol> validSymbol =
                 (fieldSymbol.IsFixedSizeBuffer
@@ -90,11 +90,11 @@ internal sealed class FixedSizeArrayGenerator : IIncrementalGenerator {
                 attribute.GetValidAttributeArgument<int>("Count", 0, AttributeName, fieldSymbol);
 
             return (validSymbol, validType, validCount).Apply((symbol, type, count) =>
-                new FixedSizeArrayInfo(symbol.Name, type, count));
+                new FixedSizeArrayInfo(symbol.Name, type, count, new AttributePropagationProvider(fieldSymbol).Output));
         }
 
         public void RenderFixedSizeArraySpan(IndentedStringBuilder builder) {
-            builder.AppendLine($"public Span<{TypeName}> {FieldName}Span => new(Unsafe.AsPointer(ref {FieldName}[0]), {Count});");
+            builder.AppendLine($"{Attributes}public Span<{TypeName}> {FieldName}Span => new(Unsafe.AsPointer(ref {FieldName}[0]), {Count});");
         }
     }
 


### PR DESCRIPTION
"Copies" the [Obsolete(....)] to generated properties and methods if present on the underlying field/method