### PR TITLE
Update AgentItemDetail and AtkTooltipManager

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
@@ -1,4 +1,12 @@
+using FFXIVClientStructs.FFXIV.Client.System.String;
+
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
+public enum ItemDetailKind : byte {
+    ChatItem = 1,      // all items linked in chat, except event items
+    InventoryItem = 2, // all(?) items outside of chat, including event items
+    ChatEventItem = 8  // event items linked in chat
+}
 
 // Client::UI::Agent::AgentItemDetail
 //   Client::UI::Agent::AgentInterface
@@ -8,5 +16,25 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 [Inherits<AgentInterface>]
 [StructLayout(LayoutKind.Explicit, Size = 0x1B8)]
 public unsafe partial struct AgentItemDetail {
+    [FieldOffset(0x118)] public ItemDetailKind ItemKind;
+    // Set to the item ID when hovering an item in the chat, otherwise it seems
+    // to be different for each inventory. Doesn't appear to have any relation
+    // to InventoryType.
+    // -  4: EquippedItems
+    // -  7: KeyItems
+    // - 48: Inventory1
+    // - 49: Inventory2
+    // - 50: Inventory3
+    // - 51: Inventory4
+    // - 69: SaddleBag1
+    // - 70: SaddleBag2
+    // - 71: PremiumSaddleBag1
+    // - 72: PremiumSaddleBag2
+    [FieldOffset(0x11C)] public uint TypeOrId;
+    [FieldOffset(0x120)] public uint Index; // The index of the item in the inventory. 0 for chat, ??? for KeyItems.
+    [FieldOffset(0x128)] public byte Flag1; // Related to checking the inventory
     [FieldOffset(0x138)] public uint ItemId;
+    [FieldOffset(0x148)] public Utf8String String1;
+    [FieldOffset(0x1B2)] public byte Flag2; // This needs to be set to 1 for the item detail tooltip to show
+    [FieldOffset(0x1B6)] public byte Flag3; // If set to zero, avoids an early return in addon->Show()
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTooltipManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTooltipManager.cs
@@ -37,6 +37,7 @@ public unsafe partial struct AtkTooltipManager {
 
     [FieldOffset(0x8)] public StdMap<Pointer<AtkResNode>, Pointer<AtkTooltipInfo>> TooltipMap;
     [FieldOffset(0x18)] public AtkStage* AtkStage;
+    [FieldOffset(0x14C)] public byte Flag1; // Allows AddonItemDetail to be shown with Flag1 |= 2.
 
     [MemberFunction("E8 ?? ?? ?? ?? 44 85 F6")]
     public partial void AttachTooltip(AtkTooltipType type, ushort parentId, AtkResNode* targetNode, AtkTooltipArgs* tooltipArgs);


### PR DESCRIPTION
Adds some missing fields to `AgentItemDetail` and `AtkTooltipManager` used by ChatTwo. All of these are used in the plugin except a new unknown `Utf8String` field which I added for posterity.

Thanks to @Infiziert90 for helping with these