### PR TITLE
Update RaptureGearsetModule/AgentBannerEditor

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerEditor.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerEditor.cs
@@ -13,8 +13,11 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 public unsafe partial struct AgentBannerEditor {
     [FieldOffset(0x28)] public AgentBannerEditorState* EditorState;
 
+    /// <param name="enabledGearsetIndex">
+    /// The index of the gearset in a filtered <see cref="RaptureGearsetModule.Entries"/> list of only enabled gearsets.
+    /// </param>
     [MemberFunction("48 89 5C 24 ?? 57 48 83 EC 30 48 83 3D ?? ?? ?? ?? ?? 8B FA 48 8B D9 0F 84")]
-    public partial void OpenForGearset(int gearsetId);
+    public partial void OpenForGearset(int enabledGearsetIndex);
 }
 
 [GenerateInterop]
@@ -77,15 +80,18 @@ public unsafe partial struct AgentBannerEditorState {
 
     [FieldOffset(0x230)] public BannerModuleEntry BannerEntry;
 
+    // presumably a struct of size 0x64
     [FieldOffset(0x350), FixedSizeArray] internal FixedSizeArray14<uint> _itemIds;
     [FieldOffset(0x388), FixedSizeArray] internal FixedSizeArray14<byte> _stain0Ids;
     [FieldOffset(0x396), FixedSizeArray] internal FixedSizeArray14<byte> _stain1Ids;
-
+    [FieldOffset(0x3A4), FixedSizeArray] internal FixedSizeArray2<ushort> _glassesIds;
     [FieldOffset(0x3A8)] public uint Checksum;
     [FieldOffset(0x3AC)] public BannerGearVisibilityFlag GearVisibilityFlag;
-    [FieldOffset(0x3B0)] public byte GearsetIndex;
+    [FieldOffset(0x3B0), Obsolete("Renamed to EnabledGearsetIndex. This is the index of a RaptureGearsetModule.Entries list, which only contains enabled entries.")] public byte GearsetIndex;
+    [FieldOffset(0x3B0)] public byte EnabledGearsetIndex;
     [FieldOffset(0x3B1)] public byte ClassJobId;
-
+    //[FieldOffset(0x3B2)] public byte UnkByteOrBool;
+    //[FieldOffset(0x3B3)] public byte UnkByteOrBool;
     [FieldOffset(0x3B8)] public AgentBannerEditor* AgentBannerEditor;
     [FieldOffset(0x3C0)] public UIModule* UIModule;
     [FieldOffset(0x3C8)] public CharaViewPortrait* CharaView;
@@ -93,7 +99,8 @@ public unsafe partial struct AgentBannerEditorState {
     [FieldOffset(0x3D8)] public EditorOpenType OpenType;
 
     [FieldOffset(0x3E4)] public float FrameCountdown; // starting at 0.5s on open
-    [FieldOffset(0x3E8)] public int GearsetId;
+    [FieldOffset(0x3E8), Obsolete("Renamed to OpenerEnabledGearsetIndex")] public int GearsetId;
+    [FieldOffset(0x3E8)] public int OpenerEnabledGearsetIndex; // not exactly sure why there is a second field for this
 
     [FieldOffset(0x3F0)] public int CloseDialogAddonId;
     [FieldOffset(0x3F4)] public bool HasDataChanged;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGearset.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGearset.cs
@@ -13,6 +13,9 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 public partial struct AgentGearSet {
     [FieldOffset(0x808)] public GearsetCharaView CharaView;
 
+    [MemberFunction("48 89 5C 24 ?? 57 48 83 EC 20 48 8B F9 8B DA 48 8B 49 10 48 8B 01 FF 50 70 4C 8D 44 24")]
+    public partial void OpenBannerEditorForGearset(int gearsetId);
+
     // Client::UI::Agent::AgentGearSet::GearsetCharaView
     //   Client::UI::Misc::CharaView
     [GenerateInterop]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
@@ -18,6 +18,9 @@ public unsafe partial struct RaptureGearsetModule {
 
     [FieldOffset(0xB5C8)] public int CurrentGearsetIndex;
 
+    [FieldOffset(0xB79C), FixedSizeArray] internal FixedSizeArray100<byte> _enabledGearsetIndex2EntryIndex;
+    [FieldOffset(0xB801)] public byte NumGearsets;
+
     /// <summary>
     /// Return a pointer to a <see cref="GearsetEntry"/> by index/ID.
     /// </summary>
@@ -139,6 +142,14 @@ public unsafe partial struct RaptureGearsetModule {
     /// <remarks>Equivalent to Flags.HasFlag(GearsetFlag.Exists) &amp;&amp; BannerIndex != 0.</remarks>
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 4F 0F B6 D3")]
     public partial bool HasLinkedBanner(byte gearsetId);
+
+    /// <summary>
+    /// Resolves the index of a GearsetEntry array that only contains enabled gearsets to the index in the actual <see cref="Entries"/> array.
+    /// </summary>
+    /// <param name="enabledGearsetIndex">The position in the list.</param>
+    /// <returns>The ID of the <see cref="GearsetEntry"/>.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 33 C9 83 F8 64")]
+    public partial int ResolveIdFromEnabledIndex(byte enabledGearsetIndex);
 
     [Flags]
     public enum GearsetFlag : byte {

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -7384,6 +7384,7 @@ classes:
       0x1407DC7C0: GetBannerIndex
       0x1407DC820: SetBannerIndex
       0x1407DC920: HasLinkedBanner
+      0x1407DC950: ResolveIdFromEnabledIndex
       0x1407DCD10: FindGearsetIdByName
   Client::UI::Misc::ItemFinderModule:
     vtbls:
@@ -8789,6 +8790,7 @@ classes:
       0x140E32910: ctor
       0x140E32BE0: Finalize
       0x140E33EB0: OpenRegistGearSetList # (this, InventoryItem*, ushort)
+      0x140E37700: OpenBannerEditorForGearset
   Client::UI::Agent::AgentSupportMain:
     vtbls:
       - ea: 0x141ECBB70


### PR DESCRIPTION
`AgentBannerEditor.OpenForGearset` incorrectly takes the gearset id, which is actually the index in a filtered `RaptureGearsetModule.Entries` list that only contains existing gearsets.

I've renamed fields and arguments accordingly and added a new functions to resolve the index.


<details>
  <summary>Detailed Explanation</summary>


For better illustration, I made a new gearset and moved it to number 51.
Internally, because of zero-based arrays, the Index in the array, as well as the Id field inside the entry, are 50.

![Screenshot1](https://github.com/user-attachments/assets/ad7b4771-d457-4938-aa25-21f79508b92b)

The problem though is how the portrait editor handles gearsets.
It doesn't take the index in the list of gearsets (which would be 50).
Instead, it takes the list of gearsets and filters out all disabled entries (whether they haven't been created at all, or were deleted).
As seen in the screenshot above, I have 44 gearsets. If you zero-base this list, the last entry will be at index 43.
And that 43 is what is sent over to the portrait editor, not 50.

What I found is that the gearset module is tracking this in a small array near the end.
This way it's possible to resolve the index of the filtered list, to get the index in the original entries array.

![Screenshot2](https://github.com/user-attachments/assets/fcd48c1f-5fb5-47af-875d-607267c39438)

</details>
