### PR TITLE
Update AgentHUD (_Exp fields)

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHUD.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHUD.cs
@@ -34,6 +34,19 @@ public unsafe partial struct AgentHUD {
     [FieldOffset(0x1400), FixedSizeArray] internal FixedSizeArray10<HudPartyMemberEnmity> _hudPartyMemberEnmity;
     [FieldOffset(0x1478), FixedSizeArray] internal FixedSizeArray10<Pointer<HudPartyMemberEnmity>> _hudPartyMemberEnmityPtrs;
 
+    [FieldOffset(0x3500)] public uint ExpCurrentExperience;
+    [FieldOffset(0x3504)] public uint ExpNeededExperience;
+    [FieldOffset(0x3508)] public uint ExpRestedExperience;
+    [FieldOffset(0x350C)] public uint ExpClassJobId;
+
+    [FieldOffset(0x351C)] public uint ExpClassJobId2; // probably for a different use case
+    [FieldOffset(0x3520)] public ushort ExpLevel;
+    [FieldOffset(0x3522)] public ushort ExpContentLevel; // level in eureka and bozja for example
+    [FieldOffset(0x3524)] public bool ExpIsLevelSynced;
+    [FieldOffset(0x3525)] public bool ExpUnkBool2;
+    [FieldOffset(0x3526)] public bool ExpIsMaxLevel;
+    [FieldOffset(0x3527)] public bool ExpIsInEureka;
+
     [FieldOffset(0x3530), FixedSizeArray] internal FixedSizeArray16<HudQueuedBattleTalk> _queuedBattleTalks;
 
     [FieldOffset(0x4A10)] public StdVector<MapMarkerData> MapMarkers;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHUD.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHUD.cs
@@ -37,9 +37,9 @@ public unsafe partial struct AgentHUD {
     [FieldOffset(0x3500)] public uint ExpCurrentExperience;
     [FieldOffset(0x3504)] public uint ExpNeededExperience;
     [FieldOffset(0x3508)] public uint ExpRestedExperience;
-    [FieldOffset(0x350C)] public uint ExpClassJobId;
+    [FieldOffset(0x350C)] public uint CharacterClassJobId;
 
-    [FieldOffset(0x351C)] public uint ExpClassJobId2; // probably for a different use case
+    [FieldOffset(0x351C)] public uint ExpClassJobId;
     [FieldOffset(0x3520)] public ushort ExpLevel;
     [FieldOffset(0x3522)] public ushort ExpContentLevel; // level in eureka and bozja for example
     [FieldOffset(0x3524)] public bool ExpIsLevelSynced;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -138,6 +138,7 @@ functions:
   0x1400B7420: IsBoundByDuty56
   0x1400B75A0: IsDutyRecorderPlayback
   0x1400B7600: IsInDeepDungeon
+  0x1400B7650: IsInEureka
   0x1400B7860: IsUnconscious
   0x1400B7870: IsRolePlaying
   0x1400B79F0: IsClassJobACrafter   # static, (classJobId) -> bool
@@ -8352,9 +8353,16 @@ classes:
       0x140E11580: Finalize
       0x140E13690: IsMainCommandEnabled
       0x140E136C0: SetMainCommandEnabledState
+      0x140E18680: UpdateCharacter
       0x140E18C70: UpdateParty
       0x140E1A770: UpdateDTR
+      0x140E1B8D0: UpdateContentGauge
+      0x140E1BBF0: UpdateMainCommands
+      0x140E1BE90: UpdateNaviMap
+      0x140E1CEE0: UpdateEnemyList
       0x140E1D720: UpdateHotBar
+      0x140E1E6D0: UpdateExp
+      0x140E30B60: UpdateBattleTalk
       0x140E2C530: OpenContextMenuFromTarget # inlined @ 0x140E0F2B0
       0x140E2FD70: GetMainCommandString  # MainCommand exd
       0x140E300B0: OpenSystemMenu


### PR DESCRIPTION
These fields are used as a cache for the UpdateExp function, so it updates the (Number|String)Arrays only when needed.