### PR TITLE
[RaptureLogModule] Update to new size and include new fields

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
@@ -42,6 +42,16 @@ public unsafe partial struct RaptureLogModule {
     [FieldOffset(0x3478)] public LogMessageSource* MsgSourceArray;
     [FieldOffset(0x3480)] public int MsgSourceArrayLength;
 
+    [FieldOffset(0x34E8)] public ulong AccountId;
+    [FieldOffset(0x34F0)] public ulong ContentId;
+    [FieldOffset(0x34F8)] public byte* Name;
+    [FieldOffset(0x3500)] public Utf8String* MessageText;
+    [FieldOffset(0x3508)] public uint EntityId;
+    [FieldOffset(0x350C)] public ushort ChatType;
+    [FieldOffset(0x350E)] public ushort WorldId;
+    [FieldOffset(0x3510)] public sbyte PartyOrAllianceMemberIdent;
+    [FieldOffset(0x3511)] public byte Flags;
+
     [MemberFunction("E8 ?? ?? ?? ?? 8B D8 48 8D 4D 00")]
     public partial uint PrintMessage(ushort logKindId, Utf8String* senderName, Utf8String* message, int timestamp, bool silent = false);
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
@@ -12,7 +12,7 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 // ctor "E8 ?? ?? ?? ?? 4C 8D A7 ?? ?? ?? ?? 49 8B CC E8 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??"
 [GenerateInterop]
 [Inherits<LogModule>]
-[StructLayout(LayoutKind.Explicit, Size = 0x3488)]
+[StructLayout(LayoutKind.Explicit, Size = 0x3710)]
 public unsafe partial struct RaptureLogModule {
     public static RaptureLogModule* Instance() => Framework.Instance()->GetUIModule()->GetRaptureLogModule();
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
@@ -42,15 +42,8 @@ public unsafe partial struct RaptureLogModule {
     [FieldOffset(0x3478)] public LogMessageSource* MsgSourceArray;
     [FieldOffset(0x3480)] public int MsgSourceArrayLength;
 
-    [FieldOffset(0x34E8)] public ulong AccountId;
-    [FieldOffset(0x34F0)] public ulong ContentId;
-    [FieldOffset(0x34F8)] public byte* Name;
-    [FieldOffset(0x3500)] public Utf8String* MessageText;
-    [FieldOffset(0x3508)] public uint EntityId;
-    [FieldOffset(0x350C)] public ushort ChatType;
-    [FieldOffset(0x350E)] public ushort WorldId;
-    [FieldOffset(0x3510)] public sbyte PartyOrAllianceMemberIdent;
-    [FieldOffset(0x3511)] public byte Flags;
+    [FieldOffset(0x3488)] public AddonMessageSub AddonMessageSub3488;
+
 
     [MemberFunction("E8 ?? ?? ?? ?? 8B D8 48 8D 4D 00")]
     public partial uint PrintMessage(ushort logKindId, Utf8String* senderName, Utf8String* message, int timestamp, bool silent = false);
@@ -135,6 +128,20 @@ public unsafe partial struct RaptureLogModule {
         sender = pSender.AsSpan().ToArray();
         message = pMessage.AsSpan().ToArray();
         return result;
+    }
+
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 0x2A)]
+    public unsafe partial struct AddonMessageSub {
+        [FieldOffset(0x00)] public ulong AccountId;
+        [FieldOffset(0x08)] public ulong ContentId;
+        [FieldOffset(0x10)] public byte* Name;
+        [FieldOffset(0x18)] public Utf8String* MessageText;
+        [FieldOffset(0x20)] public uint EntityId;
+        [FieldOffset(0x24)] public ushort ChatType;
+        [FieldOffset(0x26)] public ushort WorldId;
+        [FieldOffset(0x28)] public sbyte PartyOrAllianceMemberIdent;
+        [FieldOffset(0x29)] public byte Flags;
     }
 }
 


### PR DESCRIPTION
Must have changed in one of the recent patches
for exmaple `1407b8ac0` writes to these higher offsets now