### PR TITLE
Update EffectContainer

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/EffectContainer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/EffectContainer.cs
@@ -4,8 +4,22 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Character;
 [Inherits<ContainerInterface>]
 [StructLayout(LayoutKind.Explicit, Size = 0x50)]
 public unsafe partial struct EffectContainer {
-
+    [FieldOffset(0x10)] public float CurrentFloatHeight;
+    [FieldOffset(0x14)] public float TargetFloatHeight;
+    [FieldOffset(0x18)] public float FloatHeightChangeSpeed;
+    // [FieldOffset(0x1C)] public float UnkSpeed;
+    // [FieldOffset(0x20)] public int UnkTime;
+    // [FieldOffset(0x24)] public byte UnkRidingPillionFlag;
+    // [FieldOffset(0x26)] public short UnkRidingPillionValue;
+    // [FieldOffset(0x2C)] public float UnkTime2;
     [FieldOffset(0x30)] public StatusEffect StatusEffects;
+    [FieldOffset(0x34)] public int MountTiltSetupState1;
+    [FieldOffset(0x38)] public int MountTiltSetupState2;
+    // [FieldOffset(0x3C)] public byte Unk3C;
+    [FieldOffset(0x40)] public byte TiltParam1Type;
+    [FieldOffset(0x44)] public float TiltParam1Value;
+    [FieldOffset(0x48)] public byte TiltParam2Type;
+    [FieldOffset(0x4C)] public float TiltParam2Value;
 
     [Flags]
     public enum StatusEffect : byte {

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -7841,6 +7841,8 @@ classes:
     vtbls:
       - ea: 0x141F0FB00
         base: Client::Game::Character::ContainerInterface
+    funcs:
+      0x1408C3A80: CalculateFloatHeight
   Client::Game::Character::ReaperShroudContainer:
     vtbls:
       - ea: 0x141F0FA28
@@ -7850,6 +7852,8 @@ classes:
   Client::Game::Character::CharacterData:
     vtbls:
       - ea: 0x141F0F928
+    funcs:
+      0x14089C750: GetModelCharaId
   Client::Game::Character::TimelineContainer:
     vtbls:
       - ea: 0x141F0FA60


### PR DESCRIPTION
TiltParam setup is here: `E8 ?? ?? ?? ?? 48 8B CE E8 ?? ?? ?? ?? 48 83 BE ?? ?? ?? ?? ?? 74 26`
and handled in here `48 89 5C 24 ?? 55 56 57 48 8B EC 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 45 F0 48 8B D9`

Still not sure what these fields do, but setting MountTiltSetupState1 and 2 to 0 after the setup disables mount tilting. :)