### PR TITLE
AtkTextNode Remove Manual Overloads

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
@@ -61,18 +61,6 @@ public unsafe partial struct AtkTextNode : ICreatable {
     [MemberFunction("E8 ?? ?? ?? ?? 45 33 C0 B2 18")]
     public partial void SetFont(FontType fontType);
 
-    public void SetText(Span<byte> span) {
-        fixed (byte* ptr = span) SetText(ptr);
-    }
-
-    public void SetText(byte[] bytes) {
-        var charPtr = Marshal.AllocHGlobal(bytes.Length + 1);
-        Marshal.Copy(bytes, 0, charPtr, bytes.Length);
-        Marshal.WriteByte(charPtr, bytes.Length, 0);
-        SetText((byte*)charPtr.ToPointer());
-        Marshal.FreeHGlobal(charPtr);
-    }
-
     public AlignmentType AlignmentType {
         get => (AlignmentType)(AlignmentFontType & 0x0F);
         set => SetAlignment(value);


### PR DESCRIPTION
These are no longer necessary, as GenerateStringOverloads implements methods that can implicitly cast these args