### PR TITLE
Offset corrections for BRD gauge

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonJobHudBRD.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonJobHudBRD.cs
@@ -57,7 +57,7 @@ public unsafe partial struct AddonJobHudBRD0 {
         [FieldOffset(0xC8)] public AtkResNode* SongsPlayed;
 
         [FixedSizeArray<Pointer<AtkComponentBase>>(3)]
-        [FieldOffset(0x98)] public fixed byte SongIcon[3 * 0x08];
+        [FieldOffset(0xD0)] public fixed byte SongIcon[3 * 0x08];
     }
 
     [StructLayout(LayoutKind.Explicit, Size = 0xE0)]
@@ -87,7 +87,7 @@ public unsafe partial struct AddonJobHudBRD0 {
         [FixedSizeArray<Pointer<AtkComponentBase>>(3)]
         [FieldOffset(0xB0)] public fixed byte SongIcon[3 * 0x08];
 
-        [FieldOffset(0x60)] public byte RadiantFinaleStatus;
+        [FieldOffset(0xC8)] public byte RadiantFinaleStatus;
     }
 
     [FieldOffset(0x260)] public SongGaugeData DataPrevious;


### PR DESCRIPTION
Fixed a couple of wrong offsets in the BRD gauge.

There seem to be a few more fields within the struct that aren't yet documented, but I'm not too fussed about those; 7.0 is going to break various job gauges in a couple months (and there's no way to know which ones), so outright error-fixes are the only updates I'd bother making.