### PR TITLE
Update AtkUnitManager and some small changes

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -68,7 +68,7 @@ public unsafe partial struct PlayerState {
 
     // Size: (MountSheet.Max(row => row.Order) + 7) / 8
     /// <remarks> Use <see cref="IsMountUnlocked"/> </remarks>
-    [FieldOffset(0x2DD), FixedSizeArray] internal FixedSizeArray35<byte> _ownedMountsBitmask;
+    [FieldOffset(0x2DD), FixedSizeArray] internal FixedSizeArray35<byte> _unlockedMountsBitmask;
     // Size: (OrnamentSheet.RowCount + 7) / 8
     /// <remarks> Use <see cref="IsOrnamentUnlocked"/> </remarks>
     [FieldOffset(0x300), FixedSizeArray] internal FixedSizeArray6<byte> _unlockedOrnamentsBitmask;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerEditor.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerEditor.cs
@@ -89,7 +89,7 @@ public unsafe partial struct AgentBannerEditorState {
 
     [FieldOffset(0x2B8)] public EditorOpenType OpenType;
 
-    [FieldOffset(0x2C4)] public uint FrameCountdown; // starting at 0.5s on open
+    [FieldOffset(0x2C4)] public float FrameCountdown; // starting at 0.5s on open
     [FieldOffset(0x2C8)] public int GearsetId;
 
     [FieldOffset(0x2D0)] public int CloseDialogAddonId;

--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkUnitManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkUnitManager.cs
@@ -19,19 +19,4 @@ public unsafe partial struct RaptureAtkUnitManager {
     [FieldOffset(0x9D00)] public UIModule.UiFlags UiFlags;
 
     [FieldOffset(0x9D14)] public bool IsUiFading; // true whenever FadeMiddleBack is active
-
-    [MemberFunction("E8 ?? ?? ?? ?? 48 8B F8 41 B0 01"), GenerateStringOverloads]
-    public partial AtkUnitBase* GetAddonByName(byte* name, int index = 1);
-
-    [MemberFunction("E8 ?? ?? ?? ?? 8B 6B 20")]
-    public partial AtkUnitBase* GetAddonById(ushort id);
-
-    [VirtualFunction(8)]
-    public partial bool ShowAddonById(ushort addonId, bool show); // True calls AtkUnitBase.Show, False calls AtkUnitBase.Hide
-
-    [VirtualFunction(10)]
-    public partial void RefreshAddon(AtkUnitBase* addon, uint numValues, AtkValue* values);
-
-    [VirtualFunction(11)]
-    public partial void UpdateAddonById(ushort addonId, NumberArrayData** numberArrayData, StringArrayData** stringArrayData, bool forced);
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitManager.cs
@@ -5,7 +5,7 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 // ctor "E8 ?? ?? ?? ?? C6 83 ?? ?? ?? ?? ?? 48 8D 8B ?? ?? ?? ?? 48 8D 05"
 [GenerateInterop(isInherited: true)]
 [StructLayout(LayoutKind.Explicit, Size = 0x9C90)]
-public partial struct AtkUnitManager {
+public unsafe partial struct AtkUnitManager {
     [FieldOffset(0x0)] public AtkEventListener AtkEventListener;
     [FieldOffset(0x30)] public AtkUnitList DepthLayerOneList;
     [FieldOffset(0x840)] public AtkUnitList DepthLayerTwoList;
@@ -26,6 +26,21 @@ public partial struct AtkUnitManager {
     [FieldOffset(0x8130)] public AtkUnitList UnitList17;
     [FieldOffset(0x8940)] public AtkUnitList UnitList18;
     [FieldOffset(0x9C88)] public AtkUnitManagerFlags Flags;
+
+    [VirtualFunction(8)]
+    public partial bool SetAddonVisibility(ushort addonId, bool visible);
+
+    [VirtualFunction(10)]
+    public partial void RefreshAddon(AtkUnitBase* addon, uint numValues, AtkValue* values);
+
+    [VirtualFunction(11)]
+    public partial void UpdateAddonById(ushort addonId, NumberArrayData** numberArrayData, StringArrayData** stringArrayData, bool forced);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B F8 41 B0 01"), GenerateStringOverloads]
+    public partial AtkUnitBase* GetAddonByName(byte* name, int index = 1);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 8B 6B 20")]
+    public partial AtkUnitBase* GetAddonById(ushort id);
 }
 
 [Flags]

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3377,9 +3377,9 @@ classes:
       - ea: 0x1419BEA98
         base: Component::GUI::AtkEventListener
     vfuncs:
-      8: ShowAddonByID
+      8: SetAddonVisibility
       10: RefreshAddon
-      11: UpdateAddonByID
+      11: UpdateAddonById
     funcs:
       0x14017C1B0: Finalize
       0x140543B80: ctor


### PR DESCRIPTION
- Moved functions from `RaptureAtkUnitManager` to `AtkUnitManager`
  - Renamed vf8 from `ShowAddonByID` to `SetAddonVisibility`, because passing false as second parameter hides the addon (open for name suggestions - `UpdateAddonVisibility`? `ChangeAddonVisibility`?)
- Renamed `PlayerState.OwnedMountsBitmask` to `PlayerState.UnlockedMountsBitmask` to align it with the names of other unlock bitmask fields
- Changed the type of `AgentBannerEditorState.FrameCountdown` to float. I found this in a 7 month old git stash. 🙃 Confirmed float at 1412CDDEC.