### PR TITLE
Add DirectorTodo, update Director and EventHandler

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/Director.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/Director.cs
@@ -15,9 +15,17 @@ public unsafe partial struct Director {
     [FieldOffset(0x33C)] public byte ContentFlags; // 1 = Tourism (Explorer Mode)
     [FieldOffset(0x340)] public byte Sequence;
     [FieldOffset(0x342)] public fixed byte UnionData[10]; // I8A-I8J, UI8A-UI8J, Branch etc.
+    [FieldOffset(0x350)] public Utf8String Title;
+    [Obsolete("Renamed to Title")]
     [FieldOffset(0x350)] public Utf8String String0;
+    [FieldOffset(0x3B8)] public Utf8String Description;
+    [Obsolete("Renamed to Description")]
     [FieldOffset(0x3B8)] public Utf8String String1;
+    [FieldOffset(0x420)] public Utf8String ReliefText;
+    [Obsolete("Renamed to ReliefText")]
     [FieldOffset(0x420)] public Utf8String String2;
+    [FieldOffset(0x498)] public StdVector<EventHandlerObjective> Objectives; // 10 objectives max
+    [FieldOffset(0x4B0)] public uint EventItemId;
 
     [VirtualFunction(267)]
     public partial void PopulateMapMarkers(ushort territoryTypeId, StdVector<MapMarkerData>* markerVector);

--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
@@ -6,19 +6,59 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Event;
 // Client::Game::Event::EventHandler
 // ctor "E8 ?? ?? ?? ?? 45 33 D2 48 8D 05"
 [StructLayout(LayoutKind.Explicit, Size = 0x210)]
-public unsafe struct EventHandler {
+public unsafe partial struct EventHandler {
     [FieldOffset(0x08)] public StdSet<Pointer<GameObject>> EventObjects;
     [FieldOffset(0x18)] public EventSceneModuleUsualImpl* EventSceneModule;
     [FieldOffset(0x20)] public EventHandlerInfo Info;
+    [FieldOffset(0x5C)] public uint IconId;
 
     [FieldOffset(0xC8)] public Utf8String UnkString0;
     [FieldOffset(0x168)] public Utf8String UnkString1;
+
+    /// <remarks> You need to pass your own Utf8String, so the game can copy the title into it. </remarks>
+    [VirtualFunction(197)]
+    public partial void GetTitle(Utf8String* title);
+
+    /// <remarks> You need to pass your own Utf8String, so the game can copy the description into it. </remarks>
+    [VirtualFunction(249)]
+    public partial void GetDescription(Utf8String* description);
+
+    /// <remarks> You need to pass your own Utf8String, so the game can copy the relief text into it. </remarks>
+    [VirtualFunction(250)]
+    public partial void GetReliefText(Utf8String* reliefText);
+
+    [VirtualFunction(251)]
+    public partial int GetTimeRemaining(int currentTimestamp);
+
+    [VirtualFunction(252)]
+    public partial bool HasTimer();
+
+    [VirtualFunction(254)]
+    public partial uint GetEventItemId();
+
+    [VirtualFunction(256)]
+    public partial StdVector<EventHandlerObjective>* GetObjectives();
+
+    [VirtualFunction(259)]
+    public partial int GetRecommendedLevel();
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x38)]
 public struct EventHandlerInfo {
     [FieldOffset(0x00)] public EventId EventId;
     [FieldOffset(0x04)] public byte Flags;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x160)]
+public struct EventHandlerObjective {
+    [FieldOffset(0x00)] public bool Enabled;
+    [FieldOffset(0x04)] public int DisplayType;
+    [FieldOffset(0x08)] public Utf8String Label;
+
+    [FieldOffset(0x78)] public int CountCurrent;
+    [FieldOffset(0x7C)] public int CountNeeded;
+    [FieldOffset(0x80)] public ulong TimeLeft;
+    [FieldOffset(0x88)] public uint MapRowId;
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x04)]

--- a/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
@@ -11,6 +11,8 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
 public partial struct ContentDirector {
     [FieldOffset(0x00)] public Director Director;
 
+    [FieldOffset(0x536)] public byte ContentTypeRowId;
+
     [FieldOffset(0xC08)] public float ContentTimeLeft;
 
     /// <summary>

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/DirectorInfo.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/DirectorInfo.cs
@@ -1,0 +1,14 @@
+using FFXIVClientStructs.FFXIV.Client.Game.Event;
+using FFXIVClientStructs.FFXIV.Client.System.String;
+
+namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
+
+[StructLayout(LayoutKind.Explicit, Size = 0x148)]
+public unsafe struct DirectorInfo {
+    [FieldOffset(0x00)] public Director* Director;
+    [FieldOffset(0x08)] public Utf8String Title;
+    [FieldOffset(0x70)] public Utf8String Description;
+    [FieldOffset(0xD8)] public Utf8String ReliefText;
+    [FieldOffset(0x140)] public bool IsFullUpdatePending;
+    [FieldOffset(0x141)] public bool IsTodoShown;
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/DirectorTodo.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/DirectorTodo.cs
@@ -4,7 +4,7 @@ using FFXIVClientStructs.FFXIV.Client.System.String;
 namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x148)]
-public unsafe struct DirectorInfo {
+public unsafe struct DirectorTodo {
     [FieldOffset(0x00)] public Director* Director;
     [FieldOffset(0x08)] public Utf8String Title;
     [FieldOffset(0x70)] public Utf8String Description;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/DirectorTodo.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/DirectorTodo.cs
@@ -10,5 +10,5 @@ public unsafe struct DirectorTodo {
     [FieldOffset(0x70)] public Utf8String Description;
     [FieldOffset(0xD8)] public Utf8String ReliefText;
     [FieldOffset(0x140)] public bool IsFullUpdatePending;
-    [FieldOffset(0x141)] public bool IsTodoShown;
+    [FieldOffset(0x141)] public bool IsShown;
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
@@ -40,11 +40,11 @@ public unsafe partial struct UIState {
     [FieldOffset(0x9F78)] public QuestUI QuestUI;
     [FieldOffset(0xAF48)] public QuestTodoList QuestTodoList;
     [FieldOffset(0xB238)] public NpcTrade NpcTrade;
-    [FieldOffset(0xB560)] public DirectorInfo DirectorInfo;
-    [Obsolete("Use DirectorInfo.Director")]
+    [FieldOffset(0xB560)] public DirectorTodo DirectorTodo;
+    [Obsolete("Use DirectorTodo.Director")]
     [FieldOffset(0xB560)] public Director* ActiveDirector;
-    [FieldOffset(0xB6A8)] public DirectorInfo FateDirectorInfo;
-    [Obsolete("Use FateDirectorInfo.Director and cast Director to FateDirector*")]
+    [FieldOffset(0xB6A8)] public DirectorTodo FateDirectorTodo;
+    [Obsolete("Use FateDirectorTodo.Director and cast Director to FateDirector*")]
     [FieldOffset(0xB6A8)] public FateDirector* FateDirector;
     [FieldOffset(0xB7F0)] public Map Map;
     [FieldOffset(0xF7F0)] public MarkingController MarkingController;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
@@ -40,10 +40,12 @@ public unsafe partial struct UIState {
     [FieldOffset(0x9F78)] public QuestUI QuestUI;
     [FieldOffset(0xAF48)] public QuestTodoList QuestTodoList;
     [FieldOffset(0xB238)] public NpcTrade NpcTrade;
+    [FieldOffset(0xB560)] public DirectorInfo DirectorInfo;
+    [Obsolete("Use DirectorInfo.Director")]
     [FieldOffset(0xB560)] public Director* ActiveDirector;
-
+    [FieldOffset(0xB6A8)] public DirectorInfo FateDirectorInfo;
+    [Obsolete("Use FateDirectorInfo.Director and cast Director to FateDirector*")]
     [FieldOffset(0xB6A8)] public FateDirector* FateDirector;
-
     [FieldOffset(0xB7F0)] public Map Map;
     [FieldOffset(0xF7F0)] public MarkingController MarkingController;
     [FieldOffset(0xFAD0)] public LimitBreakController LimitBreakController;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1394,6 +1394,23 @@ classes:
       0x1401DCFE0: GetResourceAsync
       0x1401DD210: GetResourceSync
       0x1401E1A00: Initialize
+  Client::Game::UI::DirectorInfo:
+    funcs:
+      0x140964CC0: SetDirector
+      0x140964F20: SetUpdatePending
+      0x140964F40: UnsetUpdatePending
+      0x140964F50: ShowTodo # lua function "ShowDirectorTodo"
+      0x140964F60: HideTodo # lua function "HideDirectorTodo"
+      0x140964F70: GetTitle
+      0x140964F80: GetIconId
+      0x140964F90: GetDescription
+      0x140964FC0: GetReliefText
+      0x140964FF0: GetEventItemId
+      0x140965030: GetRecommendedLevel
+      0x140965080: GetCompanyLeveDirectorInfo
+      0x1409650C0: GetObjectives
+      0x1409650E0: GetTimeRemaining
+      0x140965120: HasTimer
   Client::Game::UI::UIState:
     instances:
       - ea: 0x142204720
@@ -10199,7 +10216,16 @@ classes:
       0x1407C8B70: ctor
     vfuncs:
       0: dtor
+      6: Terminate
       197: GetTitle # lua function "GetEventHandlerTitle"
+      249: GetDescription
+      250: GetReliefText
+      251: GetTimeRemaining # pass current unix timestamp as a2
+      252: HasTimer
+      254: GetEventItemId
+      256: GetObjectives
+      259: GetRecommendedLevel
+      263: Initialize
   Client::Game::Event::LuaScriptLoader<Client::Game::Event::ModuleBase>:
     vtbls:
       - ea: 0x141A48240
@@ -10481,10 +10507,10 @@ classes:
         base: Client::Game::Event::LuaEventHandler
     vfuncs:
       267: PopulateMapMarkers # (this, ushort territoryTypeId, StdVector<MapMarkerData>* markerVector)
+      286: SetSequence
+      287: Synchronize
     funcs:
       0x14082A1C0: ctor
-      0x140964F50: ShowTodo # lua function "ShowDirectorTodo"
-      0x140964F60: HideTodo # lua function "HideDirectorTodo"
   Client::Game::CallbackSheetWaiter<Client::Game::UI::QuestTodoList>:
     vtbls:
       - ea: 0x141A6FF78
@@ -10967,6 +10993,7 @@ classes:
     vfuncs:
       292: GetCurrentLevel
       293: GetMaxLevel
+      309: GetContentTypeIconId
       319: SetExperience
     funcs:
       0x14082EFA0: ctor

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1394,20 +1394,20 @@ classes:
       0x1401DCFE0: GetResourceAsync
       0x1401DD210: GetResourceSync
       0x1401E1A00: Initialize
-  Client::Game::UI::DirectorInfo:
+  Client::Game::UI::DirectorTodo:
     funcs:
       0x140964CC0: SetDirector
       0x140964F20: SetUpdatePending
       0x140964F40: UnsetUpdatePending
-      0x140964F50: ShowTodo # lua function "ShowDirectorTodo"
-      0x140964F60: HideTodo # lua function "HideDirectorTodo"
+      0x140964F50: Show # lua function "ShowDirectorTodo"
+      0x140964F60: Hide # lua function "HideDirectorTodo"
       0x140964F70: GetTitle
       0x140964F80: GetIconId
       0x140964F90: GetDescription
       0x140964FC0: GetReliefText
       0x140964FF0: GetEventItemId
       0x140965030: GetRecommendedLevel
-      0x140965080: GetCompanyLeveDirectorInfo
+      0x140965080: GetCompanyLeveInfo
       0x1409650C0: GetObjectives
       0x1409650E0: GetTimeRemaining
       0x140965120: HasTimer


### PR DESCRIPTION
`DirectorTodo` is a small struct in UIState that acts as a proxy to get data from a Director for the number/string arrays that the Todo addon uses. It is used for both, ActiveDirector and FateDirector. Sadly, I can't make generic structs with an explicit layout, so everyone who currently uses FateDirector will have to cast the Director to `FateDirector*`.