### PR TITLE
FieldMarkerModule

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/FieldMarkerModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/FieldMarkerModule.cs
@@ -26,7 +26,6 @@ public struct GamePresetPoint {
 public partial struct FieldMarkerPreset {
     [FieldOffset(0x00), FixedSizeArray] internal FixedSizeArray8<GamePresetPoint> _markers;
     [FieldOffset(0x60)] public byte ActiveMarkers;
-    [FieldOffset(0x61)] private byte Reserved;
     [FieldOffset(0x62)] public ushort ContentFinderConditionId;
     [FieldOffset(0x64)] public uint TimeStamp;
 


### PR DESCRIPTION
Remove field that was only used for padding when struct was defined as sequential.

Field doesn't even need to be private, it's just padding.