### PR TITLE
Fix radius type of MapMarkerData.SetData

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -62,7 +62,7 @@ public unsafe partial struct MapMarkerData {
         float x,
         float y,
         float z,
-        uint radius,
+        float radius,
         ushort territoryTypeId,
         uint mapId,
         uint placeNameZoneId,


### PR DESCRIPTION
Can someone confirm this is right?
Now hex-rays shows `*(_QWORD *)&this->Radius = LODWORD(radius);` 🤔