### PR TITLE
Preliminary Update AgentCraftActionSimulator for 7.0

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCraftActionSimulator.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCraftActionSimulator.cs
@@ -12,69 +12,69 @@ public unsafe partial struct AgentCraftActionSimulator {
     [FieldOffset(0x40)] public QualityEfficiencyCalculations* Quality; // Quality tab of the Efficiency Calculations window.
 }
 
-[StructLayout(LayoutKind.Explicit, Size = 0x0108)]
+[StructLayout(LayoutKind.Explicit, Size = 0x00e0)]
 public struct ProgressEfficiencyCalculations {
     [FieldOffset(0x00)] public ProgressEfficiencyCalculation BasicSynthesis;
-    [FieldOffset(0x18)] public ProgressEfficiencyCalculation RapidSynthesis;
-    [FieldOffset(0x30)] public ProgressEfficiencyCalculation MuscleMemory;
-    [FieldOffset(0x48)] public ProgressEfficiencyCalculation CarefulSynthesis;
-    [FieldOffset(0x60)] public ProgressEfficiencyCalculation FocusedSynthesis;
-    [FieldOffset(0x78)] public ProgressEfficiencyCalculation Groundwork;
-    [FieldOffset(0x90)] public ProgressEfficiencyCalculation DelicateSynthesis;
+    [FieldOffset(0x1C)] public ProgressEfficiencyCalculation RapidSynthesis;
+    [FieldOffset(0x38)] public ProgressEfficiencyCalculation MuscleMemory;
+    [FieldOffset(0x54)] public ProgressEfficiencyCalculation CarefulSynthesis;
+    [FieldOffset(0x70)] public ProgressEfficiencyCalculation Groundwork;
+    [FieldOffset(0x8C)] public ProgressEfficiencyCalculation DelicateSynthesis;
     [FieldOffset(0xA8)] public ProgressEfficiencyCalculation IntensiveSynthesis;
-    [FieldOffset(0xC0)] public ProgressEfficiencyCalculation PrudentSynthesis;
+    [FieldOffset(0xC4)] public ProgressEfficiencyCalculation PrudentSynthesis;
 }
 
-[StructLayout(LayoutKind.Explicit, Size = 0x0138)]
+[StructLayout(LayoutKind.Explicit, Size = 0x01a4)]
 public struct QualityEfficiencyCalculations {
     [FieldOffset(0x000)] public QualityEfficiencyCalculation BasicTouch;
-    [FieldOffset(0x018)] public QualityEfficiencyCalculation HastyTouch;
-    [FieldOffset(0x030)] public QualityEfficiencyCalculation StandardTouch;
-    [FieldOffset(0x048)] public QualityEfficiencyCalculation ByregotsBlessing;
-    [FieldOffset(0x060)] public QualityEfficiencyCalculation PreciseTouch;
-    [FieldOffset(0x078)] public QualityEfficiencyCalculation PrudentTouch;
-    [FieldOffset(0x090)] public QualityEfficiencyCalculation FocusedTouch;
-    [FieldOffset(0x0A8)] public QualityEfficiencyCalculation Reflect;
-    [FieldOffset(0x0C0)] public QualityEfficiencyCalculation PreparatoryTouch;
-    [FieldOffset(0x0D8)] public QualityEfficiencyCalculation DelicateSynthesis;
-    [FieldOffset(0x0F0)] public QualityEfficiencyCalculation TrainedEye;
-    [FieldOffset(0x108)] public QualityEfficiencyCalculation AdvancedTouch;
-    [FieldOffset(0x120)] public QualityEfficiencyCalculation TrainedFinesse;
+    [FieldOffset(0x01C)] public QualityEfficiencyCalculation HastyTouch;
+    [FieldOffset(0x038)] public QualityEfficiencyCalculation StandardTouch;
+    [FieldOffset(0x054)] public QualityEfficiencyCalculation ByregotsBlessing;
+    [FieldOffset(0x070)] public QualityEfficiencyCalculation PreciseTouch;
+    [FieldOffset(0x08C)] public QualityEfficiencyCalculation PrudentTouch;
+    [FieldOffset(0x0A8)] public QualityEfficiencyCalculation AdvancedTouch;
+    [FieldOffset(0x0C4)] public QualityEfficiencyCalculation Reflect;
+    [FieldOffset(0x0E0)] public QualityEfficiencyCalculation PreparatoryTouch;
+    [FieldOffset(0x0FC)] public QualityEfficiencyCalculation DelicateSynthesis;
+    [FieldOffset(0x118)] public QualityEfficiencyCalculation TrainedEye;
+    [FieldOffset(0x150)] public QualityEfficiencyCalculation TrainedFinesse;
+    // [FieldOffset(0x16C)] public QualityEfficiencyCalculation RefinedTouch;
+    // [FieldOffset(0x188)] public QualityEfficiencyCalculation DaringTouch;
 }
 
 // It looks like all efficiency calculations are represented by the same struct,
 // but they each only use certain fields, so I broke it into 2 distinct structs.
 // Left this here as a template.
-[StructLayout(LayoutKind.Explicit, Size = 0x0018)]
+[StructLayout(LayoutKind.Explicit, Size = 0x001C)]
 public struct EfficiencyCalculation {
-    [FieldOffset(0x00)] public uint ActionId;
+    [FieldOffset(0x04)] public uint ActionId;
 
-    [FieldOffset(0x04)] public uint ProgressEfficiency;
-    [FieldOffset(0x08)] public uint ProgressIncrease;
+    [FieldOffset(0x08)] public uint ProgressEfficiency;
+    [FieldOffset(0x0C)] public uint ProgressIncrease;
 
-    [FieldOffset(0x0C)] public uint QualityEfficiencyPercentage;
-    [FieldOffset(0x10)] public uint QualityIncrease;
+    [FieldOffset(0x10)] public uint QualityEfficiencyPercentage;
+    [FieldOffset(0x14)] public uint QualityIncrease;
 
     //[FieldOffset(0x14)] public byte ;
     //[FieldOffset(0x15)] public byte ;
-    [FieldOffset(0x16)] public ActionStatus Status;
+    [FieldOffset(0x1A)] public ActionStatus Status;
     //[FieldOffset(0x17)] public byte ;
 }
 
-[StructLayout(LayoutKind.Explicit, Size = 0x0018)]
+[StructLayout(LayoutKind.Explicit, Size = 0x001C)]
 public struct ProgressEfficiencyCalculation {
-    [FieldOffset(0x00)] public uint ActionId;
-    [FieldOffset(0x04)] public uint ProgressEfficiency;
-    [FieldOffset(0x08)] public uint ProgressIncrease;
-    [FieldOffset(0x16)] public ActionStatus Status;
+    [FieldOffset(0x04)] public uint ActionId;
+    [FieldOffset(0x08)] public uint ProgressEfficiency;
+    [FieldOffset(0x0C)] public uint ProgressIncrease;
+    [FieldOffset(0x1A)] public ActionStatus Status;
 }
 
-[StructLayout(LayoutKind.Explicit, Size = 0x0018)]
+[StructLayout(LayoutKind.Explicit, Size = 0x001C)]
 public struct QualityEfficiencyCalculation {
-    [FieldOffset(0x00)] public uint ActionId;
-    [FieldOffset(0x0C)] public uint QualityEfficiencyPercentage;
-    [FieldOffset(0x10)] public uint QualityIncrease;
-    [FieldOffset(0x16)] public ActionStatus Status;
+    [FieldOffset(0x04)] public uint ActionId;
+    [FieldOffset(0x10)] public uint QualityEfficiencyPercentage;
+    [FieldOffset(0x14)] public uint QualityIncrease;
+    [FieldOffset(0x1A)] public ActionStatus Status;
 }
 
 public enum ActionStatus : byte {


### PR DESCRIPTION
Found these new offsets through extensive memory poking. I haven't hit high enough level to confirm the presence of the `RefinedTouch` and `DaringTouch` fields, they *seem* like they are there, but just have zeroed memory until you actually unlock the skills.

Will send a follow-up PR when I'm higher level with any changes I can prove later. The rest of the fields I can confirm contain the expected information at the new offsets.