### PR TITLE
Change timestamp types to int

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/GcArmyManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/GcArmyManager.cs
@@ -13,8 +13,8 @@ public unsafe partial struct GcArmyManager {
 
     /// <remarks> Data is loaded on-demand inside GC Barracks </remarks>
     [FieldOffset(0)] public GcArmyData* Data;
-    [FieldOffset(0x08)] public uint LastMissionCompleteNotificationTimestamp;
-    [FieldOffset(0x0C)] public uint LastTrainingCompleteNotificationTimestamp;
+    [FieldOffset(0x08)] public int LastMissionCompleteNotificationTimestamp;
+    [FieldOffset(0x0C)] public int LastTrainingCompleteNotificationTimestamp;
 
     [MemberFunction("E8 ?? ?? ?? ?? 8B F0 41 8B DF")]
     public partial uint GetMemberCount();
@@ -61,7 +61,7 @@ public unsafe partial struct GcArmyMember {
     [FieldOffset(0x12)] public GcArmyMemberFlag Flags;
     /// <remarks> RowId of GcArmyCandidateCategory </remarks>
     [FieldOffset(0x13)] public byte CandidateCategory;
-    [FieldOffset(0x14)] public uint EnlistmentTimestamp;
+    [FieldOffset(0x14)] public int EnlistmentTimestamp;
     /// <remarks> RowId of GcArmyCaptureTactics </remarks>
     [FieldOffset(0x1C)] public byte CaptureTactics;
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/GoldSaucer/GFateDirector.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/GoldSaucer/GFateDirector.cs
@@ -18,7 +18,7 @@ public unsafe partial struct GFateDirector {
     [FieldOffset(0x6E8)] public uint MapMarkerIconId;
 
     [FieldOffset(0x760), FixedSizeArray] internal FixedSizeArray32<uint> _objectIds;
-    [FieldOffset(0x7E0)] public uint EndTimestamp;
+    [FieldOffset(0x7E0)] public int EndTimestamp;
 
     [FieldOffset(0x7EC)] public ushort BgmId;
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/PublicContentBozja.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/PublicContentBozja.cs
@@ -70,7 +70,7 @@ public unsafe partial struct DynamicEvent {
     [FieldOffset(0x50)] public byte MaxParticipants;
     [FieldOffset(0x51)] public byte Unknown4;
     [FieldOffset(0x52)] public byte Unknown5;
-    [FieldOffset(0x54)] public uint StartTimestamp;
+    [FieldOffset(0x54)] public int StartTimestamp;
     [FieldOffset(0x58)] public uint SecondsLeft;
     [FieldOffset(0x5C)] public uint SecondsDuration;
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/MJI/MJIGranariesState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/MJI/MJIGranariesState.cs
@@ -10,7 +10,7 @@ public unsafe partial struct MJIGranaryState {
     [FieldOffset(0x04)] public short RareResourceCount;
     [FieldOffset(0x06), FixedSizeArray] internal FixedSizeArray20<byte> _normalResourcePouchIds;
     [FieldOffset(0x1A), FixedSizeArray] internal FixedSizeArray20<byte> _normalResourceCounts;
-    [FieldOffset(0x44)] public uint FinishTime; // unix timestamp
+    [FieldOffset(0x44)] public int FinishTime; // unix timestamp
 }
 
 // Client::Game::MJI::MJIGranariesState

--- a/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
@@ -78,13 +78,13 @@ public unsafe partial struct QuestManager {
     /// Use <see cref="GetNextLeveAllowancesUnixTimestamp"/> or <see cref="GetNextLeveAllowancesDateTime"/> instead.
     /// </remarks>
     [MemberFunction("E8 ?? ?? ?? ?? 41 8D 75 01")]
-    private static partial uint GetNextLeveAllowancesTimestamp();
+    private static partial int GetNextLeveAllowancesTimestamp();
 
     /// <summary>
     /// Get the time when the player will receive new leve allowances.
     /// </summary>
     /// <returns>A unix timestamp as <see cref="uint"/>.</returns>
-    public static uint GetNextLeveAllowancesUnixTimestamp() => GetNextLeveAllowancesTimestamp() * 60;
+    public static int GetNextLeveAllowancesUnixTimestamp() => GetNextLeveAllowancesTimestamp() * 60;
 
     /// <summary>
     /// Get the time when the player will receive new leve allowances.

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -21,7 +21,7 @@ public unsafe partial struct PlayerState {
     /// 1 = Unknown<br/>
     /// See also: <see cref="InstanceContent.GetPenaltyRemainingInMinutes" />
     /// </remarks>
-    [FieldOffset(0x70), FixedSizeArray] internal FixedSizeArray2<uint> _penaltyTimestamps;
+    [FieldOffset(0x70), FixedSizeArray] internal FixedSizeArray2<int> _penaltyTimestamps;
 
     [FieldOffset(0x79)] public byte MaxLevel;
     [FieldOffset(0x7A)] public byte MaxExpansion;
@@ -129,8 +129,8 @@ public unsafe partial struct PlayerState {
     /// </remarks>
     [FieldOffset(0x55B)] public byte MeisterFlag;
 
-    [FieldOffset(0x560)] public uint SquadronMissionCompletionTimestamp;
-    [FieldOffset(0x564)] public uint SquadronTrainingCompletionTimestamp;
+    [FieldOffset(0x560)] public int SquadronMissionCompletionTimestamp;
+    [FieldOffset(0x564)] public int SquadronTrainingCompletionTimestamp;
     [FieldOffset(0x568)] public ushort ActiveGcArmyExpedition;
     [FieldOffset(0x56A)] public ushort ActiveGcArmyTraining;
     [FieldOffset(0x56C)] public bool HasNewGcArmyCandidate; // see lua function "GcArmyIsNewCandidate"
@@ -359,7 +359,7 @@ public unsafe partial struct PlayerState {
 
     /// <summary>Returns the expiration of the players Wondrous Tails Journal as a unix timestamp.</summary>
     [MemberFunction("8B 81 ?? ?? ?? ?? C1 E8 04 25")]
-    public partial uint GetWeeklyBingoExpireUnixTimestamp();
+    public partial int GetWeeklyBingoExpireUnixTimestamp();
 
     /// <summary>Returns whether the task is complete or not.</summary>
     /// <param name="index">Task index, starting at 1.</param>

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFreeCompanyProfile.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentFreeCompanyProfile.cs
@@ -24,7 +24,7 @@ public unsafe partial struct AgentFreeCompanyProfile {
     [FieldOffset(0x054)] public ushort EstateZone;
     [FieldOffset(0x056)] public ushort World;
     //4 byte unknown Set to 0xe0000000 in ctor
-    [FieldOffset(0x05C)] public uint FoundationDate; //UNIX Timestamp
+    [FieldOffset(0x05C)] public int FoundationDate; //UNIX Timestamp
     [FieldOffset(0x060)] public short MemberCount;
     [FieldOffset(0x062)] public short MembersOnline;
     [FieldOffset(0x064)] public FCProfile Profile;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyLetter.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyLetter.cs
@@ -27,7 +27,7 @@ public unsafe partial struct InfoProxyLetter {
     [StructLayout(LayoutKind.Explicit, Size = 0xA0)]
     public unsafe partial struct Letter {
         [FieldOffset(0x00)] public long SenderContentId;// 0xFFFFFFFF for Store
-        [FieldOffset(0x08)] public uint Timestamp;
+        [FieldOffset(0x08)] public int Timestamp;
         [FieldOffset(0x0C), FixedSizeArray] internal FixedSizeArray5<ItemAttachment> _attachments;
         [FieldOffset(0x38)] public uint Gil;
         [FieldOffset(0x3C)] public bool Read;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/BannerModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/BannerModule.cs
@@ -95,7 +95,7 @@ public unsafe partial struct BannerModuleEntry {
     [FieldOffset(0x69)] public byte AmbientLightingColorBlue;
     [FieldOffset(0x6C)] public float AnimationProgress;
     [FieldOffset(0x70)] public uint BannerTimelineIcon;
-    [FieldOffset(0x74)] public uint LastUpdated; // unix timestamp
+    [FieldOffset(0x74)] public int LastUpdated; // unix timestamp
     [FieldOffset(0x78)] public uint Checksum; // see GenerateChecksum
     [FieldOffset(0x7C)] public ushort BannerBg;
     [FieldOffset(0x7E)] public ushort BannerFrame;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/FieldMarkerModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/FieldMarkerModule.cs
@@ -28,7 +28,7 @@ public partial struct FieldMarkerPreset {
     [FieldOffset(0x00), FixedSizeArray] internal FixedSizeArray8<GamePresetPoint> _markers;
     [FieldOffset(0x60)] public byte ActiveMarkers;
     [FieldOffset(0x62)] public ushort ContentFinderConditionId;
-    [FieldOffset(0x64)] public uint TimeStamp;
+    [FieldOffset(0x64)] public int Timestamp;
 
     public bool IsMarkerActive(int index) => (ActiveMarkers & 1 << index) != 0;
     public void SetMarkerActive(int index, bool active) {

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
@@ -69,7 +69,7 @@ public unsafe partial struct RaptureLogModule {
     public partial bool GetLogMessage(int index, Utf8String* str);
 
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 ?? 0F B6 85 ?? ?? ?? ?? 48 8D 8D")]
-    public partial bool GetLogMessageDetail(int index, short* logKind, Utf8String* sender, Utf8String* message, uint* timeStamp);
+    public partial bool GetLogMessageDetail(int index, short* logKind, Utf8String* sender, Utf8String* message, int* timestamp);
 
     [MemberFunction("4C 8B D1 48 8B 89 ?? ?? ?? ?? 48 85 C9")]
     public partial void AddMsgSourceEntry(ulong contentId, int messageIndex, ushort worldId, ushort chatType);
@@ -81,11 +81,11 @@ public unsafe partial struct RaptureLogModule {
         return result;
     }
 
-    public bool GetLogMessageDetail(int index, out byte[] sender, out byte[] message, out short logKind, out uint time) {
+    public bool GetLogMessageDetail(int index, out byte[] sender, out byte[] message, out short logKind, out int time) {
         using var pMessage = new Utf8String();
         using var pSender = new Utf8String();
         short pKind = 0;
-        uint pTime = 0;
+        int pTime = 0;
 
         var result = GetLogMessageDetail(index, &pKind, &pSender, &pMessage, &pTime);
 

--- a/FFXIVClientStructs/FFXIV/Common/TimePoint.cs
+++ b/FFXIVClientStructs/FFXIV/Common/TimePoint.cs
@@ -2,7 +2,7 @@ namespace FFXIVClientStructs.FFXIV.Common;
 
 [StructLayout(LayoutKind.Explicit, Size = 0x18)]
 public struct TimePoint {
-    [FieldOffset(0x00)] public uint TimeStamp;
+    [FieldOffset(0x00)] public int Timestamp;
     [FieldOffset(0x08)] public ulong CpuMilliSeconds;
     [FieldOffset(0x10)] public ulong CpuMicroSeconds;
 }


### PR DESCRIPTION
Whether or not timestamps ever go back further than 01.01.1970, the fields should still be of type `int`.