### PR TITLE
Rename HairMakeTask to CharaMakeInGameTask

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventSceneModuleTaskManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventSceneModuleTaskManager.cs
@@ -7,7 +7,7 @@ public unsafe partial struct EventSceneModuleTaskManager {
     [FieldOffset(0x00)] public StdVector<Pointer<EventSceneTaskInterface>> Tasks;
     [FieldOffset(0x18)] public StdVector<Pointer<EventSceneTaskInterface>> GroupPoseTasks;
 
-    [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 20 48 8B 2D")]
+    [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC 20 48 8B 2D"), Obsolete("This function was inlined in 7.0")]
     public partial void ProcessTasks();
 
     [MemberFunction("E8 ?? ?? ?? ?? EB 2E 48 85 C0")]

--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventSceneTaskInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventSceneTaskInterface.cs
@@ -46,7 +46,7 @@ public enum EventSceneTaskType : uint {
     CheckItemsObtainableRareCheck = 35,
     [Obsolete("Renamed to CharaMakeInGame")]
     HairMake = 36,
-    CharaMakeInGame = 36,
+    CharaMakeInGame = 36, // created by the lua function HairMake
     WaitForBuildHouse = 37,
     WaitForFeedBuddy = 38,
     RequestRacingChocoboParam = 39,

--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventSceneTaskInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventSceneTaskInterface.cs
@@ -44,7 +44,9 @@ public enum EventSceneTaskType : uint {
     IsItemObtainable = 33,
     CheckItemsObtainable = 34,
     CheckItemsObtainableRareCheck = 35,
+    [Obsolete("Renamed to CharaMakeInGame")]
     HairMake = 36,
+    CharaMakeInGame = 36,
     WaitForBuildHouse = 37,
     WaitForFeedBuddy = 38,
     RequestRacingChocoboParam = 39,

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -11356,7 +11356,7 @@ classes:
     vtbls:
       - ea: 0x141F2F1D8
         base: Client::Game::Event::EventSceneTaskInterface
-  Client::Game::Event::HairMakeTask:
+  Client::Game::Event::CharaMakeInGameTask:
     vtbls:
       - ea: 0x141F2F220
         base: Client::Game::Event::EventSceneTaskInterface

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -11079,7 +11079,7 @@ classes:
       123: StopScreenShake
       124: PlaySE
       125: MakeRetainer
-      126: HairMake
+      126: HairMake # name based on lua function, creates CharaMakeInGameTask
       127: WaitForBuildHouse
       128: Logout
       129: Shutdown


### PR DESCRIPTION
I originally named it `HairMakeTask` because of the lua function HairMake which sets it up.
Found the name `CharaMakeInGameTask` in the old exe.