### PR TITLE
Changes InfoProxy20, AgentChatLog and adds AgentItemComp

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentChatLog.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentChatLog.cs
@@ -33,6 +33,9 @@ public unsafe partial struct AgentChatLog {
 
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 81 FF ?? ?? ?? ?? 75 20")]
     public partial bool InsertTextCommandParam(uint textParamId, bool unk);
+
+    [MemberFunction("E8 ?? ?? ?? ?? EB 7B 49 8B 06")]
+    public partial void LinkItem(uint itemId);
 }
 
 // There are definitely more channels than just these, these were all the ones I could find quickly.

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemComp.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemComp.cs
@@ -2,7 +2,7 @@
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
-[Agent(AgentId.ItemCompare)]
+[Agent(AgentId.ItemComp)]
 [StructLayout(LayoutKind.Explicit, Size = 0x60)]
 public partial struct AgentItemComp {
     [FieldOffset(0x00)] public AgentInterface AgentInterface;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemCompare.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemCompare.cs
@@ -1,0 +1,12 @@
+﻿using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
+[Agent(AgentId.ItemCompare)]
+[StructLayout(LayoutKind.Explicit, Size = 0x2D18)]
+public partial struct AgentItemComp {
+    [FieldOffset(0x00)] public AgentInterface AgentInterface;
+
+    [MemberFunction("E8 ?? ?? ?? ?? EB 3F 83 F8 FE")]
+    public partial void CompareItem(ushort parentAddonId, uint itemId, byte stainId);
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemCompare.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemCompare.cs
@@ -3,7 +3,7 @@
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 [Agent(AgentId.ItemCompare)]
-[StructLayout(LayoutKind.Explicit, Size = 0x2D18)]
+[StructLayout(LayoutKind.Explicit, Size = 0x60)]
 public partial struct AgentItemComp {
     [FieldOffset(0x00)] public AgentInterface AgentInterface;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs
@@ -193,7 +193,7 @@ public enum AgentId : uint {
     ArmouryNotebook = 156,
     MinionNotebook = 157,
     MountNotebook = 158,
-    ItemCompare = 159,
+    ItemComp = 159,
     DailyQuestSupply = 160,
     MobHunt = 161,
     PatchMark = 162, // SelectOk?

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoModule.cs
@@ -71,6 +71,7 @@ public enum InfoProxyId : uint {
     //OTherFCStuff = 17,
     LinkShellChat = 18,
     CrossRealmParty = 19,
+    NoviceNetwork = 20,
     CrossWorldLinkShell = 29,
     CrossWorldLinkShellMember = 30,
     CircleList = 31,

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxy20.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxy20.cs
@@ -1,7 +1,0 @@
-namespace FFXIVClientStructs.FFXIV.Client.UI.Info;
-
-[StructLayout(LayoutKind.Explicit, Size = 0x28)]
-public unsafe partial struct InfoProxy20 {
-    [FieldOffset(0x00)] public InfoProxyInterface InfoProxyInterface;
-
-}

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyNoviceNetwork.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyNoviceNetwork.cs
@@ -1,5 +1,6 @@
 namespace FFXIVClientStructs.FFXIV.Client.UI.Info;
 
+[InfoProxy(InfoProxyId.NoviceNetwork)]
 [StructLayout(LayoutKind.Explicit, Size = 0x28)]
 public unsafe partial struct InfoProxyNoviceNetwork {
     [FieldOffset(0x00)] public InfoProxyInterface InfoProxyInterface;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyNoviceNetwork.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyNoviceNetwork.cs
@@ -5,5 +5,5 @@ public unsafe partial struct InfoProxyNoviceNetwork {
     [FieldOffset(0x00)] public InfoProxyInterface InfoProxyInterface;
 
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 8B CB E8 ?? ?? ?? ?? 45 33 C9")]
-    public partial byte InviteToNoviceNetwork(ulong contentId, ushort worldId, byte* name);
+    public partial bool InviteToNoviceNetwork(ulong contentId, ushort worldId, byte* name);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyNoviceNetwork.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyNoviceNetwork.cs
@@ -1,0 +1,9 @@
+namespace FFXIVClientStructs.FFXIV.Client.UI.Info;
+
+[StructLayout(LayoutKind.Explicit, Size = 0x28)]
+public unsafe partial struct InfoProxyNoviceNetwork {
+    [FieldOffset(0x00)] public InfoProxyInterface InfoProxyInterface;
+
+    [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 8B CB E8 ?? ?? ?? ?? 45 33 C9")]
+    public partial byte InviteToNoviceNetwork(ulong contentId, ushort worldId, byte* name);
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyNoviceNetwork.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyNoviceNetwork.cs
@@ -5,5 +5,6 @@ public unsafe partial struct InfoProxyNoviceNetwork {
     [FieldOffset(0x00)] public InfoProxyInterface InfoProxyInterface;
 
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 8B CB E8 ?? ?? ?? ?? 45 33 C9")]
+    [GenerateCStrOverloads]
     public partial bool InviteToNoviceNetwork(ulong contentId, ushort worldId, byte* name);
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -731,7 +731,7 @@ classes:
       0: dtor
       1: Enable            # called in AtkModule_Initialize
       2: DumpInput         # called every frame from AtkModule_HandleInput
-      3: Disable           # called as part of UIModule_Finalize 
+      3: Disable           # called as part of UIModule_Finalize
       4: IsEnabled
       5: OpenSoftKeyboard  # (this, SoftKeyboardInputInterface*) - in 140577A90
       6: CloseSoftKeyboard # nullsub in SteamGamepadTextInput, so unsure. random guess!
@@ -3430,10 +3430,12 @@ classes:
     funcs:
       0x1400F3C90: ctor
       0x14017C9E0: Finalize
-  Client::UI::Info::InfoProxy20:
+  Client::UI::Info::InfoProxyNoviceNetwork:
     vtbls:
       - ea: 0x1419BFB70
         base: Client::UI::Info::InfoProxyInterface
+    funcs:
+      0x1400FADD0: InviteToNoviceNetwork
   Client::UI::Info::InfoProxyFreeCompany:
     vtbls:
       - ea: 0x1419C0558
@@ -7872,6 +7874,7 @@ classes:
       0x140CCB0C0: ctor
       0x140CCB2F0: Finalize
       0x140CD03A0: InsertTextCommandParam
+      0x140CD09B0: LinkItem
   Client::UI::Agent::AgentInventory:
     vtbls:
       - ea: 0x141A89E18


### PR DESCRIPTION
- Rename InfoProxy20 to InfoProxyNoviceNetwork
- Add LinkItem to AgentChatLog
- Add AgentItemComp

For `InviteToNoviceNetwork(ulong contentId, ushort worldId, byte* name);` i assume it is contentId, but chat2 just pushes 0 in all cases

Sigs taken from <https://github.com/Infiziert90/ChatTwo/blob/main/ChatTwo/GameFunctions/Context.cs>