### PR TITLE
AgentMap small fixes

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMap.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMap.cs
@@ -112,7 +112,7 @@ public unsafe partial struct AgentMap {
         marker->MapMarker.Index = MiniMapMarkerCount;
         marker->MapMarker.X = (short)(position.X * 16.0f);
         marker->MapMarker.Y = (short)(position.Z * 16.0f);
-        marker->MapMarker.Radius = scale;
+        marker->MapMarker.Scale = scale;
         marker->MapMarker.IconId = icon;
         MiniMapMarkerArraySpan[MiniMapMarkerCount++] = *marker;
         return true;
@@ -126,7 +126,7 @@ public unsafe partial struct AgentMap {
         marker->MapMarker.Index = MapMarkerCount;
         marker->MapMarker.X = (short)(position.X * 16.0f);
         marker->MapMarker.Y = (short)(position.Z * 16.0f);
-        marker->MapMarker.Radius = scale;
+        marker->MapMarker.Scale = scale;
         marker->MapMarker.IconId = icon;
         marker->MapMarker.Subtext = text;
         marker->MapMarker.SubtextOrientation = textPosition;
@@ -167,8 +167,7 @@ public unsafe struct MapMarkerBase {
     [FieldOffset(0x02)] public ushort IconFlags;
     [FieldOffset(0x04)] public uint IconId;
     [FieldOffset(0x08)] public uint SecondaryIconId;
-    [FieldOffset(0x0C), Obsolete("Use Radius instead")] public int Scale;
-    [FieldOffset(0x0C)] public int Radius;
+    [FieldOffset(0x0C)] public int Scale;
     [FieldOffset(0x10)] public byte* Subtext;
     [FieldOffset(0x18)] public byte Index;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMap.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMap.cs
@@ -112,7 +112,7 @@ public unsafe partial struct AgentMap {
         marker->MapMarker.Index = MiniMapMarkerCount;
         marker->MapMarker.X = (short)(position.X * 16.0f);
         marker->MapMarker.Y = (short)(position.Z * 16.0f);
-        marker->MapMarker.Scale = scale;
+        marker->MapMarker.Radius = scale;
         marker->MapMarker.IconId = icon;
         MiniMapMarkerArraySpan[MiniMapMarkerCount++] = *marker;
         return true;
@@ -126,7 +126,7 @@ public unsafe partial struct AgentMap {
         marker->MapMarker.Index = MapMarkerCount;
         marker->MapMarker.X = (short)(position.X * 16.0f);
         marker->MapMarker.Y = (short)(position.Z * 16.0f);
-        marker->MapMarker.Scale = scale;
+        marker->MapMarker.Radius = scale;
         marker->MapMarker.IconId = icon;
         marker->MapMarker.Subtext = text;
         marker->MapMarker.SubtextOrientation = textPosition;
@@ -167,7 +167,8 @@ public unsafe struct MapMarkerBase {
     [FieldOffset(0x02)] public ushort IconFlags;
     [FieldOffset(0x04)] public uint IconId;
     [FieldOffset(0x08)] public uint SecondaryIconId;
-    [FieldOffset(0x0C)] public int Scale;
+    [FieldOffset(0x0C), Obsolete("Use Radius instead")] public int Scale;
+    [FieldOffset(0x0C)] public int Radius;
     [FieldOffset(0x10)] public byte* Subtext;
     [FieldOffset(0x18)] public byte Index;
 
@@ -210,7 +211,7 @@ public struct MiniMapMarker {
     [FieldOffset(0x08)] public MapMarkerBase MapMarker;
 }
 
-[StructLayout(LayoutKind.Explicit, Size = 0x108)]
+[StructLayout(LayoutKind.Explicit, Size = 0x110)]
 public struct TempMapMarker {
     [FieldOffset(0x00)] public Utf8String TooltipText;
     [FieldOffset(0x68)] public MapMarkerBase MapMarker;


### PR DESCRIPTION
A scale value of 132 doesn't make sense, but a radius of 123 does.

![image](https://github.com/aers/FFXIVClientStructs/assets/9083275/c39e16cb-f304-4304-8cb3-d5ee8ea6643a)
![image](https://github.com/aers/FFXIVClientStructs/assets/9083275/f1ef8d99-892e-4f70-90da-780f9c549ed4)

Also TempMapMarker was 8bytes too small.

I verified that these fixes are correct by implementing them into Mappy.