### PR TITLE
Add some more command things

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Shell/RaptureShellModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Shell/RaptureShellModule.cs
@@ -24,6 +24,7 @@ public unsafe partial struct RaptureShellModule {
     [FieldOffset(0x288)] public ShellCommandInterface* ShellCommandAgent;
     [FieldOffset(0x290)] public TimePoint WaitStartTime;
     [FieldOffset(0x2A8)] public uint WaitTimeMs;
+    [FieldOffset(0x2AD)] public bool ShowCommandErrors; 
     [FieldOffset(0x2B3)] public bool MacroLocked;
     [FieldOffset(0x2C0)] public int MacroCurrentLine;
     [FieldOffset(0x2C8)] public Utf8String MacroLineText;
@@ -47,6 +48,7 @@ public unsafe partial struct RaptureShellModule {
     [FieldOffset(0x120A)] public ushort TempTellReason;
 
     [FieldOffset(0x1210)] public uint Flags;
+    [FieldOffset(0x1214)] public uint ErrorData; // ??? seems to be a byte + flags
 
     public bool IsTextCommandUnavailable => (Flags & 1) != 0;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
@@ -108,6 +108,9 @@ public unsafe partial struct UIModule {
 
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 B4 4C 8B CB"), GenerateStringOverloads]
     public static partial bool IsPlayerCharacterName(byte* name);
+    
+    [MemberFunction("48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 45 84 C9")]
+    public static partial void ProcessChatBoxEntry(Utf8String* message, nint a4 = 0, bool saveToHistory = false);
 
     public static void PlayChatSoundEffect(uint effectId) {
         if (effectId is < 1 or > 16)

--- a/FFXIVClientStructs/FFXIV/Component/Shell/ShellCommands.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Shell/ShellCommands.cs
@@ -1,9 +1,22 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
+using FFXIVClientStructs.FFXIV.Client.UI;
 
 namespace FFXIVClientStructs.FFXIV.Component.Shell;
 
+[GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x28)]
-public struct ShellCommands {
+public unsafe partial struct ShellCommands {
     [FieldOffset(0x08)] public StdMap<uint, Pointer<ShellCommandInterface>> TextCommands;
     [FieldOffset(0x18)] public StdMap<Utf8String, Pointer<DebugCommandInterface>> DebugCommands;
+
+    /// <summary>
+    /// Attempts to invoke a "debug" command (e.g. //gm). This method is ultimately called on everything passed to
+    /// <see cref="ShellCommandModule.ExecuteCommandInner"/> that isn't actually a text command. This method is
+    /// used as a de-facto error handler to catch "invalid" commands, as well as special-case handle plain messages.
+    /// </summary>
+    /// <param name="message">The message to process/attempt to invoke.</param>
+    /// <param name="uiModule">A pointer to <see cref="UIModule"/>.</param>
+    /// <returns>Returns 0 if the command was executed, -1 if the command is not found, -2 if the message is not a command at all.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 83 F8 ?? 74 ?? 83 F8 ?? 0F 85 ?? ?? ?? ?? 48 8B 07")]
+    public partial int TryInvokeDebugCommand(Utf8String* message, UIModule* uiModule);
 }


### PR DESCRIPTION
- New `ShowCommandErrors` field controls whether errors are printed to chat or not.
- `ErrorData` is... weird and seems to be combined flags with a byte.
  - Read in `RaptureShellModule.vf1` as a byte
  - Set in many commands as a full dword with value 0x50007 or 0x5000E
- Give up and finally add `ProcessChatBoxEntry` to UIModule.
  - The functionality this command exposes is already done via `ExecuteCommandInner` so I think it's a bit late to play the safety game.
  - I'd even argue this variant is safer since it *does* properly manage RaptureShellModule's state.