### PR TITLE
Obsolete GameMain.IsInSanctuary

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
@@ -47,7 +47,7 @@ public unsafe partial struct GameMain {
     public static partial bool IsInPvPInstance();
 
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 21 48 8B 4F 10")]
-    [Obsolete("Use TerritoryInfo.Instance()->InSanctuary instead.")]
+    [Obsolete("Use TerritoryInfo.Instance()->InSanctuary instead. See https://github.com/aers/FFXIVClientStructs/pull/1123 for more information.")]
     public static partial bool IsInSanctuary();
 
     [MemberFunction("E8 ?? ?? ?? ?? 41 83 7F ?? ?? 4C 8D 2D")]

--- a/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
@@ -47,6 +47,7 @@ public unsafe partial struct GameMain {
     public static partial bool IsInPvPInstance();
 
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 21 48 8B 4F 10")]
+    [Obsolete("Use TerritoryInfo.Instance()->InSanctuary instead.")]
     public static partial bool IsInSanctuary();
 
     [MemberFunction("E8 ?? ?? ?? ?? 41 83 7F ?? ?? 4C 8D 2D")]

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -148,9 +148,10 @@ functions:
   0x1400B7990: IsInEureka
   0x1400B7BA0: IsUnconscious
   0x1400B7BB0: IsRolePlaying
+  0x1400B7BC0: CanApplyGlamourPlates
+  0x1400B7D00: IsClassJobAJob       # static, (classJobId, ClassJobExd*?) -> bool
   0x1400B7D30: IsClassJobACrafter   # static, (classJobId) -> bool
   0x1400B7D40: IsClassJobAGatherer  # static, (classJobId) -> bool
-  0x1400B7D00: IsClassJobAJob       # static, (classJobId, ClassJobExd*?) -> bool
   0x1400B7ED0: GetClassJobParentId  # static, (classJobId, ClassJobExd*?) -> uint
   0x1400BB2A0: OpenWebURL
   0x140A00D30: IsGatheringTypeRare  # static, takes RowId of GatheringType
@@ -477,7 +478,6 @@ classes:
       0x1405E7420: SetActiveFestivals
       0x140AC7190: IsInPvPInstance
       0x140AC7240: IsInPvPArea
-      0x1400B7BC0: IsInSanctuary # static, more likely Client::UI::IsInSanctuary but it fits here just fine
       0x1405E42E0: GetEventGPoseController
   Client::Game::BGMSystem:
     instances:


### PR DESCRIPTION
While `GameMain.IsInSanctuary` is missing a parameter, the function is intended to check if Glamour Plates can be applied in the current territory. It contains a check whether the player has the general action "Cast Glamour" unlocked and is soley used in glamour-related code.

The games experience bar uses `TerritoryInfo.Instance()->InSanctuary` at the end of `AgentHUD.UpdateExp`, so I think we should use that too.

<details>
<summary>Decomp of GameMain.IsInSanctuary</summary>

```c
bool __fastcall Client::Game::GameMain_IsInSanctuary(bool checkCastGlamourUnlocked)
{
  Client::UI::UIModule *UIModule; // rax
  Client::UI::Info::InfoModule *v2; // rbx
  Client::Network::NetworkModuleProxy *NetworkModuleProxy; // rax
  char v4; // al
  bool result; // al

  result = 0;
  if ( !checkCastGlamourUnlocked
    || Client::Game::UI::UIState_IsUnlockLinkUnlocked(&g_Client::Game::UI::UIState_Instance, 15u) )
  {
    if ( g_Client::Game::GameMain_Instance.CurrentTerritoryIntendedUseRow )
    {
      if ( (g_Client::Game::GameMain_Instance.CurrentTerritoryIntendedUseRow->Unknown36_Unknown37_Unknown38_Unknown39_Unknown40 & 2) != 0 )
        return 1;
      UIModule = Client::System::Framework::Framework_GetUIModule(g_Client::System::Framework::Framework_InstancePointer2);
      if ( UIModule )
      {
        v2 = UIModule->GetInfoModule(UIModule);
        NetworkModuleProxy = Client::System::Framework::Framework_GetNetworkModuleProxy(g_Client::System::Framework::Framework_InstancePointer2);
        v4 = NetworkModuleProxy
           ? Client::Network::NetworkModuleProxy_IsInCrossWorldDuty(NetworkModuleProxy)
           : ((unsigned __int16)WORD2(*(_QWORD *)&v2->field_1C38) >> 8) & 1;
        if ( !v4 && g_Client::Game::UI::TerritoryInfo_Instance.InSanctuary )
          return 1;
      }
    }
  }
  return result;
}
```

</details>