### PR TITLE
Update AtkUnitBase

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonGearSetList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonGearSetList.cs
@@ -10,5 +10,5 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 [Inherits<AtkUnitBase>]
 [StructLayout(LayoutKind.Explicit, Size = 0x3A90)]
 public partial struct AddonGearSetList {
-    [FieldOffset(0x3A8D)] public bool ResetPosition;
+    [FieldOffset(0x3A8D)] public bool ShouldResetPosition;
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentWindow.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentWindow.cs
@@ -8,4 +8,23 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 [GenerateInterop]
 [Inherits<AtkComponentBase>]
 [StructLayout(LayoutKind.Explicit, Size = 0x108)]
-public partial struct AtkComponentWindow;
+public unsafe partial struct AtkComponentWindow {
+    [FieldOffset(0xC0)] public AtkUnitBase* UnitBase;
+    /// <remarks>
+    /// [0] = Title<br/>
+    /// [1] = Subtitle<br/>
+    /// [2] = CloseButton<br/>
+    /// [3] = SettingsButton<br/>
+    /// [4] = HelpButton<br/>
+    /// [5] = Unknown<br/>
+    /// [6] = TitleBar<br/>
+    /// [7] = Unknown
+    /// </remarks>
+    [FieldOffset(0xC8), FixedSizeArray] internal FixedSizeArray8<int> _nodeIds;
+    [FieldOffset(0xE8)] public AtkCollisionNode* WindowCollisionNode;
+    [FieldOffset(0xF0)] public AtkCollisionNode* TitlebarCollisionNode;
+    [FieldOffset(0xF8)] public uint TitleTextId;
+    [FieldOffset(0xFC)] public uint SubtitleTextId;
+    [FieldOffset(0x100)] public float SubtitleOffsetX;
+    [FieldOffset(0x104)] public byte ShowFlags;
+}

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentWindow.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentWindow.cs
@@ -22,7 +22,7 @@ public unsafe partial struct AtkComponentWindow {
     /// </remarks>
     [FieldOffset(0xC8), FixedSizeArray] internal FixedSizeArray8<int> _nodeIds;
     [FieldOffset(0xE8)] public AtkCollisionNode* WindowCollisionNode;
-    [FieldOffset(0xF0)] public AtkCollisionNode* TitlebarCollisionNode;
+    [FieldOffset(0xF0)] public AtkCollisionNode* TitleBarCollisionNode;
     [FieldOffset(0xF8)] public uint TitleTextId;
     [FieldOffset(0xFC)] public uint SubtitleTextId;
     [FieldOffset(0x100)] public float SubtitleOffsetX;

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentWindow.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentWindow.cs
@@ -9,7 +9,7 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 [Inherits<AtkComponentBase>]
 [StructLayout(LayoutKind.Explicit, Size = 0x108)]
 public unsafe partial struct AtkComponentWindow {
-    [FieldOffset(0xC0)] public AtkUnitBase* UnitBase;
+    [FieldOffset(0xC0)] public AtkUnitBase* OwnerUnitBase;
     /// <remarks>
     /// [0] = Title<br/>
     /// [1] = Subtitle<br/>

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkExternalInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkExternalInterface.cs
@@ -1,6 +1,7 @@
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
 // Component::GUI::AtkExternalInterface
+[GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x8)]
 public unsafe partial struct AtkExternalInterface {
     [VirtualFunction(1)]

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkExternalInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkExternalInterface.cs
@@ -7,6 +7,6 @@ public unsafe partial struct AtkExternalInterface {
     [VirtualFunction(1)]
     public partial void CallHandler(AtkValue* result, uint handlerIndex, uint valueCount, AtkValue* values);
 
-    // [VirtualFunction(2)]
-    // public partial void CallTextService(AtkValue* result, uint handlerIndex);  // guessed, so just a comment for now
+    [VirtualFunction(2)]
+    public partial void PlaySoundEffect(AtkValue* result, int soundEffectId);
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkExternalInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkExternalInterface.cs
@@ -3,6 +3,9 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 // Component::GUI::AtkExternalInterface
 [StructLayout(LayoutKind.Explicit, Size = 0x8)]
 public unsafe partial struct AtkExternalInterface {
-    // [VirtualFunction(1)]
-    // public partial void DispatchCallback(AtkValue* result, uint callbackIndex, uint valueCount, AtkValue* values); // guessed, so just a comment for now
+    [VirtualFunction(1)]
+    public partial void CallHandler(AtkValue* result, uint handlerIndex, uint valueCount, AtkValue* values);
+
+    // [VirtualFunction(2)]
+    // public partial void CallTextService(AtkValue* result, uint handlerIndex);  // guessed, so just a comment for now
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkModuleInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkModuleInterface.cs
@@ -37,7 +37,7 @@ public unsafe partial struct AtkModuleInterface {
     public partial bool CloseAddon(uint addonId);
 
     [VirtualFunction(23)]
-    public partial bool RefreshAddon(uint addonId, uint numValues, AtkValue* values);
+    public partial bool RefreshAddon(uint addonId, uint valueCount, AtkValue* values);
 
     [VirtualFunction(26)]
     public partial bool IsAddonReady(uint addonId);

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkResNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkResNode.cs
@@ -70,8 +70,6 @@ public unsafe partial struct AtkResNode : ICreatable {
     /// </summary>
     [FieldOffset(0xA0)] public uint DrawFlags;
 
-    public bool IsVisible => NodeFlags.HasFlag(NodeFlags.Visible);
-
     [MemberFunction("E9 ?? ?? ?? ?? 33 C0 48 83 C4 20 5B C3 66 90")]
     public partial void Ctor();
 
@@ -196,6 +194,9 @@ public unsafe partial struct AtkResNode : ICreatable {
 
     [MemberFunction("E8 ?? ?? ?? ?? 80 7B 61 00")]
     public partial void SetHeight(ushort height);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 EB 05")]
+    public partial bool IsVisible();
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 83 C7 08 48 83 EB 01 75 DC")]
     public partial void ToggleVisibility(bool enable);

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkResourceRendererManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkResourceRendererManager.cs
@@ -1,0 +1,4 @@
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
+
+[StructLayout(LayoutKind.Explicit, Size = 0x118)]
+public struct AtkResourceRendererManager;

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkSimpleTween.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkSimpleTween.cs
@@ -34,7 +34,7 @@ public unsafe partial struct AtkSimpleTween : ICreatable {
     public partial void Clear();
 
     [MemberFunction("E8 ?? ?? ?? ?? 44 8B 87 ?? ?? ?? ?? 4C 8B CF")]
-    public partial void Prepare(int duration, AtkResNode* node, SimpleTweenValue* values, uint numValues, float easingFactor = 0.5f);
+    public partial void Prepare(int duration, AtkResNode* node, SimpleTweenValue* values, uint valueCount, float easingFactor = 0.5f);
 
     [MemberFunction("E8 ?? ?? ?? ?? FF 4F 5C")]
     public partial void Execute();

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldComponentInfo.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldComponentInfo.cs
@@ -1,7 +1,8 @@
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
+[GenerateInterop]
+[Inherits<AtkUldObjectInfo>]
 [StructLayout(LayoutKind.Explicit, Size = 0x18)]
-public struct AtkUldComponentInfo {
-    [FieldOffset(0x0)] public AtkUldObjectInfo ObjectInfo;
+public partial struct AtkUldComponentInfo {
     [FieldOffset(0x10)] public ComponentType ComponentType;
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldManager.cs
@@ -32,7 +32,7 @@ public unsafe partial struct AtkUldManager {
     [FieldOffset(0x38)] public AtkTimelineManager* TimelineManager;
     [FieldOffset(0x40)] public ushort DrawOrderIndex;
     [FieldOffset(0x42)] public ushort NodeListCount;
-    [FieldOffset(0x48)] public void* AtkResourceRendererManager;
+    [FieldOffset(0x48)] public AtkResourceRendererManager* ResourceRendererManager;
     [FieldOffset(0x50)] public AtkResNode** NodeList;
     [FieldOffset(0x58)] public StdLinkedList<Pointer<DuplicateObjectList>> DuplicateObjectsList; // linked list of lists of duplicates
     [FieldOffset(0x78)] public AtkResNode* RootNode;
@@ -41,6 +41,9 @@ public unsafe partial struct AtkUldManager {
     [FieldOffset(0x84)] public ushort NodeListSize; // this is the allocated size of nodelist, count is the amount of nodes it has
     [FieldOffset(0x86)] public byte Flags1;
     [FieldOffset(0x89)] public AtkLoadState LoadedState; // 3 is fully loaded
+
+    [MemberFunction("E8 ?? ?? ?? ?? 44 8B 73 18")]
+    public partial void InitializeResourceRendererManager();
 
     [MemberFunction("F6 81 ?? ?? ?? ?? ?? 44 8B CA")]
     public partial AtkResNode* SearchNodeById(uint id);

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldManager.cs
@@ -43,9 +43,7 @@ public unsafe partial struct AtkUldManager {
     [FieldOffset(0x89)] public AtkLoadState LoadedState; // 3 is fully loaded
 
     [MemberFunction("F6 81 ?? ?? ?? ?? ?? 44 8B CA")]
-    private partial AtkResNode* SearchNodeByIdInternal(uint id);
-
-    public AtkResNode* SearchNodeById(uint id) => LoadedState == AtkLoadState.Loaded ? SearchNodeByIdInternal(id) : null;
+    public partial AtkResNode* SearchNodeById(uint id);
 
     [MemberFunction("48 89 5C 24 ?? 57 48 83 EC ?? 8B FA 33 DB E8")]
     public partial AtkComponentBase* CreateAtkComponent(ComponentType type);

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldObjectInfo.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldObjectInfo.cs
@@ -1,7 +1,8 @@
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
+[GenerateInterop(isInherited: true)]
 [StructLayout(LayoutKind.Explicit, Size = 0x10)]
-public unsafe struct AtkUldObjectInfo {
+public unsafe partial struct AtkUldObjectInfo {
     [FieldOffset(0x0)] public uint Id;
     [FieldOffset(0x4)] public int NodeCount;
     [FieldOffset(0x8)] public AtkResNode** NodeList;

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldWidgetInfo.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldWidgetInfo.cs
@@ -1,8 +1,9 @@
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
+[GenerateInterop]
+[Inherits<AtkUldObjectInfo>]
 [StructLayout(LayoutKind.Explicit, Size = 0x20)]
-public struct AtkUldWidgetInfo {
-    [FieldOffset(0x0)] public AtkUldObjectInfo ObjectInfo;
+public partial struct AtkUldWidgetInfo {
     [FieldOffset(0x10)] public uint AlignmentType;
     [FieldOffset(0x14)] public float X;
     [FieldOffset(0x18)] public float Y;

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -54,10 +54,25 @@ public unsafe partial struct AtkUnitBase : ICreatable {
 
     /// <summary>
     /// <code>
+    /// 0b1000_0000 = Disable auto-focus (not adding it to Focused Units list)
+    /// </code>
+    /// </summary>
+    [FieldOffset(0x188)] public byte Flags188;
+
+    /// <summary>
+    /// <code>
     /// 0b0000_0001 = OnSetup was called (= IsReady)
     /// </code>
     /// </summary>
     [FieldOffset(0x189)] public byte Flags189;
+    [FieldOffset(0x18A)] public byte Flags18A;
+
+    /// <summary>
+    /// <code>
+    /// 0b0100_0000 = Don't show on open
+    /// </code>
+    /// </summary>
+    [FieldOffset(0x18D)] public byte Flags18D;
 
     [FieldOffset(0x194)] public uint OpenTransitionDuration;
     [FieldOffset(0x198)] public uint CloseTransitionDuration;

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -310,6 +310,9 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     [VirtualFunction(43)]
     public partial void Draw();
 
+    [VirtualFunction(45)]
+    public partial bool LoadUldResourceHandle();
+
     [VirtualFunction(46)]
     public partial bool CheckWindowCollisionAtCoords(short x, short y);
 

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -104,7 +104,6 @@ public unsafe partial struct AtkUnitBase : ICreatable {
 
     [FieldOffset(0x1D8)] public AtkResNode** CollisionNodeList; // seems to be all collision nodes in tree, may be something else though
     [FieldOffset(0x1E0)] public uint CollisionNodeListCount;
-    [FieldOffset(0x1E4), FixedSizeArray] internal FixedSizeArray5<Unk1E4Struct> _unk1E4; // something with Focus?? maybe controller tabbing?
 
     public uint DepthLayer => (Flags180 >> 16) & 0xF;
 
@@ -300,15 +299,5 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     public partial void OnMouseOut();
 
     [VirtualFunction(65)]
-    public partial bool AreAllResourcesLoaded();
-
-    [StructLayout(LayoutKind.Explicit, Size = 0x0C)]
-    public struct Unk1E4Struct {
-        [FieldOffset(0x00)] public byte Unk00;
-        [FieldOffset(0x01)] public byte Unk01;
-        [FieldOffset(0x02)] public short Unk02;
-        [FieldOffset(0x04)] public short Unk04;
-
-        [FieldOffset(0x08)] public int Unk08;
-    }
+    public partial bool IsFullyLoaded();
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -101,7 +101,7 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     public partial byte FireCallbackInt(int callbackValue);
 
     [MemberFunction("E8 ?? ?? ?? ?? 8B 44 24 20 C1 E8 05")]
-    public partial void FireCallback(int valueCount, AtkValue* values, bool close = false);
+    public partial void FireCallback(uint valueCount, AtkValue* values, bool close = false);
 
     [MemberFunction("E8 ?? ?? ?? ?? F6 46 40 0F")]
     public partial void UpdateCollisionNodeList(bool clearFocus);
@@ -203,10 +203,10 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     public partial bool CheckWindowCollisionAtCoords(short x, short y);
 
     [VirtualFunction(48)]
-    public partial void OnSetup(uint numValues, AtkValue* values);
+    public partial void OnSetup(uint valueCount, AtkValue* values);
 
     [VirtualFunction(50)]
-    public partial void OnRefresh(uint numValues, AtkValue* values);
+    public partial void OnRefresh(uint valueCount, AtkValue* values);
 
     [VirtualFunction(51)]
     public partial void OnRequestedUpdate(NumberArrayData** numberArrayData, StringArrayData** stringArrayData);
@@ -230,7 +230,7 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     public partial void SetCloseTransition(float duration, short offsetX, short offsetY, float scale);
 
     [MemberFunction("E8 ?? ?? ?? ?? 4D 8B C6 48 8B D3 48 8B CF")]
-    public partial bool SetAtkValues(uint numValues, AtkValue* values);
+    public partial bool SetAtkValues(uint valueCount, AtkValue* values);
 
     [MemberFunction("E8 ?? ?? ?? ?? 0F BF 8C 24 ?? ?? ?? ?? 01 8F")]
     public partial bool MoveDelta(short* xDelta, short* yDelta);

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -135,6 +135,9 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     [MemberFunction("E8 ?? ?? ?? ?? 0F BF 8C 24 ?? ?? ?? ?? 01 8F")]
     public partial bool MoveDelta(short* xDelta, short* yDelta);
 
+    [MemberFunction("E8 ?? ?? ?? ?? 8D 55 0D 48 8B CE")]
+    public partial bool ContainsNode(AtkResNode* node);
+
     [VirtualFunction(3)]
     public partial bool Open(uint depthLayer);
 

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -88,7 +88,6 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     /// Mainly used by Gold Saucer addons. Handled in AtkModule handler 50.<br/>
     /// The following scds can be loaded:
     /// <code>
-    /// 0 = sound/system/SE_UI.scd
     /// 1 = sound/system/SE_GS.scd
     /// 2 = sound/system/SE_TTriad.scd
     /// 3 = sound/system/SE_EMJ.scd

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -54,49 +54,20 @@ public unsafe partial struct AtkUnitBase : ICreatable {
 
     /// <summary>
     /// <code>
-    /// 0b1000_0000 = Disable auto-focus (not adding it to FocusedUnitsList)
-    /// </code>
-    /// </summary>
-    [FieldOffset(0x188)] public byte Flags188;
-    /// <summary>
-    /// <code>
-    /// 0b0000_0001 = OnSetup was called (= IsReady)<br/>
-    /// 0b0000_0010 = ? ("75 57 F6 83 ?? ?? ?? ?? ?? 74 3F")
+    /// 0b0000_0001 = OnSetup was called (= IsReady)
     /// </code>
     /// </summary>
     [FieldOffset(0x189)] public byte Flags189;
-    [FieldOffset(0x18A)] public byte Flags18A;
-    [FieldOffset(0x18B)] public byte Flags18B;
-    /// <summary>
-    /// <code>
-    /// 0b0000_1000 = Do not register default events (checked before calling "40 53 48 83 EC 40 48 8B 91")
-    /// </code>
-    /// </summary>
-    [FieldOffset(0x18C)] public byte Flags18C;
-    /// <summary>
-    /// <code>
-    /// 0b0010_0000 = Do not set text in AtkTextNodes from LabelID<br/>
-    /// 0b0100_0000 = Show on Open
-    /// </code>
-    /// </summary>
-    [FieldOffset(0x18D)] public byte Flags18D;
-    [FieldOffset(0x190)] public uint Flags190; // seen being used in AddonAreaMap_vf60
+
     [FieldOffset(0x194)] public uint OpenTransitionDuration;
     [FieldOffset(0x198)] public uint CloseTransitionDuration;
-    [FieldOffset(0x19C)] public uint Flags19C;
 
     [FieldOffset(0x1A1)] public byte NumOpenPopups; // used for dialogs and context menus to block inputs via ShouldIgnoreInputs
 
     [FieldOffset(0x1A4)] public float OpenTransitionScale;
     [FieldOffset(0x1A8)] public float CloseTransitionScale;
     [FieldOffset(0x1AC)] public float Scale;
-    /// <summary>
-    /// <code>
-    /// 0b0000_0000_0000_0000_0000_0000_1000_0000 = Do not register default events (inside "40 53 48 83 EC 40 48 8B 91")<br/>
-    /// 0b0000_0000_0000_0000_0000_0010_0000_0000 = Store strings from AtkValues in AtkValueStrings vector? ("8B 81 ?? ?? ?? ?? 4C 8B DA C1 E8 09")
-    /// </code>
-    /// </summary>
-    [FieldOffset(0x1B0)] public uint Flags1B0;
+
     /// <summary>
     /// An optional scd resource that is loaded along with the uld resource in <see cref="LoadUldResourceHandle"/>.<br/>
     /// Mainly used by Gold Saucer addons. Handled in AtkModule handler 50.<br/>
@@ -114,12 +85,6 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     [FieldOffset(0x1B6)] public byte VisibilityFlags;
 
     [FieldOffset(0x1B8)] public ushort DrawOrderIndex;
-    /// <summary>
-    /// <code>
-    /// 0b0000_0100 = WindowCollisionNode is RootNode
-    /// </code>
-    /// </summary>
-    [FieldOffset(0x1BA)] public byte Flag1BA;
 
     [FieldOffset(0x1BC)] public short X;
     [FieldOffset(0x1BE)] public short Y;

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -21,16 +21,106 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     [FieldOffset(0x108)] public AtkComponentNode* WindowNode;
     [FieldOffset(0x110)] public AtkSimpleTween RootNodeTween; // used for open/close transitions
     [FieldOffset(0x160)] public AtkValue* AtkValues;
-    [FieldOffset(0x182)] public byte Flags;
-    [FieldOffset(0x189)] public byte UnkFlags189;
+    [FieldOffset(0x168)] public StdVector<Pointer<byte>> CachedAtkValueStrings; // set here: "48 8D 54 24 ?? E8 ?? ?? ?? ?? 48 83 C4 20 41 5E"
+
+    /// <summary>
+    /// <code>
+    /// DepthLayer:<br/>
+    ///   Getter: (Flags180 >> 16) &amp; 0xF<br/>
+    ///   Mask: 0b0000_0000_0000_1111_0000_0000_0000_0000<br/>
+    /// <br/>
+    /// Visibility(?) Flags:<br/>
+    ///   Getter: (Flags180 >> 20) &amp; 0xF<br/>
+    ///   Mask: 0b0000_0000_1111_0000_0000_0000_0000_0000<br/>
+    ///   Values:
+    ///     0b0010 = Is visible<br/>
+    ///     0b0100 = Is hidden due to modal (like Retainer Menu)<br/>
+    /// <br/>
+    /// Applied Visibility(?) Flags:<br/>
+    ///   Getter: (Flags180 >> 24) &amp; 0xF<br/>
+    ///   Mask: 0b0000_1111_0000_0000_0000_0000_0000_0000<br/>
+    ///   Values: same as above<br/>
+    /// <br/>
+    /// UldLoadState:<br/>
+    ///   Getter: (Flags180 >> 28) &amp; 0xF<br/>
+    ///   Mask: 0b1111_0000_0000_0000_0000_0000_0000_0000<br/>
+    ///   Values:
+    ///     0 = Not loaded<br/>
+    ///     1 = UldResource loaded<br/>
+    ///     2 = UldManager finished loading the uld
+    /// </code>
+    /// </summary>
+    [FieldOffset(0x180)] public uint Flags180;
+
+    /// <summary>
+    /// <code>
+    /// 0b1000_0000 Disable auto-focus (not adding it to FocusedUnitsList)
+    /// </code>
+    /// </summary>
+    [FieldOffset(0x188)] public byte Flags188;
+    /// <summary>
+    /// <code>
+    /// 0b0000_0001 = OnSetup was called (= IsReady)<br/>
+    /// 0b0000_0010 = ? ("75 57 F6 83 ?? ?? ?? ?? ?? 74 3F")
+    /// </code>
+    /// </summary>
+    [FieldOffset(0x189)] public byte Flags189;
+    [FieldOffset(0x18A)] public byte Flags18A;
+    [FieldOffset(0x18B)] public byte Flags18B;
+    /// <summary>
+    /// <code>
+    /// 0b0000_1000 = Do not register default events (checked before calling "40 53 48 83 EC 40 48 8B 91")
+    /// </code>
+    /// </summary>
+    [FieldOffset(0x18C)] public byte Flags18C;
+    /// <summary>
+    /// <code>
+    /// 0b0010_0000 = Do not set text in AtkTextNodes from LabelID<br/>
+    /// 0b0100_0000 = Show on Open
+    /// </code>
+    /// </summary>
+    [FieldOffset(0x18D)] public byte Flags18D;
+    [FieldOffset(0x190)] public uint Flags190; // seen being used in AddonAreaMap_vf60
     [FieldOffset(0x194)] public uint OpenTransitionDuration;
     [FieldOffset(0x198)] public uint CloseTransitionDuration;
+    [FieldOffset(0x19C)] public uint Flags19C;
+
     [FieldOffset(0x1A1)] public byte NumOpenPopups; // used for dialogs and context menus to block inputs via ShouldIgnoreInputs
+
     [FieldOffset(0x1A4)] public float OpenTransitionScale;
     [FieldOffset(0x1A8)] public float CloseTransitionScale;
     [FieldOffset(0x1AC)] public float Scale;
+    /// <summary>
+    /// <code>
+    /// 0b0000_0000_0000_0000_0000_0000_1000_0000 = Do not register default events (inside "40 53 48 83 EC 40 48 8B 91")<br/>
+    /// 0b0000_0000_0000_0000_0000_0010_0000_0000 = Store strings from AtkValues in AtkValueStrings vector? ("8B 81 ?? ?? ?? ?? 4C 8B DA C1 E8 09")
+    /// </code>
+    /// </summary>
+    [FieldOffset(0x1B0)] public uint Flags1B0;
+    /// <summary>
+    /// An optional scd resource that is loaded along with the uld resource in <see cref="LoadUldResourceHandle"/>.<br/>
+    /// Mainly used by Gold Saucer addons. Handled in AtkModule handler 50.<br/>
+    /// The following scds can be loaded:
+    /// <code>
+    /// 0 = sound/system/SE_UI.scd
+    /// 1 = sound/system/SE_GS.scd
+    /// 2 = sound/system/SE_TTriad.scd
+    /// 3 = sound/system/SE_EMJ.scd
+    /// 4 = sound/system/SE_10thMG.scd
+    /// </code>
+    /// </summary>
+    [FieldOffset(0x1B4)] public byte SoundEffectScdResourceIndex;
+
     [FieldOffset(0x1B6)] public byte VisibilityFlags;
+
     [FieldOffset(0x1B8)] public ushort DrawOrderIndex;
+    /// <summary>
+    /// <code>
+    /// 0b0000_0100 WindowCollisionNode is RootNode
+    /// </code>
+    /// </summary>
+    [FieldOffset(0x1BA)] public byte Flag1BA;
+
     [FieldOffset(0x1BC)] public short X;
     [FieldOffset(0x1BE)] public short Y;
     [FieldOffset(0x1C0)] public short OpenTransitionOffsetX;
@@ -43,20 +133,23 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     [FieldOffset(0x1CE)] public ushort ParentId;
     [FieldOffset(0x1D0)] public ushort HostId; // for example, in CharacterProfile this holds the ID of the Character addon
     [FieldOffset(0x1D2)] public ushort ContextMenuParentId;
+
     [FieldOffset(0x1D5)] public byte Alpha;
     [FieldOffset(0x1D6)] public byte ShowHideFlags;
+
     [FieldOffset(0x1D8)] public AtkResNode** CollisionNodeList; // seems to be all collision nodes in tree, may be something else though
     [FieldOffset(0x1E0)] public uint CollisionNodeListCount;
+    [FieldOffset(0x1E4), FixedSizeArray] internal FixedSizeArray5<Unk1E4Struct> _unk1E4; // something with Focus?? maybe controller tabbing?
 
-    public int DepthLayer => Flags & 0xF;
+    public uint DepthLayer => (Flags180 >> 16) & 0xF;
 
     public bool IsVisible {
-        get => (Flags & 0x20) == 0x20;
-        set => Flags = value ? Flags |= 0x20 : Flags &= 0xDF;
+        get => (Flags180 & 0x200000) != 0;
+        set => Flags180 = value ? Flags180 |= 0x200000 : Flags180 &= 0xFFDFFFFF;
     }
 
     /// <summary> <c>true</c> when Setup is complete. </summary>
-    public bool IsReady => (UnkFlags189 & 0x01) != 0;
+    public bool IsReady => (Flags189 & 0x01) != 0;
 
     [MemberFunction("E8 ?? ?? ?? ?? 83 8B ?? ?? ?? ?? ?? 33 C0")]
     public partial void Ctor();
@@ -240,4 +333,14 @@ public unsafe partial struct AtkUnitBase : ICreatable {
 
     [VirtualFunction(65)]
     public partial bool AreAllResourcesLoaded();
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x0C)]
+    public struct Unk1E4Struct {
+        [FieldOffset(0x00)] public byte Unk00;
+        [FieldOffset(0x01)] public byte Unk01;
+        [FieldOffset(0x02)] public short Unk02;
+        [FieldOffset(0x04)] public short Unk04;
+
+        [FieldOffset(0x08)] public int Unk08;
+    }
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -109,7 +109,7 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     /// 4 = sound/system/SE_10thMG.scd
     /// </code>
     /// </summary>
-    [FieldOffset(0x1B4)] public byte SoundEffectScdResourceIndex;
+    [FieldOffset(0x1B4)] public byte ScdResourceIndex;
 
     [FieldOffset(0x1B6)] public byte VisibilityFlags;
 

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -120,6 +120,21 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     [MemberFunction("E8 ?? ?? ?? ?? 45 33 C9 8D 56 01")]
     public partial void UnsubscribeAtkArrayData(byte arrayType, byte arrayIndex, bool clean = false);
 
+    [MemberFunction("E9 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 8D 15"), GenerateStringOverloads]
+    public partial bool LoadUldByName(byte* name, byte a3 = 0, uint a4 = 6);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 8D 53 24")]
+    public partial void SetOpenTransition(float duration, short offsetX, short offsetY, float scale);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 8D 55 06 48 8B CE")]
+    public partial void SetCloseTransition(float duration, short offsetX, short offsetY, float scale);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 4D 8B C6 48 8B D3 48 8B CF")]
+    public partial bool SetAtkValues(uint valueCount, AtkValue* values);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 0F BF 8C 24 ?? ?? ?? ?? 01 8F")]
+    public partial bool MoveDelta(short* xDelta, short* yDelta);
+
     [VirtualFunction(3)]
     public partial bool Open(uint depthLayer);
 
@@ -219,19 +234,4 @@ public unsafe partial struct AtkUnitBase : ICreatable {
 
     [VirtualFunction(62)]
     public partial void OnMouseOut();
-
-    [MemberFunction("E9 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 8D 15"), GenerateStringOverloads]
-    public partial bool LoadUldByName(byte* name, byte a3 = 0, uint a4 = 6);
-
-    [MemberFunction("E8 ?? ?? ?? ?? 8D 53 24")]
-    public partial void SetOpenTransition(float duration, short offsetX, short offsetY, float scale);
-
-    [MemberFunction("E8 ?? ?? ?? ?? 8D 55 06 48 8B CE")]
-    public partial void SetCloseTransition(float duration, short offsetX, short offsetY, float scale);
-
-    [MemberFunction("E8 ?? ?? ?? ?? 4D 8B C6 48 8B D3 48 8B CF")]
-    public partial bool SetAtkValues(uint valueCount, AtkValue* values);
-
-    [MemberFunction("E8 ?? ?? ?? ?? 0F BF 8C 24 ?? ?? ?? ?? 01 8F")]
-    public partial bool MoveDelta(short* xDelta, short* yDelta);
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -54,7 +54,7 @@ public unsafe partial struct AtkUnitBase : ICreatable {
 
     /// <summary>
     /// <code>
-    /// 0b1000_0000 Disable auto-focus (not adding it to FocusedUnitsList)
+    /// 0b1000_0000 = Disable auto-focus (not adding it to FocusedUnitsList)
     /// </code>
     /// </summary>
     [FieldOffset(0x188)] public byte Flags188;
@@ -116,7 +116,7 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     [FieldOffset(0x1B8)] public ushort DrawOrderIndex;
     /// <summary>
     /// <code>
-    /// 0b0000_0100 WindowCollisionNode is RootNode
+    /// 0b0000_0100 = WindowCollisionNode is RootNode
     /// </code>
     /// </summary>
     [FieldOffset(0x1BA)] public byte Flag1BA;

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -234,4 +234,7 @@ public unsafe partial struct AtkUnitBase : ICreatable {
 
     [VirtualFunction(62)]
     public partial void OnMouseOut();
+
+    [VirtualFunction(65)]
+    public partial bool AreAllResourcesLoaded();
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -112,7 +112,9 @@ public unsafe partial struct AtkUnitBase : ICreatable {
         set => Flags180 = value ? Flags180 |= 0x200000 : Flags180 &= 0xFFDFFFFF;
     }
 
-    /// <summary> <c>true</c> when Setup is complete. </summary>
+    /// <summary>
+    /// Check if OnSetup was called.
+    /// </summary>
     public bool IsReady => (Flags189 & 0x01) != 0;
 
     [MemberFunction("E8 ?? ?? ?? ?? 83 8B ?? ?? ?? ?? ?? 33 C0")]
@@ -298,6 +300,13 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     [VirtualFunction(62)]
     public partial void OnMouseOut();
 
+    /// <summary>
+    /// Check if all resources are loaded.<br/>
+    /// This includes the uld, an optional scd (for Gold Saucer addons) and textures the uld needs.
+    /// </summary>
+    /// <remarks>
+    /// Use <see cref="IsReady" /> to check if OnSetup has been called (preferred).
+    /// </remarks>
     [VirtualFunction(65)]
     public partial bool IsFullyLoaded();
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -316,8 +316,7 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     public partial void OnMouseOut();
 
     /// <summary>
-    /// Check if all resources are loaded.<br/>
-    /// This includes the uld, an optional scd (for Gold Saucer addons) and textures the uld needs.
+    /// Check if all necessary resources are loaded and nodes/components are set up.
     /// </summary>
     /// <remarks>
     /// Use <see cref="IsReady" /> to check if OnSetup has been called (preferred).

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitManager.cs
@@ -31,7 +31,7 @@ public unsafe partial struct AtkUnitManager {
     public partial bool SetAddonVisibility(ushort addonId, bool visible);
 
     [VirtualFunction(10)]
-    public partial void RefreshAddon(AtkUnitBase* addon, uint numValues, AtkValue* values);
+    public partial void RefreshAddon(AtkUnitBase* addon, uint valueCount, AtkValue* values);
 
     [VirtualFunction(11)]
     public partial void AddonRequestUpdateById(ushort addonId, NumberArrayData** numberArrayData, StringArrayData** stringArrayData, bool forced);

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3388,9 +3388,9 @@ classes:
       8: SetAddonVisibility
       10: RefreshAddon
       11: AddonRequestUpdateById
-      19: IsSoundEffectScdLoaded
-      20: LoadSoundEffectScd
-      21: UnloadSoundEffectScd # it really just DecRefs it
+      19: IsScdResourceLoaded
+      20: LoadScdResource
+      21: UnloadScdResource # it really just DecRefs it
     funcs:
       0x14017C1B0: Finalize
       0x140543B80: ctor

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -6174,6 +6174,12 @@ classes:
         base: Component::GUI::AtkComponentBase
     funcs:
       0x14058DA90: ctor
+    vfuncs:
+      20: GetWindowCollisionNode
+      21: GetTitlebarCollisionNode
+      22: GetCloseButtonNode
+      23: SetAddon
+      25: ToggleTitleBarVisibility
   Component::GUI::AtkComponentJournalCanvas:
     vtbls:
       - ea: 0x141A0A628

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5837,7 +5837,7 @@ classes:
       57: OnOpenTransitionStarted
       61: OnMouseOver
       62: OnMouseOut
-      65: AreAllResourcesLoaded
+      65: IsFullyLoaded
     funcs:
       0x140538A80: ctor
       0x140538CB0: Destructor

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5836,6 +5836,7 @@ classes:
     funcs:
       0x140538A80: ctor
       0x140538CB0: Destructor
+      0x1405390E0: FireCallbackAndHideOrClose
       0x1405390F0: FireCallbackInt  # this creates an int AtkValue and puts its argument into it before calling Callback
       0x140539440: SetPosition
       0x1405395C0: SetAlpha
@@ -5860,7 +5861,6 @@ classes:
       0x14053D210: GetComponentListById
       0x14053D2B0: GetTextNodeById
       0x14053D310: GetImageNodeById
-      0x1405390E0: FireCallbackAndHideOrClose
       0x14053D410: FireCallback
       0x14053E030: MoveDelta
       0x14053FAC0: UpdateCollisionNodeList

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -629,7 +629,7 @@ classes:
       - ea: 0x141A08160
     vfuncs:
       0: dtor
-      1: DispatchCallback
+      1: CallHandler
   Component::GUI::AtkManagedInterface:
   Component::GUI::AtkModuleEvent:
     vtbls:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5979,6 +5979,8 @@ classes:
       0x14056B5C0: HandleInput
       0x14056B9C0: IsTextInputActive
       0x14056B840: SetUIScene
+      0x1400C6750: PlaySoundEffectHandler
+      0x1400C82A0: ScdResourceHandler
   Component::GUI::AtkComponentCheckBox:
     vtbls:
       - ea: 0x141A09718

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5850,6 +5850,7 @@ classes:
       0x140539CF0: GetScaledHeight
       0x140539D30: CalculateBounds
       0x14053A500: SetFlag
+      0x14053B920: ContainsNode
       0x14053C060: Draw
       0x14053C360: LoadUldByName
       0x14053C480: SetOpenTransition

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -6176,7 +6176,7 @@ classes:
       0x14058DA90: ctor
     vfuncs:
       20: GetWindowCollisionNode
-      21: GetTitlebarCollisionNode
+      21: GetTitleBarCollisionNode
       22: GetCloseButtonNode
       23: SetAddon
       25: ToggleTitleBarVisibility

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5856,11 +5856,11 @@ classes:
       0x14053B920: ContainsNode
       0x14053C060: Draw
       0x14053C360: LoadUldByName
-      0x14053C3F0: SetOpenSoundEffectScdIndex
+      0x14053C3F0: SetScdResourceIndex
       0x14053C480: SetOpenTransition
       0x14053C4C0: SetCloseTransition
-      0x14053C580: SubscribeAtkArrayData # handler: "4C 8B D2 48 8B D1 41 83 F9 04"
-      0x14053C710: UnsubscribeAtkArrayData # handler: "48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B DA 48 8B F9 41 83 F9 04"
+      0x14053C580: SubscribeAtkArrayData
+      0x14053C710: UnsubscribeAtkArrayData
       0x14053C9C0: SetFocusNode
       0x14053CF40: GetNodeById
       0x14053D070: GetButtonNodeById

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -6178,7 +6178,7 @@ classes:
       20: GetWindowCollisionNode
       21: GetTitleBarCollisionNode
       22: GetCloseButtonNode
-      23: SetAddon
+      23: SetOwnerUnitBase
       25: ToggleTitleBarVisibility
   Component::GUI::AtkComponentJournalCanvas:
     vtbls:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3388,6 +3388,9 @@ classes:
       8: SetAddonVisibility
       10: RefreshAddon
       11: AddonRequestUpdateById
+      19: IsSoundEffectScdLoaded
+      20: LoadSoundEffectScd
+      21: UnloadSoundEffectScd # it really just DecRefs it
     funcs:
       0x14017C1B0: Finalize
       0x140543B80: ctor
@@ -5853,6 +5856,7 @@ classes:
       0x14053B920: ContainsNode
       0x14053C060: Draw
       0x14053C360: LoadUldByName
+      0x14053C3F0: SetOpenSoundEffectScdIndex
       0x14053C480: SetOpenTransition
       0x14053C4C0: SetCloseTransition
       0x14053C580: SubscribeAtkArrayData # handler: "4C 8B D2 48 8B D1 41 83 F9 04"

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5833,6 +5833,7 @@ classes:
       57: OnOpenTransitionStarted
       61: OnMouseOver
       62: OnMouseOut
+      65: AreAllResourcesLoaded
     funcs:
       0x140538A80: ctor
       0x140538CB0: Destructor

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5713,7 +5713,7 @@ classes:
       0x14052BC50: GetPriority
       0x14052BC70: SetPriority
       0x14052BC90: IsVisible
-      0x14052BCC0: SetVisibility
+      0x14052BCC0: ToggleVisibility
       0x14052C0F0: GetIsUsingDepthBasedDrawPriority
       0x14052C110: SetUseDepthBasedDrawPriority
       0x14052C160: SetDepth

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1616,6 +1616,7 @@ classes:
       0x140511C90: ctor
   Component::GUI::AtkUldManager:
     funcs:
+      0x140534FA0: InitializeResourceRendererManager
       0x140531CD0: SetupFromULDResourceHandle
       0x1405332B0: CreateTimeline
       0x140534250: ReadTPHD

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -630,6 +630,7 @@ classes:
     vfuncs:
       0: dtor
       1: CallHandler
+      2: PlaySoundEffect
   Component::GUI::AtkManagedInterface:
   Component::GUI::AtkModuleEvent:
     vtbls:


### PR DESCRIPTION
Going through AtkUnitBase again, adding flag fields as they are used by the game and doing some cleanup.

Along with the flags, a couple notable changes:
- Added `AtkResNode.IsVisible` function
  It looks like someone found a function to check if an AtkResNode is visible. It does a little bit more than just checking the flag, so I included it. This obviously changes it from being a property to being a function.
- Added `AtkUnitBase.IsFullyLoaded` (vf65) and removed `AtkUldManager.SearchNodeById` wrapper
  This virtual function checks if all resources (uld and optional scd) are loaded and if the UldManager loaded the uld and all the textures it needs. This function should be the preferred way of checking if an addon was fully loaded going forward.
- Added `AtkExternalInterface` vfuncs 1 (CallHandler) and 2 (PlaySoundEffect).