### PR TITLE
Enable deterministic CI builds

### DIFF
--- a/FFXIVClientStructs/FFXIVClientStructs.csproj
+++ b/FFXIVClientStructs/FFXIVClientStructs.csproj
@@ -30,7 +30,12 @@
     
     <InteropGenerator_InteropNamespace>FFXIVClientStructs.Interop.Generated</InteropGenerator_InteropNamespace>
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
   <ItemGroup>
     <CompilerVisibleProperty Include="InteropGenerator_InteropNamespace" />
   </ItemGroup>

--- a/InteropGenerator.Runtime/InteropGenerator.Runtime.csproj
+++ b/InteropGenerator.Runtime/InteropGenerator.Runtime.csproj
@@ -6,4 +6,9 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR enables

- [ContinuousIntegrationBuild](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild) to normalize file paths in pdb files, and
- [Deterministic](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/code-generation#deterministic) to produce byte-for-byte identical dlls across compilations for identical inputs.
