### PR TITLE
PCT gauge update

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGaugeEnums.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGaugeEnums.cs
@@ -94,6 +94,8 @@ public enum NadiFlags : byte {
 public enum CanvasFlags : byte {
     Pom = 1,
     Wing = 2,
+    Claw = 4,
+    Maw = 8,
     Weapon = 16,
     Landscape = 32,
 }
@@ -101,5 +103,9 @@ public enum CanvasFlags : byte {
 [Flags]
 public enum CreatureFlags : byte {
     Pom = 1,
-    Wings = 16
+    Wings = 2,
+    Claw = 4,
+
+    MooglePortait = 16,
+    MadeenPortrait = 32,
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
@@ -87,14 +87,15 @@ public struct RedMageGauge {
 [StructLayout(LayoutKind.Explicit, Size = 0x10)]
 public struct PictomancerGauge {
     [FieldOffset(0x08)] public byte PalleteGauge;
-    [FieldOffset(0x0A)] public byte WhitePaint;
+    [FieldOffset(0x0A)] public byte Paint;
     [FieldOffset(0x0B)] public CanvasFlags CanvasFlags;
     [FieldOffset(0x0C)] public CreatureFlags CreatureFlags;
 
-    public bool CreatureMotifDrawn => CanvasFlags.HasFlag(CanvasFlags.Pom) || CanvasFlags.HasFlag(CanvasFlags.Wing); // Will require update at level 96 with Maw & Claw most likely
+    public bool CreatureMotifDrawn => CanvasFlags.HasFlag(CanvasFlags.Pom) || CanvasFlags.HasFlag(CanvasFlags.Wing) || CanvasFlags.HasFlag(CanvasFlags.Claw) || CanvasFlags.HasFlag(CanvasFlags.Maw);
     public bool WeaponMotifDrawn => CanvasFlags.HasFlag(CanvasFlags.Weapon);
     public bool LandscapeMotifDrawn => CanvasFlags.HasFlag(CanvasFlags.Landscape);
-    public bool MooglePortraitReady => CreatureFlags.HasFlag(CreatureFlags.Wings);
+    public bool MooglePortraitReady => CreatureFlags.HasFlag(CreatureFlags.MooglePortait);
+    public bool MadeenPortraitReady => CreatureFlags.HasFlag(CreatureFlags.MadeenPortrait);
 }
 
 #endregion


### PR DESCRIPTION
Updated PCT gauge with values at max level.

- White Paint => Paint (Black Paint is controlled by a buff and the gauge only shows it visually but isn't tracked by the gauge)
- Updated creature flags
- I suspect Maw would have a creature flag of 8, however given that using Maw instantly sets the Madeen portrait it currently isn't used and therefore cannot prove that.