### PR TITLE
Add AtkClippingMaskNode

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkClippingMaskNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkClippingMaskNode.cs
@@ -1,0 +1,23 @@
+using FFXIVClientStructs.FFXIV.Client.System.Memory;
+
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
+
+// Component::GUI::AtkClippingMaskNode
+//   Component::GUI::AtkResNode
+//     Component::GUI::AtkEventTarget
+// common CreateAtkNode function "E8 ?? ?? ?? ?? 49 8B 55 08 48 89 04 13"
+// type 10
+[GenerateInterop]
+[Inherits<AtkResNode>]
+[StructLayout(LayoutKind.Explicit, Size = 0xC0)]
+[VirtualTable("E8 ?? ?? ?? ?? 49 8B 55 08 48 89 04 13", [1, 396])]
+public unsafe partial struct AtkClippingMaskNode : ICreatable {
+    [FieldOffset(0xB0)] public AtkUldPartsList* PartsList;
+    [FieldOffset(0xB8)] public ushort PartId;
+
+    // 7.0 inlines this ctor
+    public void Ctor() {
+        AtkResNode.Ctor();
+        VirtualTable = StaticVirtualTablePointer;
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkResNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkResNode.cs
@@ -249,7 +249,7 @@ public enum NodeType : ushort {
     Counter = 5,
 
     Collision = 8,
-    UnknownNode10 = 10 // new 6.5
+    ClippingMask = 10
     // Component: >=1000
 }
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5893,6 +5893,10 @@ classes:
     funcs:
 #     0x1405A02A0: ctor # INLINED IN 7.0 in CreateResNode
       0x14063E610: CheckCollisionAtCoords
+  Component::GUI::AtkClippingMaskNode:
+    vtbls:
+      - ea: 0x141EF5EC0
+        base: Component::GUI::AtkResNode
   Component::GUI::AtkComponentNode:
     vtbls:
       - ea: 0x141EF5ED8


### PR DESCRIPTION
This is essentially an image node with a monochrome texture loaded, which serves as a mask for other nodes in the draw list.

Every example I've found of this type has been located within an `AtkComponentNode`, rather than being in the Addon's main node list. The mask is seemingly applied to the `NextSiblingNode` and to all subsequent siblings within the Component. It is not applied to previous sibling nodes, or to nodes outside the Component.