### PR TITLE
chore: Add IconA/IconB obsoletes pointing to new fields.

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.HotBarSlot.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.HotBarSlot.cs
@@ -49,6 +49,9 @@ public partial struct RaptureHotbarModule {
         /// Curiously, this value does not apply to macros as their substitution happens much earlier in the process.
         /// </remarks>
         [FieldOffset(0xBC)] public uint OriginalApparentActionId;
+        
+        [Obsolete($"Renamed to {nameof(OriginalApparentActionId)}.", true)]
+        [FieldOffset(0xBC)] public uint IconA;
 
         /// <summary>
         /// The action ID that is used to determine this hotbar slot's icon (and usually display text).
@@ -58,6 +61,9 @@ public partial struct RaptureHotbarModule {
         /// where this field would be used.
         /// </summary>
         [FieldOffset(0xC0)] public uint ApparentActionId;
+        
+        [Obsolete($"Renamed to {nameof(ApparentActionId)}.", true)]
+        [FieldOffset(0xC0)] public uint IconB;
 
         /// Unknown field with offset 0xC4 (196), possibly overloaded
         ///
@@ -78,12 +84,18 @@ public partial struct RaptureHotbarModule {
         /// </summary>
         /// <seealso cref="OriginalApparentActionId"/>
         [FieldOffset(0xC8)] public HotbarSlotType OriginalApparentSlotType;
-
+        
+        [Obsolete($"Renamed to {nameof(OriginalApparentSlotType)}.", true)] 
+        [FieldOffset(0xC8)] public uint IconTypeA;
+        
         /// <summary>
         /// The <see cref="HotbarSlotType"/> assigned to this hotbar slot for display purposes.
         /// </summary>
         /// <seealso cref="ApparentActionId"/>
         [FieldOffset(0xC9)] public HotbarSlotType ApparentSlotType;
+        
+        [Obsolete($"Renamed to {nameof(ApparentSlotType)}.", true)]
+        [FieldOffset(0xC9)] public uint IconTypeB;
 
         /// Appears to be the "primary cost" of this action, mapping down to 0, 1, 2, 4, 5, 6, 7.
         ///


### PR DESCRIPTION
Per request from @MidoriKami, adds back `IconA`, `IconB`, `IconTypeA`, and `IconTypeB` with an obsolete pointing to the new field names.

I'm still honestly not sold on the names `ApparentActionId` and `OriginalApparentActionId`, but I also can't think of any better ones (`BaseApparentActionId` maybe?).

Obsoletes to be removed eventually after apiX release.