### PR TITLE
Fix PlayerState.IsAdventureComplete

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/PlayerState.cs
@@ -107,15 +107,10 @@ public unsafe partial struct PlayerState {
 
     [FieldOffset(0x522)] public byte SightseeingLogUnlockState; // 0 = Not Unlocked, 1 = ARR Part 1, 2 = ARR Part 2
     [FieldOffset(0x523)] public byte SightseeingLogUnlockStateEx; // 3 = Quest "Sights of the North" completed (= AdventureExPhase unlocked?)
-    // Ref: PlayerState.IsAdventureExPhaseComplete
-    // Size: (AdventureExPhaseSheet.RowCount + 7) / 8
-    /// <remarks> Use <see cref="IsAdventureExPhaseComplete"/> </remarks>
-    [FieldOffset(0x524), FixedSizeArray] internal FixedSizeArray1<byte> _unlockedAdventureExPhaseBitmask; // TODO: update size
-
+    [FieldOffset(0x524), FixedSizeArray] internal FixedSizeArray44<byte> _unlockedAdventureBitmask; // maybe?
     // Ref: PlayerState.IsAdventureComplete
-    // Size: (AdventureSheet.RowCount + 7) / 8
     /// <remarks> Use <see cref="IsAdventureComplete"/> </remarks>
-    [FieldOffset(0x550), FixedSizeArray] internal FixedSizeArray43<byte> _unlockedAdventureBitmask;
+    [FieldOffset(0x550), FixedSizeArray] internal FixedSizeArray44<byte> _completedAdventureBitmask;
 
     [FieldOffset(0x581), FixedSizeArray] internal FixedSizeArray56<byte> _unlockFlags;
 
@@ -329,15 +324,16 @@ public unsafe partial struct PlayerState {
     /// Check if all vistas of an expansion in the Sightseeing Log have been discovered.
     /// </summary>
     /// <param name="adventureExPhaseId">AdventureExPhase RowId</param>
-    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 90")]
+    [Obsolete("The signature is wrong. There is currently no alternative to this function.")]
+    [MemberFunction("81 FA ?? ?? ?? ?? 73 1F 0F B6 C2")]
     public partial bool IsAdventureExPhaseComplete(uint adventureExPhaseId);
 
     /// <summary>
     /// Check if a Sightseeing Log vista has been discovered.
     /// </summary>
-    /// <param name="adventureId">Index of Row (= RowId - 2162688)</param>
-    [MemberFunction("81 FA ?? ?? ?? ?? 73 1F 0F B6 C2")]
-    public partial bool IsAdventureComplete(uint adventureId);
+    /// <param name="adventureIndex">Index of the Adventure Row</param>
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 90")]
+    public partial bool IsAdventureComplete(uint adventureIndex);
 
     /// <summary>
     /// Check if a specific set of Glasses are unlocked. Internally, this will look up the associated GlassesStyle

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1799,9 +1799,10 @@ classes:
       0x140AD90E0: IsSecretRecipeBookUnlocked # DoH unlockable books
       0x140AD9250: SetSightseeingLogUnlockState
       0x140AD92A0: SetSightseeingLogUnlockStateEx
-      0x140AD92F0: SetAdventureExPhaseComplete
-      0x140AD9340: IsAdventureExPhaseComplete
-      0x140AD9570: IsAdventureComplete
+      0x140AD92F0: SetAdventureComplete
+      0x140AD9340: IsAdventureComplete
+      0x140AD9520: SetAdventureUnlocked # maybe?
+      0x140AD9570: IsAdventureUnlocked # maybe?
       0x140AD9ED0: IsFolkloreBookUnlocked     # DoL unlockable books
       0x140ADBB90: IsMcGuffinUnlocked
       0x140ADC000: IsFramersKitUnlocked


### PR DESCRIPTION
I'm not quite sure what's going on.
- The function `IsAdventureComplete` didn't return what we expected.
- I found out that `IsAdventureExPhaseComplete` actually returns whether a vista was discovered, so I moved the sig over to `IsAdventureComplete`.
![K3FsAZTU29](https://github.com/user-attachments/assets/5a504cc5-8e55-4ec9-a7db-a94c9acfc3ee)
![7nrLiL6ikC](https://github.com/user-attachments/assets/877b4033-5167-44c9-9d63-ff86a96b77ee)
- Tried to figure out where `IsAdventureExPhaseComplete` is, but I can't find it. Maybe they reworked it? Didn't check old exes. Marked it obsolete and removed it from data.yml.
-  I added `SetAdventureUnlocked`/`IsAdventureUnlocked` functions to the data.yml and renamed `_unlockedAdventureExPhaseBitmask` to `_completedAdventureBitmask`, but I'm not sure if that's correct, because I already unlocked the sightseeing log for all expansions, which is why I didn't add the functions to PlayerState.cs.