### PR TITLE
Update the ContentsFinderQueueInfo ConditionId data types

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/ContentsFinder.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/ContentsFinder.cs
@@ -26,11 +26,11 @@ public unsafe partial struct ContentsFinder {
 
 [StructLayout(LayoutKind.Explicit, Size = 0x90)]
 public struct ContentsFinderQueueInfo {
-    [FieldOffset(0x04)] public byte QueuedContentFinderConditionId1;
-    [FieldOffset(0x0C)] public byte QueuedContentFinderConditionId2;
-    [FieldOffset(0x14)] public byte QueuedContentFinderConditionId3;
-    [FieldOffset(0x1C)] public byte QueuedContentFinderConditionId4;
-    [FieldOffset(0x24)] public byte QueuedContentFinderConditionId5;
+    [FieldOffset(0x04)] public uint QueuedContentFinderConditionId1;
+    [FieldOffset(0x0C)] public uint QueuedContentFinderConditionId2;
+    [FieldOffset(0x14)] public uint QueuedContentFinderConditionId3;
+    [FieldOffset(0x1C)] public uint QueuedContentFinderConditionId4;
+    [FieldOffset(0x24)] public uint QueuedContentFinderConditionId5;
 
     [FieldOffset(0x28)] public uint QueuedClassJobId;
 


### PR DESCRIPTION
Updates the data type of the following properties of the `ContentsFinderQueueInfo ` struct to be `uint` rather than `byte`:

- `QueuedContentFinderConditionId1`
- `QueuedContentFinderConditionId2`
- `QueuedContentFinderConditionId3`
- `QueuedContentFinderConditionId4`
- `QueuedContentFinderConditionId5`