### PR TITLE
Fix PreloadActionTmbByKey

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/Scheduler/ActionTimelineManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Scheduler/ActionTimelineManager.cs
@@ -8,8 +8,15 @@ public unsafe partial struct ActionTimelineManager {
     public static partial ActionTimelineManager* Instance();
 
     [MemberFunction("48 83 EC 38 48 8B 02 C7 44 24")]
-    public partial bool PreloadActionTmbByKey(byte** key);
+    public partial bool PreloadActionTmb(PreloadActionTmbInfo* info);
 
-    [MemberFunction("E8 ?? ?? ?? ?? 4C 8B C6 48 89 45 A7")]
-    public static partial byte* GetActionTimelineKey(uint actionTimelineRowId);
+    [StructLayout(LayoutKind.Explicit, Size = 0x10)]
+    public struct PreloadActionTmbInfo {
+        [FieldOffset(0x00)] public byte* Key;
+
+        // ActionTimeline Row Index
+        // or
+        // WeaponTimeline Row Index + 0x20000
+        [FieldOffset(0x08)] public uint Index;
+    }
 }

--- a/FFXIVClientStructs/FFXIV/Client/System/Scheduler/Resource/SchedulerResourceManagement.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Scheduler/Resource/SchedulerResourceManagement.cs
@@ -4,6 +4,6 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Scheduler.Resource;
 [StructLayout(LayoutKind.Explicit, Size = 0x58)]
 public unsafe struct SchedulerResourceManagement {
     [FieldOffset(0x08)] public SchedulerResource* Begin;
-    [FieldOffset(0x10)] public void* Unknown;
+    [FieldOffset(0x10)] public void* Unknown; // TODO: SchedulerResources map/set<T>, see LoadActionTmb
     [FieldOffset(0x18)] public ulong NumResources;
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -15733,7 +15733,7 @@ classes:
     funcs:
       0x14139B030: CreateInstance
       0x14139B080: ctor
-      0x14139B420: PreloadActionTmbByKey
+      0x14139B420: PreloadActionTmb
   Client::System::Scheduler::TimelineGroup:
     vtbls:
       - ea: 0x141B662D8


### PR DESCRIPTION
I revisited this function because I encountered T-Poses. While doing so I found it was passing a small struct containing the Key **and** an Index of the loop in `sub_1404DBEB0`.
The index is probably used as some kind of cache id, since it offsets WeaponTimeline indexes by 0x20000 (it also sets it to `SchedulerResource.Unk1`, but I didn't look into it more).
Since it now takes a new struct `PreloadActionTmbInfo`, I renamed the function from `PreloadActionTmbByKey` to `PreloadActionTmb`.

I also removed `GetActionTimelineKey()` since it wasn't really part of the `ActionTimelineManager`, `GetWeaponTimelineKey()` is not siggable and you can just get the Key from the Lumina sheets.