### PR TITLE
Fix GameObject.GetRadius signature.

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -58,7 +58,7 @@ public unsafe partial struct GameObject {
     public partial byte* GetName();
 
     [VirtualFunction(7)]
-    public partial float GetRadius();
+    public partial float GetRadius(bool adjustByTransformation = true);
 
     [VirtualFunction(8)]
     public partial float GetHeight();


### PR DESCRIPTION
This was changed some time ago in the game. Easiest way to see how this new argument is used is looking at Character.GetRadius override.