### PR TITLE
Add AtkArrayData types

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonAreaMap.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonAreaMap.cs
@@ -1,4 +1,4 @@
-﻿using FFXIVClientStructs.FFXIV.Component.GUI;
+using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI;
 
@@ -8,10 +8,10 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 [StructLayout(LayoutKind.Explicit, Size = 0x7D8)]
 public unsafe partial struct AddonAreaMap {
     [GenerateInterop]
-    [StructLayout(LayoutKind.Explicit, Size = 6 * 4)] 
-    public partial struct AreaMapIntArrayData {
-        public static AreaMapIntArrayData* Instance = (AreaMapIntArrayData*) AtkStage.Instance()->GetNumberArrayData(NumberArrayType.AreaMap);
-    
+    [StructLayout(LayoutKind.Explicit, Size = 6 * 4)]
+    public unsafe partial struct AddonAreaMapNumberArray {
+        public static AddonAreaMapNumberArray* Instance() => (AddonAreaMapNumberArray*)AtkStage.Instance()->GetNumberArrayData(NumberArrayType.AreaMap);
+
         [FieldOffset(0x0)] public int X;
         [FieldOffset(0x4)] public int Y;
         [FieldOffset(0x8)] public int PlayerRotation; // 0 is South, -90 is West, -180/+180 is North, 90 is East

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonAreaMap.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonAreaMap.cs
@@ -1,0 +1,22 @@
+﻿using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI;
+
+[Addon("AreaMap")]
+[GenerateInterop]
+[Inherits<AtkUnitBase>]
+[StructLayout(LayoutKind.Explicit, Size = 0x7D8)]
+public unsafe partial struct AddonAreaMap {
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 6 * 4)] 
+    public partial struct AreaMapIntArrayData {
+        public static AreaMapIntArrayData* Instance = (AreaMapIntArrayData*) AtkStage.Instance()->GetNumberArrayData(NumberArrayType.AreaMap);
+    
+        [FieldOffset(0x0)] public int X;
+        [FieldOffset(0x4)] public int Y;
+        [FieldOffset(0x8)] public int PlayerRotation; // 0 is South, -90 is West, -180/+180 is North, 90 is East
+        [FieldOffset(0xC)] public int ConeRotation; // 0 is North, -90 is East, -180/+180 is South, 90 is West
+        // [FieldOffset(0x10)] public int UnkInt; // Always a zero it seems
+        // [FieldOffset(0x14)] public int UnkInt; // Always a zero it seems
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonNamePlate.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonNamePlate.cs
@@ -73,6 +73,8 @@ public unsafe partial struct AddonNamePlate {
     [GenerateInterop]
     [StructLayout(LayoutKind.Explicit, Size = 1006 * 4)]
     public partial struct NamePlateIntArrayData {
+        public static NamePlateIntArrayData* Instance = (NamePlateIntArrayData*) AtkStage.Instance()->GetNumberArrayData(NumberArrayType.Nameplate);
+        
         [FieldOffset(0x0)] public int ActiveNamePlateCount;
         [FieldOffset(0x4)] public bool ForceNamePlateRebake;
         [FieldOffset(0x8)] public int NamePlateSize;

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonNamePlate.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonNamePlate.cs
@@ -70,11 +70,63 @@ public unsafe partial struct AddonNamePlate {
         public bool IsLocalPlayer => IsPlayerCharacter && ClickThrough;
     }
 
+    [Obsolete("Renamed to AddonNamePlateNumberArray")]
     [GenerateInterop]
     [StructLayout(LayoutKind.Explicit, Size = 1006 * 4)]
     public partial struct NamePlateIntArrayData {
-        public static NamePlateIntArrayData* Instance = (NamePlateIntArrayData*) AtkStage.Instance()->GetNumberArrayData(NumberArrayType.Nameplate);
-        
+        [FieldOffset(0x0)] public int ActiveNamePlateCount;
+        [FieldOffset(0x4)] public bool ForceNamePlateRebake;
+        [FieldOffset(0x8)] public int NamePlateSize;
+        [FieldOffset(0xC)] public bool DisableFixedFontResolution;
+        [FieldOffset(0x10)] public bool DoFullUpdate;
+        // [FieldOffset(0x14)] public int UnkInt;
+        [FieldOffset(0x18)][FixedSizeArray] internal FixedSizeArray50<NamePlateObjectIntArrayData> _objectData;
+
+        [StructLayout(LayoutKind.Explicit, Size = 20 * 4)]
+        public struct NamePlateObjectIntArrayData {
+            [FieldOffset(0x0)] public UIObjectKind NamePlateKind;
+            [FieldOffset(0x4)] public int HPLabelState;
+            /// <summary>
+            /// &amp; 0x1 - Update<br/>
+            /// &amp; 0x2 - Update Colors<br/>
+            /// </summary>
+            [FieldOffset(0x8)] public int UpdateFlags;
+            [FieldOffset(0xC)] public int X;
+            [FieldOffset(0x10)] public int Y;
+            [FieldOffset(0x14)] public float Depth;
+            [FieldOffset(0x18)] public int Scale;
+            [FieldOffset(0x1C)] public int GaugeFillPercentage;
+            [FieldOffset(0x20)] public uint NameTextColor;
+            [FieldOffset(0x24)] public uint NameEdgeColor;
+            [FieldOffset(0x28)] public uint GaugeFillColor;
+            [FieldOffset(0x2C)] public uint GaugeContainerColor; // unused if Disable Alternate Part Id true
+            [FieldOffset(0x30)] public int MarkerIconId;
+            [FieldOffset(0x34)] public int NameIconId;
+            // [FieldOffset(0x38)] public int UnkAdjust;
+            [FieldOffset(0x3C)] public int NamePlateObjectIndex;
+            // [FieldOffset(0x40)] public int Unk;
+            /// <summary>
+            /// &amp; 0x1 - Is prefix title<br/>
+            /// &amp; 0x8 - Use Depth-based Priority (terrain obstruction)<br/>
+            /// &amp; 0x80 - Hide title<br/>
+            /// &amp; 0x100 - Disable Alternate Part Id<br/>
+            /// </summary>
+            [FieldOffset(0x44)] public int DrawFlags;
+            // [FieldOffset(0x48)] public int Unk;
+            /// <summary>
+            /// &amp; 0x1 - Draw name text<br/>
+            /// &amp; 0x2 - Draw gauge<br/>
+            /// &amp; 0x4 - Unknown, seems to be set 1-2 frames after node appears<br/>
+            /// </summary>
+            [FieldOffset(0x4C)] public int VisibilityFlags;
+        }
+    }
+
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 1006 * 4)]
+    public partial struct AddonNamePlateNumberArray {
+        public static AddonNamePlateNumberArray* Instance() => (AddonNamePlateNumberArray*)AtkStage.Instance()->GetNumberArrayData(NumberArrayType.NamePlate);
+
         [FieldOffset(0x0)] public int ActiveNamePlateCount;
         [FieldOffset(0x4)] public bool ForceNamePlateRebake;
         [FieldOffset(0x8)] public int NamePlateSize;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGrandCompanySupply.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGrandCompanySupply.cs
@@ -15,7 +15,7 @@ public unsafe partial struct AgentGrandCompanySupply {
     [FieldOffset(0x68)] public GrandCompanyItem* ItemArray;
 
     [FieldOffset(0x78)] public int NumItems;
-    [FieldOffset(0x90)] public int SelectedTab;
+    [FieldOffset(0x90)] public int SelectedTab; // TODO: this is a short
 }
 
 [GenerateInterop]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGrandCompanySupply.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGrandCompanySupply.cs
@@ -15,7 +15,7 @@ public unsafe partial struct AgentGrandCompanySupply {
     [FieldOffset(0x68)] public GrandCompanyItem* ItemArray;
 
     [FieldOffset(0x78)] public int NumItems;
-    [FieldOffset(0x90)] public int SelectedTab; // TODO: this is a short
+    [FieldOffset(0x90)] public short SelectedTab;
 }
 
 [GenerateInterop]

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkArrayData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkArrayData.cs
@@ -15,3 +15,288 @@ public unsafe partial struct AtkArrayData {
     [FieldOffset(0x1E)] public byte UpdateState;
     [FieldOffset(0x1F)] public sbyte RefCount; // initialized to -1, used by Agents
 }
+
+public enum NumberArrayType {
+    ChatLog = 0,
+    ChatLog2 = 1,
+    CharaSelect = 2,
+    Hud = 3, // ParameterWidget, Status, Exp
+    PartyList = 4,
+    NamePlate = 5,
+    ActionBar = 6,
+    Inventory = 7,
+    BagWidget = 8,
+    Hud2 = 9, // Notification, TargetInfo, ContentGauge, FocusTargetInfo, VoteKickDialogue, VoteTreasure
+    Trade = 10,
+    NeedGreed = 11,
+
+    PartyMemberList = 13,
+
+    LinkShell = 15,
+    BlackList = 16,
+    FriendList = 17,
+
+    Letter = 19, // LetterList, LetterViewer
+    SocialList = 20, // search results
+    EnemyList = 21,
+    CastBar = 22,
+    TargetCursor = 23,
+    AreaMap = 24,
+
+    Journal = 26,
+    ToDoList = 27,
+    RecipeNote = 28,
+    ItemDetail = 29,
+    FlyText = 30,
+    ActionDetail = 31,
+
+    MiniTalk = 34,
+    Talk = 35,
+    ItemSearch = 36,
+    BattleTalk = 37,
+    ArmouryBoard = 38,
+    FreeCompanyMember = 39,
+
+    HousingBlackListSetting = 41,
+    LimitBreak = 42,
+    LegacyItemStorage = 43,
+    FreeCompanyApplication = 44,
+    GearSetList = 45,
+    FreeCompanyRights = 46, // also MemberRankAssign, FreeCompanyRank
+    CabinetStore = 47,
+    CabinetWithdraw = 48,
+
+    FreeCompanyActivity = 50,
+    FreeCompanyExchange = 51,
+    FreeCompanyStatus = 52,
+    ConfigSystem = 53,
+
+    NaviMap = 55,
+    AreaMap2 = 56,
+    ContentsFinderConfirm = 57,
+    FreeCompanyChest = 58,
+    Buddy = 59,
+    //FreeCompanyExchange2 = 60,
+    FreeCompanyAction = 61,
+    RecommendList = 62,
+
+    Character = 64,
+    FishingNote = 65,
+    FishGuide = 66,
+    GearSetView = 67,
+    HousingSignBoard = 68,
+    Housing = 69, // HousingSelectDeed, HousingGardening, HousingGoods, HousingEditInterior, HousingEditExterior
+    AllianceList = 70,
+    LookingForGroup = 71,
+    Credits = 72,
+    HousingTravellersNote = 73,
+    DTR = 74,
+    RetainerCharacter = 75,
+    AdventureNoteBook = 76,
+    HousingChocoboList = 77,
+    TripleTriad = 78,
+    GSInfoGeneral = 79,
+    RaceChocobo = 80,
+    Currency = 81,
+    BeginnerChannelMentorList = 82,
+    BeginnerChannelBeginnerList = 83,
+
+    PvPDuelRequest = 85,
+    JobHud = 86,
+    PvPTeam = 87,
+    PvPTeamMember = 88,
+    PvPTeamResult = 89,
+    PvPTeamActivity = 90,
+
+    ContentMemberList = 92,
+
+    CrossWorldLinkShell = 94,
+
+    Lovm = 97,
+
+    LovmQueueList = 99,
+    LovmNamePlate = 100,
+    LovmMiniMap = 101,
+    LovmActionDetail = 102,
+    GoldSaucerArcadeMachine = 103, // PunchingMachine, BasketBall, Hammer, MogCatcher, MinerBotanistAim
+    PvPProfile = 104,
+    Orchestrion = 105,
+
+    RetainerTask = 107,
+    YKWNote = 108,
+    DeepDungeonNaviMap = 109,
+    DeepDungeonStatus = 110,
+    ProgressBar = 111,
+    GcArmyExpedition = 112,
+    GcArmyTraining = 113,
+    GcArmyCapture = 114,
+    PvPMKS = 116,
+    PvPSpectatorCameraList = 117,
+    PvPSpectatorList = 118,
+    PvPFrontline = 119,
+    LFGRecruiterNameSearch = 120,
+    Snipe = 121,
+
+    PVPSimulationHeader = 123,
+    PVPSimulationAlliance = 124,
+    PVPSimulationHeader2 = 125,
+    PVPSimulationDisplay = 126,
+    EurekaElementalHud = 127,
+    Performance = 128,
+    ContentsReplayPlayer = 129,
+    SatisfactionSupplyChangeMiragePrism = 130,
+    SatisfactionSupplyMiragePrism = 131,
+    Description = 132, // DescriptionYTC, DescriptionDD
+    Alarm = 133,
+    Merchant = 134,
+    MerchantEquipSelect = 135,
+    EurekaLogosShardList = 136,
+    EurekaLogosAetherList = 137,
+    RhythmAction = 138,
+    WorldTranslate = 139,
+    Emj = 140,
+    PerformanceGamepadGuide = 141,
+    PerformanceMetronome = 142,
+    PerformancePlayGuide = 143,
+    CruisingInfo = 144,
+    MYCInfo = 145,
+    MYCItemBag = 146,
+    WeeklyPuzzle = 147,
+    TeleportTown = 148,
+    PvPMKSNaviMap = 149,
+    TurnBreak = 150,
+    MJIHousingGoods = 151,
+    FGSHud = 152,
+    FGSResult = 153,
+}
+
+public enum StringArrayType {
+    ChatLog = 0,
+    CharaSelect = 1,
+    Hud = 2, // ParameterWidget, Status, Exp
+    PartyList = 3,
+    NamePlate = 4,
+    ActionBar = 5,
+    Inventory = 6,
+    CharacterItems = 7,
+    Hud2 = 8, // Notification, TargetInfo, ContentGauge, FocusTargetInfo
+    Trade = 9,
+
+    PartyMemberList = 11,
+
+    LinkShell = 13,
+    BlackList = 14,
+    FriendList = 15,
+
+    Letter = 17, // LetterList, LetterViewer
+    SocialList = 18, // search results
+    EnemyList = 19,
+    CastBar = 20,
+    AreaMap = 21,
+
+    Journal = 23,
+    ToDoList = 24,
+    RecipeNote = 25,
+    ItemDetail = 26, // search results and RetainerHistory
+    FlyText = 27,
+    ActionDetail = 28,
+
+    MiniTalk = 31,
+    CommonCurrencies = 32, // holds Gil, Grand Company Seals, Dark Matter; used by Repair, MateriaAttachDialog, GrandCompanyExchange, GrandCompanySupplyList
+    ItemSearch = 33,
+    BattleTalk = 34,
+    ArmouryBoard = 35,
+    FreeCompanyMember = 36,
+
+    HousingBlackListSetting = 38,
+    LegacyItemStorage = 39,
+    FreeCompanyApplication = 40,
+    GearSetList = 41,
+    FreeCompanyRights = 42,
+    CabinetStore = 43,
+    CabinetWithdraw = 44,
+
+    FreeCompanyActivity = 46,
+    FreeCompanyExchange = 47,
+    FreeCompanyStatus = 48,
+    ConfigSystem = 49,
+
+    NaviMap = 51,
+    AreaMap2 = 52,
+    ContentsFinderConfirm = 53,
+    FreeCompanyChest = 54,
+    Buddy = 55,
+    //FreeCompanyExchange = 56,
+    FreeCompanyAction = 57,
+    RecommendList = 58,
+    Character = 59, // Character, CharacterProfile, CharacterClass, CharacterRepute
+    FishingNote = 60,
+    FishGuide = 61,
+    GearSetView = 62,
+    HousingSignBoard = 63,
+    Housing = 64, // HousingSelectDeed, HousingGardening, HousingGoods, HousingEditInterior, HousingEditExterior
+    AllianceList = 65,
+    LookingForGroup = 66,
+    HousingTravellersNote = 67,
+    DTR = 68,
+    //PadMouseMode = 69,
+    RetainerCharacter = 70,
+    AdventureNoteBook = 71,
+    HousingChocoboList = 72,
+    TripleTriad = 73,
+    LimitBreak = 74,
+    RaceChocobo = 75,
+    Currency = 76,
+    BeginnerChannelMentorList = 77,
+    BeginnerChannelBeginnerList = 78,
+    PvPDuelRequest = 79,
+    JobHud = 80,
+    PvPTeam = 81,
+    PvPTeamMember = 82,
+    PvPTeamResult = 83,
+    PvPTeamActivity = 84,
+    ContentMemberList = 85,
+
+    CrossWorldLinkShell = 87,
+    LovmNamePlate = 88,
+    LovmActionDetail = 89,
+    LovmResult = 90,
+    Lovm = 91,
+
+    PvPProfile = 93,
+    Orchestrion = 94,
+
+    RetainerTask = 97,
+    YKWNote = 98,
+    DeepDungeonNaviMap = 99,
+    DeepDungeonStatus = 100,
+    GcArmyExpedition = 101,
+    GcArmyTraining = 102,
+    GcArmyCapture = 103,
+    PvPMKS = 104,
+    PvPSpectatorList = 105,
+    LFGRecruiterNameSearch = 106,
+    Snipe = 107,
+    Performance = 108,
+    ContentsReplayPlayer = 109,
+    SatisfactionSupplyChangeMiragePrism = 110,
+    SatisfactionSupplyMiragePrism = 111,
+    Alarm = 112,
+    Merchant = 113,
+    MerchantEquipSelect = 114,
+    EurekaLogosShardList = 115,
+    RhythmAction = 116,
+    WorldTranslate = 117,
+    PVPSimulationHeader2 = 118,
+    PVPSimulationDisplay = 119,
+    Emj = 120,
+    WeeklyPuzzle = 121,
+    MYCInfo = 122,
+    TeleportTown = 123,
+    MJIHousingGoods = 124,
+}
+
+public enum ExtendArrayType {
+    AreaMapSubZones = 1,
+    NaviMapMapMarkers = 2, // Pointers to MapMarkerBase?
+}

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkStage.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkStage.cs
@@ -45,6 +45,9 @@ public unsafe partial struct AtkStage {
     [MemberFunction("E8 ?? ?? ?? ?? 45 33 F6 48 85 C0 74 06")]
     public partial NumberArrayData** GetNumberArrayData();
 
+    public NumberArrayData* GetNumberArrayData(NumberArrayType type)
+        => GetNumberArrayData()[(int)type];
+
     // Top 5 Signatures out of 215 xrefs for 14062B5F0:
     // XREF Signature #1 @ 14122E36C: E8 ?? ?? ?? ?? 41 6B CE
     // XREF Signature #2 @ 1410EC295: E8 ?? ?? ?? ?? 42 8D 1C AD
@@ -54,6 +57,22 @@ public unsafe partial struct AtkStage {
     [MemberFunction("E8 ?? ?? ?? ?? 42 8D 1C AD")]
     public partial StringArrayData** GetStringArrayData();
 
+    public StringArrayData* GetStringArrayData(StringArrayType type)
+        => GetStringArrayData()[(int)type];
+
     [MemberFunction("48 8B 41 38 48 8B 40 48")]
     public partial ExtendArrayData** GetExtendArrayData();
 }
+
+public enum NumberArrayType {
+    Nameplate = 5,
+    AreaMap = 24,
+    AreaMap2 = 56, 
+}
+
+public enum StringArrayType {
+    Nameplate = 4,
+    AreaMap = 21,
+    AreaMap2 = 52,
+}
+

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkStage.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkStage.cs
@@ -62,17 +62,7 @@ public unsafe partial struct AtkStage {
 
     [MemberFunction("48 8B 41 38 48 8B 40 48")]
     public partial ExtendArrayData** GetExtendArrayData();
-}
 
-public enum NumberArrayType {
-    Nameplate = 5,
-    AreaMap = 24,
-    AreaMap2 = 56, 
+    public ExtendArrayData* GetExtendArrayData(ExtendArrayType type)
+        => GetExtendArrayData()[(int)type];
 }
-
-public enum StringArrayType {
-    Nameplate = 4,
-    AreaMap = 21,
-    AreaMap2 = 52,
-}
-


### PR DESCRIPTION
This PR is a continuation of and supersedes #1073.

- Moved `NumberArrayType` and `StringArrayType` from underneath `AtkStage` to underneath the `AtkArrayData` struct and updated them with many new types.
- Added `ExtendArrayType`.
- Added `AtkStage.GetExtendArrayData(ExtendArrayType)`
- Renamed `AddonAreaMap.AreaMapIntArrayData` to just `AddonAreaMapNumberArray`.
- Marked `AddonNamePlate.NamePlateIntArrayData` obsolete (because it already existed before the other PR), and moved/renamed it to just `AddonNamePlateNumberArray`.

Closes #1073