### PR TITLE
Update RenderManager/ModelRenderer offsets and sizes for 7.0

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Render/Manager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Render/Manager.cs
@@ -4,15 +4,16 @@ namespace FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 //   Client::Graphics::Singleton<Client::Graphics::Render::Manager>
 // ctor "48 89 01 48 8D 59 08"
 [GenerateInterop]
-[StructLayout(LayoutKind.Explicit, Size = 0x2D750)]
+[StructLayout(LayoutKind.Explicit, Size = 0x51F10)]
 public unsafe partial struct Manager {
     [StaticAddress("48 8B 05 ?? ?? ?? ?? 48 8D 4D 80", 3, true)]
     public static partial Manager* Instance();
 
     [FieldOffset(0x8), FixedSizeArray] internal FixedSizeArray32<View> _views;
 
-    [FieldOffset(0x13660)] public ModelRenderer ModelRenderer;
+    [FieldOffset(0x22990)] public ModelRenderer ModelRenderer;
 
+    // TODO check and update for 7.0
     public enum RenderViews : uint {
         OmniShadow0 = 0,
         OmniShadow1,

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Render/ModelRenderer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Render/ModelRenderer.cs
@@ -6,7 +6,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 // Client::Graphics::Render::ModelRenderer
 //   Client::Graphics::Render::BaseRenderer
 [GenerateInterop]
-[StructLayout(LayoutKind.Explicit, Size = 0x228)]
+[StructLayout(LayoutKind.Explicit, Size = 0x380)]
 public unsafe partial struct ModelRenderer {
     [StructLayout(LayoutKind.Explicit, Size = 0x20)]
     public partial struct Callback {
@@ -27,36 +27,86 @@ public unsafe partial struct ModelRenderer {
         [FieldOffset(0x10)] public ushort* OutFlags;
     }
 
+    /// <summary> Indices of <see cref="ConstantSamplerIds"/> for well-known constant buffers. </summary>
+    public enum WellKnownConstant {
+        /// <summary> The g_LightDirection constant buffer (CRC: 0xEF4E7491). </summary>
+        LightDirection = 0,
+        /// <summary> The g_WorldViewMatrix constant buffer (CRC: 0x76BB3DC0). </summary>
+        WorldViewMatrix = 1,
+        /// <summary> The g_JointMatrixArray constant buffer (CRC: 0x88AA546A). </summary>
+        JointMatrixArray = 2,
+        /// <summary> The g_JointMatrixArrayPrev constant buffer (CRC: 0xB531360D). </summary>
+        JointMatrixArrayPrev = 3,
+        /// <summary> The g_WrinklessWeightRate constant buffer (CRC: 0x17FB799E). </summary>
+        WrinklessWeightRate = 5,
+        /// <summary> The g_AuraParam constant buffer (CRC: 0x07EF6FA3). </summary>
+        AuraParam = 6,
+        /// <summary> The g_InstancingMatrix constant buffer (CRC: 0x8413183B). </summary>
+        InstancingMatrix = 11,
+        /// <summary> The g_PrevInstancingMatrix constant buffer (CRC: 0xC38E361C). </summary>
+        PrevInstancingMatrix = 12,
+        /// <summary> The g_SelectionModelParameter constant buffer (CRC: 0x04543FA3). </summary>
+        SelectionModelParameter = 13,
+    }
+
+    /// <summary> Indices of <see cref="ConstantSamplerIds"/> for well-known samplers/textures. </summary>
+    public enum WellKnownSampler {
+        /// <summary> The g_SamplerFinalColor sampler/texture (CRC: 0x8EA9DF48). </summary>
+        SamplerFinalColor = 4,
+        /// <summary> The g_CompositeCommonSampler sampler (CRC: 0x7FE24A4B). </summary>
+        CompositeCommonSampler = 7,
+        /// <summary> The g_SamplerAuraTexture texture (CRC: 0x07A92F70). </summary>
+        SamplerAuraTexture = 8,
+        /// <summary> The g_SamplerAuraTexture1 texture (CRC: 0x01DCD829). </summary>
+        SamplerAuraTexture1 = 9,
+        /// <summary> The g_SamplerAuraTexture2 texture (CRC: 0x98D58993). </summary>
+        SamplerAuraTexture2 = 10,
+        /// <summary> The g_SamplerNormal sampler/texture (CRC: 0x0C5EC1F1). </summary>
+        SamplerNormal = 14,
+        /// <summary> The g_SamplerIndex sampler/texture (CRC: 0x565F8FD8). </summary>
+        SamplerIndex = 15,
+        /// <summary> The g_SamplerViewPosition sampler/texture (CRC: 0xBC615663). </summary>
+        SamplerViewPosition = 16,
+        /// <summary> The g_SamplerDepthWithWater sampler/texture (CRC: 0xE4B2A798). </summary>
+        SamplerDepthWithWater = 17,
+    }
+
     /// <summary> <see cref="ShaderPackage.ConstantSamplerUnknown.Id"/> of the g_LightDirection constant buffer (CRC: 0xEF4E7491). </summary>
-    [FieldOffset(0x8)] public uint LightDirectionId;
+    [FieldOffset(0x8), Obsolete("Use ConstantSamplerIds[(int)WellKnownConstant.LightDirection]")] public uint LightDirectionId;
     /// <summary> <see cref="ShaderPackage.ConstantSamplerUnknown.Id"/> of the g_WorldViewMatrix constant buffer (CRC: 0x76BB3DC0). </summary>
-    [FieldOffset(0xC)] public uint WorldViewMatrixId;
+    [FieldOffset(0xC), Obsolete("Use ConstantSamplerIds[(int)WellKnownConstant.WorldViewMatrix]")] public uint WorldViewMatrixId;
     /// <summary> <see cref="ShaderPackage.ConstantSamplerUnknown.Id"/> of the g_JointMatrixArray constant buffer (CRC: 0x88AA546A). </summary>
-    [FieldOffset(0x10)] public uint JointMatrixArrayId;
+    [FieldOffset(0x10), Obsolete("Use ConstantSamplerIds[(int)WellKnownConstant.JointMatrixArray]")] public uint JointMatrixArrayId;
     /// <summary> <see cref="ShaderPackage.ConstantSamplerUnknown.Id"/> of the g_SelectionModelParameter constant buffer (CRC: 0x04543FA3). </summary>
-    [FieldOffset(0x14)] public uint SelectionModelParameterId;
+    [FieldOffset(0x3C), Obsolete("Use ConstantSamplerIds[(int)WellKnownConstant.SelectionModelParameter]")] public uint SelectionModelParameterId;
 
     /// <summary> <see cref="ShaderPackage.ConstantSamplerUnknown.Id"/> of the g_SamplerNormal sampler/texture (CRC: 0x0C5EC1F1). </summary>
-    [FieldOffset(0x18)] public uint SamplerNormalId;
+    [FieldOffset(0x40), Obsolete("Use ConstantSamplerIds[(int)WellKnownSampler.SamplerNormal]")] public uint SamplerNormalId;
     /// <summary> <see cref="ShaderPackage.ConstantSamplerUnknown.Id"/> of the g_SamplerIndex sampler/texture (CRC: 0x565F8FD8). </summary>
-    [FieldOffset(0x1C)] public uint SamplerIndexId;
+    [FieldOffset(0x44), Obsolete("Use ConstantSamplerIds[(int)WellKnownSampler.SamplerIndex]")] public uint SamplerIndexId;
     /// <summary> <see cref="ShaderPackage.ConstantSamplerUnknown.Id"/> of the g_SamplerViewPosition sampler/texture (CRC: 0xBC615663). </summary>
-    [FieldOffset(0x20)] public uint SamplerViewPositionId;
+    [FieldOffset(0x48), Obsolete("Use ConstantSamplerIds[(int)WellKnownSampler.SamplerViewPosition]")] public uint SamplerViewPositionId;
 
-    [FieldOffset(0x28), FixedSizeArray] internal FixedSizeArray6<ShaderSceneKey> _sceneKeys;
+    [FieldOffset(0x8), FixedSizeArray] internal FixedSizeArray18<uint> _constantSamplerIds;
 
-    [FieldOffset(0x88), FixedSizeArray] internal FixedSizeArray3<ShaderSubViewKey> _subViewKeys;
+    [FieldOffset(0x50), FixedSizeArray] internal FixedSizeArray18<ShaderSceneKey> _sceneKeys;
 
-    [FieldOffset(0xB8)] public ShaderCodeResourceHandle* CharacterSelectionModelVS;
-    [FieldOffset(0xC0)] public ShaderCodeResourceHandle* CharacterSelectionModelPS;
-    [FieldOffset(0xC8)] public TextureResourceHandle* DitherTexture;
-    [FieldOffset(0xD0)] public ShaderPackageResourceHandle* CharacterGlassShaderPackage;
-    [FieldOffset(0xD8)] public ShaderCodeResourceHandle* CharacterMultiViewportGS;
+    [FieldOffset(0x170), FixedSizeArray] internal FixedSizeArray5<ShaderSubViewKey> _subViewKeys;
 
-    // At 0xE0: pointer to an unknown ConstantBuffer of size 1 vector (0x10 bytes).
-    // At 0xE8, ..., 0x160: pointers to 16 unknown ConstantBuffers of size 4 vectors (0x40 bytes) each.
+    [FieldOffset(0x1C0)] public ShaderCodeResourceHandle* CharacterSelectionModelVS;
+    [FieldOffset(0x1C8)] public ShaderCodeResourceHandle* CharacterSelectionModelPS;
+    [FieldOffset(0x1D0)] public TextureResourceHandle* DitherTexture;
+    [FieldOffset(0x1D8)] public ShaderPackageResourceHandle* IrisShaderPackage;
+    [FieldOffset(0x1E0)] public ShaderPackageResourceHandle* CharacterGlassShaderPackage;
+    [FieldOffset(0x1E8)] public ShaderPackageResourceHandle* CharacterTransparencyShaderPackage;
+    [FieldOffset(0x1F0)] public ShaderPackageResourceHandle* CharacterTattooShaderPackage;
+    [FieldOffset(0x1F8)] public ShaderPackageResourceHandle* CharacterOcclusionShaderPackage;
+    [FieldOffset(0x200)] public ShaderPackageResourceHandle* HairMaskShaderPackage;
 
-    [FieldOffset(0x168)] public JobSystem JobSystem; // Client::Graphics::JobSystem<Client::Graphics::Render::ModelRenderer>
+    // At 0x238: pointer to an unknown ConstantBuffer of size 1 vector (0x10 bytes).
+    // At 0x240, ..., 0x2B8: pointers to 16 unknown ConstantBuffers of size 4 vectors (0x40 bytes) each.
+
+    [FieldOffset(0x2C0)] public JobSystem JobSystem; // Client::Graphics::JobSystem<Client::Graphics::Render::ModelRenderer>
 
     // This function, among other things, constructs an OnRenderMaterialParams struct with its params and calls CharacterBase.OnRenderMaterial with it (through some indirections - see Model.RenderMaterialCallback).
     [MemberFunction("E8 ?? ?? ?? ?? 44 0F B7 20")]

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Render/SubView.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Render/SubView.cs
@@ -4,8 +4,9 @@ using FFXIVClientStructs.FFXIV.Common.Math;
 namespace FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 
 // Client::Graphics::Render::SubView
-[StructLayout(LayoutKind.Explicit, Size = 0x58)]
+[StructLayout(LayoutKind.Explicit, Size = 0x60)]
 public unsafe struct SubView {
+    // TODO check and update for 7.0
     [FieldOffset(0x8)] public uint Flags;
     [FieldOffset(0x10)] public Rectangle ViewportRegion;
     [FieldOffset(0x20)] public void* Camera; // Client::Graphics::Render::Camera
@@ -14,5 +15,5 @@ public unsafe struct SubView {
     [FieldOffset(0x38)] public Texture* RenderTarget_3;
     [FieldOffset(0x40)] public Texture* RenderTarget_4;
     [FieldOffset(0x48)] public uint RenderTargetUsedCount;
-    [FieldOffset(0x50)] public Texture* DepthStencil;
+    [FieldOffset(0x58)] public Texture* DepthStencil;
 }

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Render/View.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Render/View.cs
@@ -4,7 +4,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 
 // Client::Graphics::Render::View
 [GenerateInterop]
-[StructLayout(LayoutKind.Explicit, Size = 0x5A0)]
+[StructLayout(LayoutKind.Explicit, Size = 0x620)]
 public unsafe partial struct View {
     [FieldOffset(0x8)] public uint Flags;
     [FieldOffset(0x10)] public Rectangle CanvasRegion;


### PR DESCRIPTION
I fixed an offset that was obviously wrong in SubView, but as I don't use this struct, I cannot know for sure whether it is now entirely correct.