### PR TITLE
Update LootItem

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Loot.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Loot.cs
@@ -20,25 +20,36 @@ public unsafe partial struct Loot {
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x40)]
-public unsafe struct LootItem {
+public struct LootItem {
     [FieldOffset(0x00)] public uint ChestObjectId;
     [FieldOffset(0x04)] public uint ChestItemIndex; // This loot item's index in the chest it came from
     [FieldOffset(0x08)] public uint ItemId;
     [FieldOffset(0x0C)] public ushort ItemCount;
+    [FieldOffset(0x0E), FixedSizeArray] internal FixedSizeArray2<LootItemMateria> _materia;
+    [FieldOffset(0x18), FixedSizeArray] internal FixedSizeArray2<byte> _glamourStainIds;
+
+    [FieldOffset(0x1C)] public uint GlamourItemId;
     [FieldOffset(0x20)] public RollState RollState;
     [FieldOffset(0x24)] public RollResult RollResult;
     [FieldOffset(0x28)] public uint RollValue;
     [FieldOffset(0x2C)] public float Time;
     [FieldOffset(0x30)] public float MaxTime;
+    
     [FieldOffset(0x38)] public LootMode LootMode;
 }
 
-public enum RollState {
-    UpToNeed = 0, //Can roll up to Need
-    UpToGreed = 1,//Can roll up to Gree
-    UpToPass = 2, //Can only pass
+[StructLayout(LayoutKind.Explicit, Size = 2)]
+public struct LootItemMateria {
+    [FieldOffset(0x00)] public byte MateriaId;
+    [FieldOffset(0x01)] public byte MateriaGrade;
+}
+
+public enum RollState { // TODO: underlying type should be byte
+    UpToNeed = 0, // Can roll up to Need
+    UpToGreed = 1,// Can roll up to Gree
+    UpToPass = 2, // Can only pass
     Rolled = 17,
-    Unavailable = 21, //Lootmaster undecided?
+    Unavailable = 21, // Lootmaster undecided?
     Unknown = 28, // Default value
 }
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
@@ -39,7 +39,7 @@ public unsafe partial struct AgentLobby {
     [FieldOffset(0x1128)] public uint DialogAddonId;
     [FieldOffset(0x112C)] public uint DialogAddonId2;
     [FieldOffset(0x1130)] public uint LobbyScreenTextAddonId;
-    // [FieldOffset(0x1134)] public uint LogoAddonId; // not used?
+    [FieldOffset(0x1134)] public uint LogoAddonId;
     [FieldOffset(0x1138)] public uint TitleDCWorldMapAddonId;
     [FieldOffset(0x113C)] public uint TitleMovieSelectorAddonId;
     [FieldOffset(0x1140)] public uint TitleGameVersionAddonId;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2086,6 +2086,13 @@ classes:
         base: Component::GUI::AtkModuleInterface::AtkEventInterface
     funcs:
       0x140B2F650: ctor # unused, inlined
+      0x140B30C50: GetItem
+      0x140B30DF0: SetSelectedIndex
+  Client::Game::UI::LootItem:
+    funcs:
+      0x140B2F220: ctor_FromData
+      0x140B2F2E0: ctor
+      0x140B2F330: GetMateria
   Client::Game::UI::GatheringNote:
     instances:
       - ea: 0x14276B7F0


### PR DESCRIPTION
The fields don't really make sense, but that's what xrefs led to.
Maybe these were added early into the games development. 🤷‍♂️

As reference:
```c
bool __fastcall sub_140B30220(
        Client::Game::UI::Loot *a1,
        unsigned int chestObjectId,
        unsigned int chestItemIndex,
        unsigned int itemId,
        unsigned __int16 itemCount,
        unsigned __int16 *materia,              // ptr to 5 entries of { byte MateriaId; byte MateriaGrade; }
        byte *glamourStainIds,                  // ptr to 2 bytes (stain ids)
        unsigned int glamourItemId,
        Client::Game::UI::RollState rollState,
        Client::Game::UI::RollResult rollResult,
        float time,
        float maxTime,
        byte rollValue,
        byte a14,
        Client::Game::UI::LootMode lootMode,
        int a16)
```

Also lil bit of formatting and snuck in AgentLobby.LogoAddonId.