### PR TITLE
ci: Add concurrency to pr-change-check

### DIFF
--- a/.github/workflows/pr-change-check.yaml
+++ b/.github/workflows/pr-change-check.yaml
@@ -8,7 +8,11 @@ on:
       - reopened
     paths:
       - 'FFXIVClientStructs/**/*.cs'
-  
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When pushing multiple commits in a row (separately, for example I just realized I need to rebase after I pushed), several jobs of the `pr-change-check` action run in parallel.

In the worst case scenario where one action could be a bit slower with building than the other, it can cause the comment from a newer commit to be deleted and replaced with an older one.

This change adds concurrency to the action, cancelling running `pr-change-check` jobs on the same PR, so that only the last started action is allowed to comment.

I used the example from the [GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-using-concurrency-and-the-default-behavior). The `github.workflow` context contains the name of the action, and `github.ref` contains the pull request merge branch ([source](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context)).
