### PR TITLE
methods for getting correct interact range on objects

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventFramework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventFramework.cs
@@ -1,4 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Common.Lua;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game.Event;
@@ -35,6 +36,9 @@ public unsafe partial struct EventFramework {
     [MemberFunction("E8 ?? ?? ?? ?? 48 85 C0 74 1B 66 83 78 ?? ??")]
     public partial EventHandler* GetEventHandlerById(uint id);
     public EventHandler* GetEventHandlerById(ushort id) => GetEventHandlerById((uint)(id | 0x10000));
+
+    [MemberFunction("40 53 57 41 56 48 83 EC 70 48 8B 02")]
+    public partial bool CheckInteractRange(GameObject* source, GameObject* target, byte interactionType, bool logErrorsToUser);
 
     [MemberFunction("E8 ?? ?? ?? ?? 41 0F B7 4E ?? 3B C8")]
     public static partial uint GetCurrentContentId();

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -101,6 +101,9 @@ public unsafe partial struct GameObject {
 
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 ?? 48 8B 17 45 33 C9")]
     public partial bool IsReadyToDraw();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 0F 5A C7")]
+    public partial Vector3* GetPosition();
 }
 
 // if (EntityId == 0xE0000000)

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -12131,6 +12131,7 @@ classes:
       0x1409DD7A0: GetQuestBattleDirector
       0x1409DD7F0: GetGoldSaucerDirector
       0x1409E2840: GetEventHandlerById
+      0x1409E3D40: CheckInteractRange
       0x140B1F350: GetCurrentContentType
       0x140B1F420: GetCurrentContentId # static
       0x140B1F4A0: CanLeaveCurrentContent # static


### PR DESCRIPTION
added `GetPosition` method on GameObject, the address was already in data.yml

added `CheckInteractRange` on EventFramework, which calls GetPosition internally

the result of GetPosition is used for checking interact range as well as attack range. a value different from the Position field on the struct can be returned from the object's LayoutInstance or the DrawObject.