### PR TITLE
[Not Dawntrain] Fix incorrect return type

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -301,7 +301,7 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     public partial void OnSetup(uint valueCount, AtkValue* values);
 
     [VirtualFunction(50)]
-    public partial void OnRefresh(uint valueCount, AtkValue* values);
+    public partial bool OnRefresh(uint valueCount, AtkValue* values);
 
     [VirtualFunction(51)]
     public partial void OnRequestedUpdate(NumberArrayData** numberArrayData, StringArrayData** stringArrayData);

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitManager.cs
@@ -31,7 +31,7 @@ public unsafe partial struct AtkUnitManager {
     public partial bool SetAddonVisibility(ushort addonId, bool visible);
 
     [VirtualFunction(10)]
-    public partial void RefreshAddon(AtkUnitBase* addon, uint valueCount, AtkValue* values);
+    public partial bool RefreshAddon(AtkUnitBase* addon, uint valueCount, AtkValue* values);
 
     [VirtualFunction(11)]
     public partial void AddonRequestUpdateById(ushort addonId, NumberArrayData** numberArrayData, StringArrayData** stringArrayData, bool forced);


### PR DESCRIPTION
Addon Lifecycle originally tried to use OnRefresh as a `void` return, but that caused a bunch of corruption errors, we discovered this issue and fixed it using our own delegate. Since then ClientStructs has added these functions, but they were added with the wrong return type.

```cs
char Component::GUI::AtkUnitBase_OnRefresh()
{
  return 1;
}
```

```cs
char __fastcall Component::GUI::AtkUnitManager_RefreshAddon(
        __int64 a1,
        Component::GUI::AtkUnitBase *a2,
        unsigned int a3,
        Component::GUI::AtkValue *a4)
{
  if ( !a2 )
    return 0;
  Component::GUI::AtkUnitBase_SetAtkValues(a2, a3, a4);
  return (a2->union.vtable->OnRefresh)(a2, a3, a2->AtkValues);
}
```

![rider64_KL51OblxdS](https://github.com/aers/FFXIVClientStructs/assets/9083275/8ebfbf5d-9257-4c0e-8296-8d5292198412)
