### PR TITLE
Add UIModuleHandler

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
@@ -13,6 +13,9 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 
 // Client::UI::UIModule
 //   Client::UI::UIModuleInterface
+//   Component::GUI::AtkModuleEvent
+//   Component::Excel::ExcelLanguageEvent
+//   Common::Configuration::ConfigBase::ChangeEventInterface
 [GenerateInterop]
 [Inherits<UIModuleInterface>, Inherits<AtkModuleEvent>, Inherits<ExcelLanguageEvent>, Inherits<ChangeEventInterface>]
 [StructLayout(LayoutKind.Explicit, Size = 0xEE030)]
@@ -20,6 +23,7 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 public unsafe partial struct UIModule {
     public static UIModule* Instance() => Framework.Instance()->GetUIModule();
 
+    [FieldOffset(0x30), FixedSizeArray] internal FixedSizeArray57<UIModuleHandler> _uIModuleHandlers;
     [FieldOffset(0x3C0), FixedSizeArray] internal FixedSizeArray19<RaptureAtkHistory> _atkHistory;
     [FieldOffset(0x7E8)] public int LinkshellCycle;
     [FieldOffset(0x7EC)] public int CrossWorldLinkshellCycle;
@@ -125,5 +129,12 @@ public unsafe partial struct UIModule {
         ActionBars = 16,
         Unk32 = 32, //same as 1 ?
         TargetInfo = 64 //+disable system menu / ESC key
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x10)]
+    public struct UIModuleHandler {
+        // called via AtkModuleEvent.CallHandler()
+        [FieldOffset(0x0)] public delegate* unmanaged<void*, AtkValue*, AtkValue*, uint, AtkValue*> FunctionPtr; // (mostLikelyUIModule, result, values, valueCount) -> result
+        [FieldOffset(0x8)] public uint UIModuleOffset;
     }
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkExternalInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkExternalInterface.cs
@@ -1,7 +1,7 @@
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
 // Component::GUI::AtkExternalInterface
-[GenerateInterop]
+[GenerateInterop(isInherited: true)]
 [StructLayout(LayoutKind.Explicit, Size = 0x8)]
 public unsafe partial struct AtkExternalInterface {
     [VirtualFunction(1)]

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkModuleEvent.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkModuleEvent.cs
@@ -1,5 +1,9 @@
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
+// Component::GUI::AtkModuleEvent
 [GenerateInterop(isInherited: true)]
 [StructLayout(LayoutKind.Explicit, Size = 8)]
-public unsafe partial struct AtkModuleEvent;
+public unsafe partial struct AtkModuleEvent {
+    [VirtualFunction(0)]
+    public partial void CallHandler(AtkValue* result, uint handlerIndex, AtkValue* values, uint valueCount);
+}

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -644,6 +644,8 @@ classes:
   Component::GUI::AtkModuleEvent:
     vtbls:
       - ea: 0x141F049D0
+    vfuncs:
+      0: CallHandler
   Component::GUI::AtkMessageBoxManager:
     vtbls:
       - ea: 0x141EF57D0


### PR DESCRIPTION
*Can* be used to make a function that calls a handler to send a chat message instead of adding a lose method ProcessChatBoxEntry in kaz's PR.

0x141175F9C is where the game calls the AtkModule handler, which calls the UIModule handler.