### PR TITLE
Add AgentDetail and update InfoProxySearchComment

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentDetail.cs
@@ -1,0 +1,37 @@
+using FFXIVClientStructs.FFXIV.Client.UI.Info;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
+// Client::UI::Agent::AgentDetail
+//   Client::UI::Agent::AgentInterface
+//     Component::GUI::AtkModuleInterface::AtkEventInterface
+[Agent(AgentId.Detail)]
+[StructLayout(LayoutKind.Explicit, Size = 0x48)]
+public unsafe partial struct AgentDetail {
+    [FieldOffset(0)] public AgentInterface AgentInterface;
+
+    [FieldOffset(0x30)] public InfoProxySearchComment* InfoProxySearchCommentPtr;
+
+    [FieldOffset(0x41)] public bool IsBattleMentor;
+    [FieldOffset(0x42)] public bool IsTradeMentor;
+    [FieldOffset(0x43)] public bool IsReturner;
+
+    /// <summary>
+    /// Opens the SocialDetail addon.
+    /// </summary>
+    /// <param name="characterData">
+    /// A pointer to the data of the character.
+    /// </param>
+    /// <param name="infoProxySearchComment28">
+    /// A pointer to <see cref="InfoProxySearchComment"/>+0x28.<br/>
+    /// Used open the editor version of the Social Info window as it will write to this on save.<br/>
+    /// Pass 0 for other players, so it just opens the viewer.
+    /// </param>
+    /// <param name="ownerAddonId">
+    /// The owner addon id, used to position the window.<br/>
+    /// Can be 0, but will open slightly off-center.
+    /// </param>
+    [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? BE ?? ?? ?? ??")]
+    public partial void OpenForCharacterData(InfoProxyCommonList.CharacterData* characterData, nint infoProxySearchComment28 = 0, int ownerAddonId = 0);
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentDetail.cs
@@ -13,9 +13,11 @@ public unsafe partial struct AgentDetail {
 
     [FieldOffset(0x30)] public InfoProxySearchComment* InfoProxySearchCommentPtr;
 
-    [FieldOffset(0x41)] public bool IsBattleMentor;
-    [FieldOffset(0x42)] public bool IsTradeMentor;
-    [FieldOffset(0x43)] public bool IsReturner;
+    // Don't use these, as they are probably used for SocialDetail.
+    // See functions in PlayerState if you want to check these.
+    [FieldOffset(0x41)] internal bool IsBattleMentor;
+    [FieldOffset(0x42)] internal bool IsTradeMentor;
+    [FieldOffset(0x43)] internal bool IsReturner;
 
     /// <summary>
     /// Opens the SocialDetail addon.
@@ -23,15 +25,15 @@ public unsafe partial struct AgentDetail {
     /// <param name="characterData">
     /// A pointer to the data of the character.
     /// </param>
-    /// <param name="infoProxySearchComment28">
-    /// A pointer to <see cref="InfoProxySearchComment"/>+0x28.<br/>
-    /// Used open the editor version of the Social Info window as it will write to this on save.<br/>
-    /// Pass 0 for other players, so it just opens the viewer.
+    /// <param name="updateDataPacket">
+    /// A pointer to <see cref="InfoProxySearchComment.UpdateData"/>.<br/>
+    /// If set, used to open the editor version of the Social Info window as it will write to this on save.<br/>
+    /// Pass <c>null</c> for other players, so it just opens the viewer.
     /// </param>
     /// <param name="ownerAddonId">
     /// The owner addon id, used to position the window.<br/>
     /// Can be 0, but will open slightly off-center.
     /// </param>
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? BE ?? ?? ?? ??")]
-    public partial void OpenForCharacterData(InfoProxyCommonList.CharacterData* characterData, nint infoProxySearchComment28 = 0, int ownerAddonId = 0);
+    public partial void OpenForCharacterData(InfoProxyCommonList.CharacterData* characterData, InfoProxySearchComment.UpdateDataPacket* updateDataPacket = null, int ownerAddonId = 0);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
@@ -92,6 +92,8 @@ public enum AgentId : uint {
     SocialPartyMember = 59,
     // PartyInvite,
     SocialSearch = 61,
+    Detail = 62,
+    [Obsolete("Renamed to Detail")]
     SocialDetail = 62,
     LetterList = 63,
     LetterView = 64,

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
@@ -21,6 +21,12 @@ public unsafe partial struct InfoModule {
     public InfoProxyInterface* GetInfoProxyById(uint id)
         => GetInfoProxyById((InfoProxyId)id);
 
+    [MemberFunction("E8 ?? ?? ?? ?? 49 83 C9 FF 48 8D 8C 24")]
+    public partial byte* GetLocalCharacterName();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 39 03")]
+    public partial ulong GetLocalContentId();
+
     /// <summary>
     /// Checks if the local player has a specific online status set.
     /// </summary>

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCommonList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCommonList.cs
@@ -7,7 +7,11 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Info;
 public unsafe partial struct InfoProxyCommonList {
     [FieldOffset(0x0)] public InfoProxyPageInterface InfoProxyPageInterface;
     [FieldOffset(0x20)] public Utf8String Unk20;
+    [FieldOffset(0x88)] public byte NumberArrayIndex;
+    [Obsolete("Renamed to NumberArrayIndex")]
     [FieldOffset(0x88)] public byte Unk88; //Corresponding ATkModule NumberArrrayIndex
+    [FieldOffset(0x89)] public byte StringArrayIndex;
+    [Obsolete("Renamed to StringArrayIndex")]
     [FieldOffset(0x89)] public byte Unk89; //Corresponding ATkModule StringArrrayIndex
     [FieldOffset(0x8A)] public ushort DataSize;
     [FieldOffset(0x8C)] public ushort DictSize;
@@ -26,6 +30,12 @@ public unsafe partial struct InfoProxyCommonList {
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 85 FF 74 55")]
     public partial CharacterData* GetEntry(uint idx);
+
+    [MemberFunction("E9 ?? ?? ?? ?? 3B 5F 10")]
+    public partial CharacterData* GetEntryByContentId(ulong contentId, int a3 = 0, byte a4 = 0);
+
+    [MemberFunction("E8 ?? ?? ?? ?? EB 3C 8D 45 EF"), GenerateCStrOverloads]
+    public partial CharacterData* GetEntryByName(byte* characterName, ushort worldId);
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 13 45 33 C9")]
     public partial void ApplyFilters();

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCommonList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCommonList.cs
@@ -32,7 +32,7 @@ public unsafe partial struct InfoProxyCommonList {
     public partial CharacterData* GetEntry(uint idx);
 
     [MemberFunction("E9 ?? ?? ?? ?? 3B 5F 10")]
-    public partial CharacterData* GetEntryByContentId(ulong contentId, int a3 = 0, byte a4 = 0);
+    public partial CharacterData* GetEntryByContentId(ulong contentId, uint nameCrc32 = 0, byte a4 = 0);
 
     [MemberFunction("E8 ?? ?? ?? ?? EB 3C 8D 45 EF"), GenerateCStrOverloads]
     public partial CharacterData* GetEntryByName(byte* characterName, ushort worldId);

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxySearchComment.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxySearchComment.cs
@@ -6,11 +6,46 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Info;
 [StructLayout(LayoutKind.Explicit, Size = 0x240)]
 public unsafe partial struct InfoProxySearchComment {
     [FieldOffset(0x00)] public InfoProxyInterface InfoProxyInterface;
+
     [FieldOffset(0x20)] public void* Unk20;
-    [FieldOffset(0x3a)] public fixed byte SearchCommentAsByteArr[62]; //Length is guessed
-    //136 bytes
+    [FieldOffset(0x28)] public UpdateDataPacket UpdateData;
+
+    [Obsolete("Use UpdateData.SearchComment")]
+    [FieldOffset(0x3A)] public fixed byte SearchCommentAsByteArr[62]; //Length is guessed
+
     [FieldOffset(0x100)] public Utf8String SearchComment;
     [FieldOffset(0x168)] public Utf8String UnkString1;
     [FieldOffset(0x1D0)] public Utf8String UnkString2;
-    //8 bytes
+    [FieldOffset(0x238)] public bool HasUpdateData;
+
+    [StructLayout(LayoutKind.Explicit, Size = 0xD3)]
+    public struct UpdateDataPacket {
+        [FieldOffset(0x00)] public InfoProxyCommonList.CharacterData.OnlineStatus OnlineStatusMask;
+        [FieldOffset(0x08)] public ulong LookingForPartyClassJobIdMask;
+        [FieldOffset(0x10)] public byte ClassJobId;
+        [FieldOffset(0x11)] public InfoProxyCommonList.CharacterData.LanguageMask LanguageMask;
+        [FieldOffset(0x12)] public fixed byte SearchComment[0xC1];
+    }
+
+    [MemberFunction("38 51 38 74 0A")]
+    public partial void SetUpdateClassJobId(byte classJobId);
+
+    [MemberFunction("48 39 51 30 74 0B")]
+    public partial void SetUpdateLookingForPartyClassJobIdMask(ulong classJobIdMask);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 0F B6 53 15")]
+    public partial void SetUpdateOnlineStatus(InfoProxyCommonList.CharacterData.OnlineStatus onlineStatus);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8D 53 16")]
+    public partial void SetUpdateLanguageMask(InfoProxyCommonList.CharacterData.LanguageMask languageMask);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 33 D2 48 8B CF E8 ?? ?? ?? ?? 33 C0"), GenerateCStrOverloads]
+    public partial void SetUpdateSearchComment(byte* searchComment);
+
+    [MemberFunction("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B D9 BF ?? ?? ?? ?? 8B C7")]
+    public partial void SendOnlineStatusUpdate(uint onlineStatusId);
+
+    /// <param name="updateData">The packet to send. If <c>null</c>, it will use <see cref="UpdateData"/>.</param>
+    [MemberFunction("E8 ?? ?? ?? ?? C6 83 ?? ?? ?? ?? ?? 40 84 FF")]
+    public partial void SendUpdateData(UpdateDataPacket* updateData = null);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxySearchComment.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxySearchComment.cs
@@ -18,7 +18,7 @@ public unsafe partial struct InfoProxySearchComment {
     [FieldOffset(0x1D0)] public Utf8String UnkString2;
     [FieldOffset(0x238)] public bool HasUpdateData;
 
-    [StructLayout(LayoutKind.Explicit, Size = 0xD3)]
+    [StructLayout(LayoutKind.Explicit, Size = 0xD8)]
     public struct UpdateDataPacket {
         [FieldOffset(0x00)] public InfoProxyCommonList.CharacterData.OnlineStatus OnlineStatusMask;
         [FieldOffset(0x08)] public ulong LookingForPartyClassJobIdMask;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3095,7 +3095,7 @@ classes:
       0x1400AD990: Finalize
       0x1400ADA40: GetInfoProxyById
       0x1400ADA60: GetLocalCharacterName
-      0x1400ADAE0: GetLocalContentID
+      0x1400ADAE0: GetLocalContentId
       0x1400ADB30: GetOnlineStatusFlags
       0x1400ADBB0: IsOnlineStatusSet
       0x1400ADC30: IsInCrossWorldDuty
@@ -3132,9 +3132,9 @@ classes:
       0x1400ED040: Finalize
       0x1400ED6F0: ClearListDataImpl
       0x1400EDE60: GetContentIDForEntry
-      0x1400EDE80: SearchEntryByName
+      0x1400EDE80: GetEntryByName
       0x1400EDF80: GetEntry
-      0x1400EE5E0: SearchEntryByContentID
+      0x1400EE5E0: GetEntryByContentId
       0x1400EE830: SwapData
   Client::UI::Info::InfoProxySearchComment:
     vtbls:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3154,7 +3154,7 @@ classes:
       0x1400FA4C0: FixOnlineStatusFlag2
       0x1400FA550: GetUpdateData
       0x1400FA560: GetUpdateSearchComment
-      0x1400FA590: SendUpdateData2 # Checks some TerritoryIntendedUseRow and calls ContentDirector.vf337?
+      0x1400FA590: PropagateUpdateData
       0x14017C7A0: Finalize
   Client::UI::UIClipboard:
     vtbls:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3143,6 +3143,18 @@ classes:
     funcs:
       0x1400F95B0: ctor
       0x1400FAB00: RequestData
+      0x1400F9E80: SendUpdateData
+      0x1400FA030: SetUpdateClassJobId
+      0x1400FA050: SetUpdateLookingForPartyClassJobIdMask
+      0x1400FA070: SetUpdateOnlineStatus
+      0x1400FA0D0: SetUpdateLanguageMask
+      0x1400FA0F0: SetUpdateSearchComment
+      0x1400FA220: SendOnlineStatusUpdate
+      0x1400FA400: FixOnlineStatusFlag1
+      0x1400FA4C0: FixOnlineStatusFlag2
+      0x1400FA550: GetUpdateData
+      0x1400FA560: GetUpdateSearchComment
+      0x1400FA590: SendUpdateData2 # Checks some TerritoryIntendedUseRow and calls ContentDirector.vf337?
       0x14017C7A0: Finalize
   Client::UI::UIClipboard:
     vtbls:
@@ -6222,6 +6234,7 @@ classes:
       0x140678BC0: FormatAddonText2<int,int,string>
       0x140678FB0: FormatAddonText2<int,string,uint>
       0x140679840: FormatTimeSpan
+      0x14067A010: GetTextChecker
       0x14067AE70: Update
       0x14067B780: FormatAddonTextApply
   Client::UI::Misc::RaptureLogModule:


### PR DESCRIPTION
This should roughly be the code that's needed to open the Search Info window for the local player:

```cs
var infoModule = InfoModule.Instance();
if (infoModule->IsInCrossWorldDuty())
    return;

var localContentId = infoModule->GetLocalContentId();
var characterData = InfoProxyParty.Instance()->InfoProxyCommonList.GetEntryByContentId(localContentId);
if (characterData == null)
    return;

var updateDataPacket = &InfoProxySearchComment.Instance()->UpdateData;
AgentDetail.Instance()->OpenForCharacterData(characterData, updateDataPacket);
```

---

I also updated `InfoProxySearchComment`, so it's possible to send online status and search comment updates.