### PR TITLE
Update Client::Game::UI::MobHunt

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/MobHunt.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/MobHunt.cs
@@ -71,7 +71,7 @@ public unsafe partial struct MobHunt {
         => (ObtainedFlags & 1 << index) != 0;
 
     [GenerateInterop]
-    [StructLayout(LayoutKind.Explicit, Size = MaxMarkIndex)]
+    [StructLayout(LayoutKind.Explicit, Size = 0x14)]
     public partial struct KillCounts {
         [FieldOffset(0x00), FixedSizeArray] internal FixedSizeArray5<int> _counts;
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/MobHunt.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/MobHunt.cs
@@ -24,28 +24,34 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 /// 15 - Endwalker Level 2<br/>
 /// 16 - Endwalker Level 3<br/>
 /// 17 - Endwalker Elite
+/// 18 - Dawntrail Level 1<br/>
+/// 19 - Dawntrail Level 2<br/>
+/// 20 - Dawntrail Level 3<br/>
+/// 21 - Dawntrail Elite
 /// </remarks>
 // Client::Game::UI::MobHunt
 [GenerateInterop]
-[StructLayout(LayoutKind.Explicit, Size = 0x198)]
+[StructLayout(LayoutKind.Explicit, Size = 0x1F0)]
 public unsafe partial struct MobHunt {
+    public const int MaxMarkIndex = 22;
+
     [StaticAddress("48 8D 0D ?? ?? ?? ?? 0F B6 50 08 E8 ?? ?? ?? ?? 84 C0 48 8B 47 28", 3)]
     public static partial MobHunt* Instance();
 
-    [FieldOffset(0x08), FixedSizeArray] internal FixedSizeArray18<byte> _availableMarkId;
-    [FieldOffset(0x1A), FixedSizeArray] internal FixedSizeArray18<byte> _obtainedMarkId;
+    [FieldOffset(0x08), FixedSizeArray] internal FixedSizeArray22<byte> _availableMarkId;
+    [FieldOffset(0x1E), FixedSizeArray] internal FixedSizeArray22<byte> _obtainedMarkId;
 
-    [FieldOffset(0x2C), FixedSizeArray] internal FixedSizeArray18<KillCounts> _currentKills;
+    [FieldOffset(0x34), FixedSizeArray] internal FixedSizeArray22<KillCounts> _currentKills;
 
-    [FieldOffset(0x194)] public int ObtainedFlags;
+    [FieldOffset(0x1EC)] public int ObtainedFlags;
 
-    /// <param name="markIndex">Mark Bill Index 0-18</param>
+    /// <param name="markIndex">Mark Bill Index 0-22</param>
     /// <param name="mobIndex">Mob Index 0-4</param>
     /// <returns>Current kill count</returns>
     [MemberFunction("80 FA 16 73 19")]
     public partial int GetKillCount(byte markIndex, byte mobIndex);
 
-    /// <param name="markIndex">Mark Bill Index 0-18</param>
+    /// <param name="markIndex">Mark Bill Index 0-22</param>
     /// <returns>MobHuntOrder Primary Row Id</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 89 44 24 38 45 8B FE")]
     public partial int GetObtainedHuntOrderRowId(byte markIndex);
@@ -54,7 +60,7 @@ public unsafe partial struct MobHunt {
     public partial int GetAvailableHuntOrderRowId(byte markIndex);
 
     /// <param name="itemId">Mark Bill ItemId</param>
-    /// <returns>18 Indicates Not Found</returns>
+    /// <returns>MaxMarkIndex Value Indicates Not Found</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 0F B6 D0 48 8D 0D ?? ?? ?? ?? 44 0F B6 E0")]
     public partial int GetMarkIndexFromItemId(uint itemId);
 
@@ -65,7 +71,7 @@ public unsafe partial struct MobHunt {
         => (ObtainedFlags & 1 << index) != 0;
 
     [GenerateInterop]
-    [StructLayout(LayoutKind.Explicit, Size = 0x14)]
+    [StructLayout(LayoutKind.Explicit, Size = MaxMarkIndex)]
     public partial struct KillCounts {
         [FieldOffset(0x00), FixedSizeArray] internal FixedSizeArray5<int> _counts;
 

--- a/ida/ffxiv_structs.yml
+++ b/ida/ffxiv_structs.yml
@@ -22694,7 +22694,7 @@ structs:
   name: KillCounts
   namespace: Client.Game.UI
   union: False
-  size: 20
+  size: 22
   fields:
   - type: int
     name: Counts
@@ -44078,23 +44078,23 @@ structs:
   name: MobHunt
   namespace: Client.Game.UI
   union: False
-  size: 408
+  size: 496
   fields:
   - type: byte
     name: AvailableMarkId
     offset: 8
-    size: 18
+    size: 22
   - type: byte
     name: ObtainedMarkId
-    offset: 26
-    size: 18
+    offset: 30
+    size: 22
   - type: Client::Game::UI::MobHunt::KillCounts
     name: CurrentKills
-    offset: 44
-    size: 18
+    offset: 52
+    size: 22
   - type: int
     name: ObtainedFlags
-    offset: 404
+    offset: 492
   virtual_functions: []
   member_functions:
   - signature: 80 FA 16 73 19


### PR DESCRIPTION
Fixes the offset and array sizes for the 4 new Dawntrail MobHunt order types.
Adds a constant MaxMarkIndex that can be used to refer to 1 past the last MobHuntOrderType index, which is returned by `GetMarkIndexFromItemId(uint)` or to iterate over all the order types.