### PR TITLE
fix AtkUnitBase.GetComponentByNodeId

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -169,7 +169,14 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     public partial AtkComponentList* GetComponentListById(uint nodeId);
 
     [MemberFunction("E8 ?? ?? ?? ?? 8D 55 9F")]
-    public partial AtkComponentNode* GetComponentNodeById(uint nodeId);
+    public partial AtkComponentBase* GetComponentByNodeId(uint nodeId);
+
+    public AtkComponentNode* GetComponentNodeById(uint nodeId) {
+        // Added to avoid API breaking
+        var component = GetComponentByNodeId(nodeId);
+        if (component == null) return null;
+        return component->OwnerNode;
+    }
 
     [MemberFunction("E9 ?? ?? ?? ?? 83 C3 F9")]
     public partial byte FireCallbackInt(int callbackValue);

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5964,7 +5964,7 @@ classes:
       0x140652930: UnsubscribeAtkArrayData
       0x140652B40: SetFocusNode
       0x140653220: GetNodeById
-      0x140653340: GetComponentNodeById
+      0x140653340: GetComponentByNodeId
       0x1406533D0: GetButtonNodeById
       0x140653710: GetComponentListById
       0x140653990: GetTextNodeById


### PR DESCRIPTION
`AtkUnitBase.GetComponentNodeById` currently returns an incorrectly cast `AtkComponentBase`

I've renamed the original to `GetComponentByNodeId` based on what it actually does, and added a temporary function to avoid breaking the API