### PR TITLE
Remove old ArrayData.SetValue overloads and update comments

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/ExtendArrayData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/ExtendArrayData.cs
@@ -1,7 +1,8 @@
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
+// ExtendArrayData 1 stores pointers to AgentMap.MapMarkers
 [GenerateInterop, Inherits<AtkArrayData>]
 [StructLayout(LayoutKind.Explicit, Size = 0x28)]
 public unsafe partial struct ExtendArrayData {
-    [FieldOffset(0x20)] public void** DataArray; // as far as I'm aware this can contain literally any data type they want, yay
+    [FieldOffset(0x20)] public void** DataArray;
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/NumberArrayData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/NumberArrayData.cs
@@ -5,15 +5,17 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 public unsafe partial struct NumberArrayData {
     [FieldOffset(0x20)] public int* IntArray;
 
-    /// <summary>Set a value at the specified index of the IntArray.</summary>
-    /// <param name="index">The index in the array.</param>
-    /// <param name="value">The integer value.</param>
-    /// <param name="force">If <c>true</c> it bypasses the check if the value is different from what is stored (read before write).</param>
-    /// <param name="silent">If <c>false</c> and the value was changed, UpdateState will be set to <c>1</c> to request an update on subscribed addons.</param>
+    /// <summary>
+    /// Set a value at the specified index of the IntArray.
+    /// </summary>
+    /// <param name="index"> The index in the array. </param>
+    /// <param name="value"> The integer value. </param>
+    /// <param name="force">
+    /// If <c>true</c> it bypasses the check if the value is different from what is stored.
+    /// </param>
+    /// <param name="suppressUpdates">
+    /// If <c>false</c> and the value was changed, UpdateState will be set to <c>1</c> to request an update on subscribed addons.
+    /// </param>
     [MemberFunction("3B 51 08 7D 28")]
-    public partial void SetValue(int index, int value, bool force, bool silent);
-
-    public void SetValue(int index, int value) {
-        SetValue(index, value, false, false);
-    }
+    public partial void SetValue(int index, int value, bool force = false, bool suppressUpdates = false);
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/StringArrayData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/StringArrayData.cs
@@ -6,14 +6,16 @@ public unsafe partial struct StringArrayData {
     [FieldOffset(0x20)] public byte** StringArray;
     [FieldOffset(0x28)] public byte** ManagedStringArray;
 
-    /// <summary>Set a value at the specified index of the StringArray.</summary>
-    /// <param name="index">The index in the array.</param>
+    /// <summary>
+    /// Set a value at the specified index of the StringArray.
+    /// </summary>
+    /// <param name="index"> The index in the array. </param>
     /// <param name="value">
     /// A pointer to a null terminated string.<br/>
     /// <b>Note:</b> When passing a C# string (made possible by the generator overload), make sure managed is set to <c>true</c>.
     /// </param>
     /// <param name="readBeforeWrite">
-    /// If <c>true</c>, it compares the stored pointer with the passed pointer (not the text it points to) before setting it (read before write).<br/>
+    /// If <c>true</c>, it compares the stored pointer with the passed pointer (not the text it points to) before setting it.<br/>
     /// If <c>false</c>, the stored pointer will always be replaced with the passed pointer.<br/><br/>
     /// In any way, it only has an effect if managed is <c>false</c>.
     /// </param>
@@ -22,22 +24,24 @@ public unsafe partial struct StringArrayData {
     /// The game will allocate memory in the UI space and copy the text. The passed pointer can then be freed right after the SetValue call.<br/>
     /// Internally, the pointer to the allocated memory is (also) stored in ManagedStringArray to allow SetValue to reuse or reallocate the space as needed.
     /// </param>
-    /// <param name="silent">If <c>false</c> and the value was changed, UpdateState will be set to <c>1</c> to request an update on subscribed addons.</param>
+    /// <param name="suppressUpdates">
+    /// If <c>false</c> and the value was changed, <see cref="UpdateState"/> will be set to <c>1</c> to request an update on subscribed addons.
+    /// </param>
     [MemberFunction("E8 ?? ?? ?? ?? F6 47 14 08"), GenerateStringOverloads]
-    public partial void SetValue(int index, byte* value, bool readBeforeWrite, bool managed, bool silent);
+    public partial void SetValue(int index, byte* value, bool readBeforeWrite = true, bool managed = true, bool suppressUpdates = false);
 
-    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 4F 10 41 0F B6 9F"), GenerateStringOverloads]
-    public partial void SetValueForced(int index, byte* value, bool notify);
-
-    public void SetValue(int index, byte* value, bool notify) {
-        SetValueForced(index, value, notify);
-    }
-
-    public void SetValue(int index, string value, bool notify) {
-        SetValueForced(index, value, notify);
-    }
-
-    public void SetValue(int index, byte[] value, bool notify) {
-        SetValueForced(index, value, notify);
-    }
+    /// <summary>
+    /// Force set a value at the specified index of the StringArray.
+    /// </summary>
+    /// <param name="index"> The index in the array. </param>
+    /// <param name="value">
+    /// A pointer to a null terminated string.<br/>
+    /// <b>Note:</b> This function will not make a managed copy of the passed text. Only the pointer will be stored.
+    /// </param>
+    /// <param name="readBeforeWrite">
+    /// If <c>true</c>, it compares the stored pointer with the passed pointer (not the text it points to) before setting it.<br/>
+    /// If <c>false</c>, the stored pointer will always be replaced with the passed pointer, but <see cref="UpdateState"/> will still only be set to <c>1</c> when it was different.<br/>
+    /// </param>
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 4F 10 41 0F B6 9F")]
+    public partial void SetValueForced(int index, byte* value, bool readBeforeWrite = true);
 }


### PR DESCRIPTION
- finally getting rid of the overloads we added last year
- changing the parameter name `silent` to `suppressUpdates` to make clear what it does
- adding comments to `StringArrayData.SetValueForced`
- removing `GenerateStringOverloads` from `StringArrayData.SetValueForced`. it only stores pointers and does not make a managed copy of the text
- added default values to not so important parameters