### PR TITLE
Revert "ci: Add concurrency to pr-change-check"

### DIFF
--- a/.github/workflows/pr-change-check.yaml
+++ b/.github/workflows/pr-change-check.yaml
@@ -8,11 +8,7 @@ on:
       - reopened
     paths:
       - 'FFXIVClientStructs/**/*.cs'
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
+  
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts aers/FFXIVClientStructs#1097 due to breaking ci currently