### PR TITLE
Add layout prefetch functions to LayoutWorld

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/LayoutEngine/LayoutManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/LayoutEngine/LayoutManager.cs
@@ -35,6 +35,8 @@ public unsafe partial struct LayoutManager {
     [FieldOffset(0x0DC)] public int ForceUpdateAllStreaming;
     [FieldOffset(0x0E2)] public bool SkipAddingTerrainCollider;
     //[FieldOffset(0x0E3)] public bool uE3;
+    [FieldOffset(0x0EA)] public byte LayerEntryType;
+    [FieldOffset(0x0EC)] public uint LevelId;
     [FieldOffset(0x0F0)] public int StreamingOriginType;
     [FieldOffset(0x100)] public Vector3 ForcedStreamingOrigin;
     //[FieldOffset(0x110)] public Vector3 u110_streamingType5Origin;

--- a/FFXIVClientStructs/FFXIV/Client/LayoutEngine/LayoutWorld.cs
+++ b/FFXIVClientStructs/FFXIV/Client/LayoutEngine/LayoutWorld.cs
@@ -1,3 +1,4 @@
+using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 
 namespace FFXIVClientStructs.FFXIV.Client.LayoutEngine;
@@ -18,7 +19,7 @@ public unsafe partial struct LayoutWorld {
     [FieldOffset(0x018)] public LayoutManager* GlobalLayout;
     [FieldOffset(0x020)] public LayoutManager* ActiveLayout;
     //[FieldOffset(0x028)] public LayoutManager* UnkLayout28;
-    //[FieldOffset(0x030)] public LayoutManager* UnkLayout30;
+    [FieldOffset(0x030)] public LayoutManager* PrefetchLayout;
     [FieldOffset(0x038)] public void* CutscenePrefetchResource;
     [FieldOffset(0x068)] public long MillisecondsSinceLastUpdate;
     [FieldOffset(0x080)] public StdMap<ulong, Pointer<LayoutManager>> LoadedLayouts; // key = (LvbCrc << 32) | TerritoryTypeRowId
@@ -26,4 +27,10 @@ public unsafe partial struct LayoutWorld {
     [FieldOffset(0x0A0)] public fixed float StreamingRadiusPerType[90];
     // 0x208 - some other map, value = Client::System::Resource::Handle::ResourceHandle*
     [FieldOffset(0x218)] public StdMap<Utf8String, Pointer<byte>>* RsvMap;
+
+    [MemberFunction("E8 ?? ?? ?? ?? 45 33 F6 44 89 B7")]
+    public partial void UnloadPrefetchLayout();
+
+    [MemberFunction("48 89 6C 24 ?? 56 57 41 56 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 8B 41 20"), GenerateStringOverloads]
+    public partial void LoadPrefetchLayout(int type, byte* bgName, byte layerEntryType, uint levelId, uint territoryTypeId, GameMain* gameMain, uint cfcId);
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3818,7 +3818,14 @@ classes:
     vtbls:
       - ea: 0x1419CB780
     funcs:
-      0x140194540: ctor
+      0x140194520: ctor
+      0x140194540: ctor_FromBuffer
+      0x140194590: Finalize
+      0x1401945F0: GetDigest
+      0x14019A080: Calculate
+      0x1401945C0: Update
+    vfuncs:
+      0: dtor
   Client::Graphics::ReferencedClassBase:
     vtbls:
       - ea: 0x1419D38F0
@@ -6262,6 +6269,9 @@ classes:
     funcs:
       0x1405BADA0: ctor
       0x1405BB030: CreateSingleton
+      0x1405BBDB0: LoadPrefetchLayout
+      0x1405BC1B0: UnloadManagerLayout
+      0x1405F90A0: UnloadPrefetchLayout
   Client::LayoutEngine::LayoutManager:
     vtbls:
       - ea: 0x141A0C210


### PR DESCRIPTION
Adds a function to prefetch a layout and another one to cancel it.

`LayoutWorld.PrefetchLayout` is called with type 1 and [LayerEntryType](https://github.com/NotAdam/Lumina/blob/master/src/Lumina/Data/Parsing/Layer/LayerEnums.cs) 71 (PrefetchRange) when near a zone barrier, or with type 2 and LayerEntryType 40 (PopRange) when starting to cast Teleport.
