### PR TITLE
Emit generated source files

### DIFF
--- a/FFXIVClientStructs/FFXIVClientStructs.csproj
+++ b/FFXIVClientStructs/FFXIVClientStructs.csproj
@@ -23,10 +23,8 @@
     <Product>FFXIVClientStructs</Product>
     <AssemblyTitle>FFXIVClientStructs</AssemblyTitle>
 
-    <!--
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
-    -->
     
     <!-- InteropGenerator -->
     <InteropGenerator_InteropNamespace>FFXIVClientStructs.Interop.Generated</InteropGenerator_InteropNamespace>

--- a/FFXIVClientStructs/FFXIVClientStructs.csproj
+++ b/FFXIVClientStructs/FFXIVClientStructs.csproj
@@ -22,16 +22,17 @@
     <Company>FFXIVClientStructs</Company>
     <Product>FFXIVClientStructs</Product>
     <AssemblyTitle>FFXIVClientStructs</AssemblyTitle>
-
-    <!-- Required for documentation builds, docfx does not support generators directly -->
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
     
     <!-- InteropGenerator -->
     <InteropGenerator_InteropNamespace>FFXIVClientStructs.Interop.Generated</InteropGenerator_InteropNamespace>
     
     <!-- GitInfo generator -->
     <ThisAssemblyNamespace>FFXIVClientStructs</ThisAssemblyNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsDocsBuild)' == 'true'">
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/FFXIVClientStructs/FFXIVClientStructs.csproj
+++ b/FFXIVClientStructs/FFXIVClientStructs.csproj
@@ -23,6 +23,7 @@
     <Product>FFXIVClientStructs</Product>
     <AssemblyTitle>FFXIVClientStructs</AssemblyTitle>
 
+    <!-- Required for documentation builds, docfx does not support generators directly -->
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
     


### PR DESCRIPTION
This is required for docs generation on our end. docfx can't work directly with source generators.
If it was disabled on purpose, maybe it could be enabled conditionally?