### PR TITLE
Fix SetUpdateOnlineStatus params

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxySearchComment.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxySearchComment.cs
@@ -34,7 +34,7 @@ public unsafe partial struct InfoProxySearchComment {
     public partial void SetUpdateLookingForPartyClassJobIdMask(ulong classJobIdMask);
 
     [MemberFunction("E8 ?? ?? ?? ?? 0F B6 53 15")]
-    public partial void SetUpdateOnlineStatus(InfoProxyCommonList.CharacterData.OnlineStatus onlineStatus);
+    public partial void SetUpdateOnlineStatus(InfoProxyCommonList.CharacterData.OnlineStatus onlineStatus, bool skipAwayCheck = false);
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8D 53 16")]
     public partial void SetUpdateLanguageMask(InfoProxyCommonList.CharacterData.LanguageMask languageMask);


### PR DESCRIPTION
I forgot a parameter..
I know it's breaking change, but it didn't land on Dalamud stable yet and Una is the only one currently testing it.

```c
void __fastcall Client::UI::Info::InfoProxySearchComment_SetUpdateOnlineStatus(
        Client::UI::Info::InfoProxySearchComment *a1,
        Client::UI::Info::InfoProxyCommonList::CharacterData::OnlineStatus a2,
        bool skipAwayFix)
{
  a2a = a2;
  if ( a1->UpdateData.OnlineStatusMask != a2 )
  {
    if ( !skipAwayFix && (a2 & 0x20000) != 0 )
    {
      Client::UI::Info::InfoProxySearchComment_FixOnlineStatusFlag1(a1, &a2a);
      Client::UI::Info::InfoProxySearchComment_FixOnlineStatusFlag2(a1, &a2a);
      a2 = a2a;
    }
    a1->UpdateData.OnlineStatusMask = a2;
    a1->HasUpdateData = 1;
  }
}
```

`log2(0x20000) = 17`, the Away status. I think it removes the Mentor/Novice/RP/Returner/Trial statuses because Away has priority.