### PR TITLE
Obsolete uint Agent/InfoProxy getters

### DIFF
--- a/FFXIVClientStructs.InteropSourceGenerators/AgentGettersGenerator.cs
+++ b/FFXIVClientStructs.InteropSourceGenerators/AgentGettersGenerator.cs
@@ -101,7 +101,7 @@ internal sealed class AgentGettersGenerator : IIncrementalGenerator {
             StructInfo.RenderStart(builder);
 
             builder.AppendLine();
-            builder.AppendLine($"public static {StructInfo.Name}* Instance() => ({StructInfo.Name}*)AgentModule.Instance()->GetAgentByInternalID({AgentInfo.AgentId});");
+            builder.AppendLine($"public static {StructInfo.Name}* Instance() => ({StructInfo.Name}*)AgentModule.Instance()->GetAgentByInternalId((AgentId){AgentInfo.AgentId});");
             builder.AppendLine();
 
             StructInfo.RenderEnd(builder);
@@ -114,7 +114,7 @@ internal sealed class AgentGettersGenerator : IIncrementalGenerator {
         }
 
         public void RenderAgentGetter(IndentedStringBuilder builder) {
-            builder.AppendLine($"public {StructInfo.Name}* Get{StructInfo.Name}() => ({StructInfo.Name}*)GetAgentByInternalID({AgentInfo.AgentId});");
+            builder.AppendLine($"public {StructInfo.Name}* Get{StructInfo.Name}() => ({StructInfo.Name}*)GetAgentByInternalId((AgentId){AgentInfo.AgentId});");
         }
     }
 }

--- a/FFXIVClientStructs.InteropSourceGenerators/InfoProxyInstanceGenerator.cs
+++ b/FFXIVClientStructs.InteropSourceGenerators/InfoProxyInstanceGenerator.cs
@@ -100,7 +100,7 @@ public class InfoProxyInstanceGenerator : IIncrementalGenerator {
             StructInfo.RenderStart(builder);
 
             builder.AppendLine();
-            builder.AppendLine($"public static {StructInfo.Name}* Instance() => ({StructInfo.Name}*)InfoModule.Instance()->GetInfoProxyById((uint){InfoProxyInfo.InfoProxyId});");
+            builder.AppendLine($"public static {StructInfo.Name}* Instance() => ({StructInfo.Name}*)InfoModule.Instance()->GetInfoProxyById((InfoProxyId){InfoProxyInfo.InfoProxyId});");
             builder.AppendLine();
 
             StructInfo.RenderEnd(builder);
@@ -113,7 +113,7 @@ public class InfoProxyInstanceGenerator : IIncrementalGenerator {
         }
 
         public void RenderInfoProxyGetter(IndentedStringBuilder builder) {
-            builder.AppendLine($"public {StructInfo.Name}* Get{StructInfo.Name}() => ({StructInfo.Name}*)GetInfoProxyById((uint){InfoProxyInfo.InfoProxyId});");
+            builder.AppendLine($"public {StructInfo.Name}* Get{StructInfo.Name}() => ({StructInfo.Name}*)GetInfoProxyById((InfoProxyId){InfoProxyInfo.InfoProxyId});");
         }
     }
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
@@ -22,6 +22,7 @@ public unsafe partial struct AgentModule {
     [MemberFunction("E8 ?? ?? ?? ?? 0F B7 A8")]
     public partial AgentInterface* GetAgentByInternalId(AgentId agentID);
 
+    [Obsolete("Use GetAgentByInternalId(AgentId)")]
     public AgentInterface* GetAgentByInternalID(uint agentId)
         => GetAgentByInternalId((AgentId)agentId);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
@@ -17,6 +17,7 @@ public unsafe partial struct InfoModule {
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 55 68")]
     public partial InfoProxyInterface* GetInfoProxyById(InfoProxyId id);
 
+    [Obsolete("Use GetInfoProxyById(InfoProxyId)")]
     public InfoProxyInterface* GetInfoProxyById(uint id)
         => GetInfoProxyById((InfoProxyId)id);
 


### PR DESCRIPTION
~~Stacked PR~~, based on https://github.com/aers/FFXIVClientStructs/pull/855 to make it an optional change.

This PR marks `GetAgentByInternalID(uint)` and `GetInfoProxyById(uint)` obsolete and makes the enum variants the primary and only getters. Users can just cast to AgentId/InfoProxyId if an something is missing in the enum. 🤷‍♂️