### PR TITLE
Update RenderTargetManager, add GraphicsConfig

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Device.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Device.cs
@@ -40,7 +40,7 @@ public unsafe partial struct Device {
     [MemberFunction("E8 ?? ?? ?? ?? 49 89 45 48")]
     public partial ConstantBuffer* CreateConstantBuffer(int byteSize, uint flags, uint unk);
 
-    // TODO: use TextureFormat enum for textureFormat
+    // TODO: use TextureFormat enum for textureFormat API 12 spec
     [MemberFunction("E8 ?? ?? ?? ?? 48 89 07 48 8D 7F 20")]
     public partial Texture* CreateTexture2D(int* size, byte mipLevel, uint textureFormat, uint flags, uint unk);
 }

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Device.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Device.cs
@@ -40,6 +40,7 @@ public unsafe partial struct Device {
     [MemberFunction("E8 ?? ?? ?? ?? 49 89 45 48")]
     public partial ConstantBuffer* CreateConstantBuffer(int byteSize, uint flags, uint unk);
 
+    // TODO: use TextureFormat enum for textureFormat
     [MemberFunction("E8 ?? ?? ?? ?? 48 89 07 48 8D 7F 20")]
     public partial Texture* CreateTexture2D(int* size, byte mipLevel, uint textureFormat, uint flags, uint unk);
 }

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Texture.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Texture.cs
@@ -34,6 +34,7 @@ public unsafe partial struct Texture {
     [FieldOffset(0x68)] public void* D3D11Texture2D; // ID3D11Texture2D1
     [FieldOffset(0x70)] public void* D3D11ShaderResourceView; // ID3D11ShaderResourceView1
 
+    // TODO: use TextureFormat enum for textureFormat
     public static Texture* CreateTexture2D(int width, int height, byte mipLevel, uint textureFormat, uint flags, uint unk) {
         var size = stackalloc int[2];
         size[0] = width;
@@ -41,6 +42,7 @@ public unsafe partial struct Texture {
         return CreateTexture2D(size, mipLevel, textureFormat, flags, unk);
     }
 
+    // TODO: use TextureFormat enum for textureFormat
     public static Texture* CreateTexture2D(int* size, byte mipLevel, uint textureFormat, uint flags, uint unk)
         => Device.Instance()->CreateTexture2D(size, mipLevel, textureFormat, flags, unk);
 

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Texture.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Texture.cs
@@ -34,7 +34,7 @@ public unsafe partial struct Texture {
     [FieldOffset(0x68)] public void* D3D11Texture2D; // ID3D11Texture2D1
     [FieldOffset(0x70)] public void* D3D11ShaderResourceView; // ID3D11ShaderResourceView1
 
-    // TODO: use TextureFormat enum for textureFormat
+    // TODO: use TextureFormat enum for textureFormat API 12 spec
     public static Texture* CreateTexture2D(int width, int height, byte mipLevel, uint textureFormat, uint flags, uint unk) {
         var size = stackalloc int[2];
         size[0] = width;
@@ -42,7 +42,7 @@ public unsafe partial struct Texture {
         return CreateTexture2D(size, mipLevel, textureFormat, flags, unk);
     }
 
-    // TODO: use TextureFormat enum for textureFormat
+    // TODO: use TextureFormat enum for textureFormat API 12 spec
     public static Texture* CreateTexture2D(int* size, byte mipLevel, uint textureFormat, uint flags, uint unk)
         => Device.Instance()->CreateTexture2D(size, mipLevel, textureFormat, flags, unk);
 

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Render/GraphicsConfig.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Render/GraphicsConfig.cs
@@ -1,0 +1,61 @@
+namespace FFXIVClientStructs.FFXIV.Client.Graphics.Render;
+
+// Client::Graphics::Render::GraphicsConfig
+//   Client::Graphics::Singleton
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0xB8)]
+public unsafe partial struct GraphicsConfig {
+    [StaticAddress("48 8B 05 ?? ?? ?? ?? 0F B6 8B ?? ?? ?? ?? 88 48", 3, isPointer: true)]
+    public static partial GraphicsConfig* Instance();
+
+    [FieldOffset(0x08)] public uint UpdateFlags;
+    // most fields are named after the corresponding ConfigOption
+    [FieldOffset(0x0C)] public byte Gamma;
+
+    [FieldOffset(0x10)] public bool LodType;
+
+    [FieldOffset(0x12)] public bool ShadowLOD;
+    [FieldOffset(0x13)] public bool ShadowBgLOD;
+
+    [FieldOffset(0x17)] public bool ParallaxOcclusion;
+    [FieldOffset(0x18)] public bool Tessellation;
+
+    [FieldOffset(0x20)] public byte ReflectionType;
+    [FieldOffset(0x21)] public bool GlareRepresentation;
+    [FieldOffset(0x22)] public byte GrassQuality;
+    [FieldOffset(0x23)] public byte SSAO;
+    [FieldOffset(0x24)] public byte Glare;
+    [FieldOffset(0x25)] public bool GlareStrong; // Glare >= 2
+    [FieldOffset(0x26)] public bool DepthOfField;
+
+    [FieldOffset(0x28)] public bool RadialBlur;
+    [FieldOffset(0x29)] public bool Vignetting;
+
+    [FieldOffset(0x2C)] public uint AntiAliasing;
+    [FieldOffset(0x30)] public byte TextureFilterQuality;
+    [FieldOffset(0x31)] public byte TextureAnisotropicQuality;
+
+    [FieldOffset(0x33)] public bool TranslucentQuality;
+    [FieldOffset(0x34)] public byte ShadowVisibilityTypeFlags;
+    [FieldOffset(0x35)] public byte ShadowSoftShadowType;
+    [FieldOffset(0x36)] public byte ShadowTextureSizeType;
+    [FieldOffset(0x37)] public byte ShadowCascadeCountType;
+    [FieldOffset(0x39)] public byte TargetCircleType;
+    [FieldOffset(0x3A)] public byte TargetLineType;
+    [FieldOffset(0x3B)] public byte LinkLineType;
+
+    [FieldOffset(0x40)] public byte CharaLight;
+    [FieldOffset(0x41)] public byte ShadowLightValidType;
+
+    [FieldOffset(0x44)] public byte DynamicRezoEnable;
+
+    [FieldOffset(0x46)] public bool DynamicRezoEnableCutScene;
+
+    [FieldOffset(0x49)] public byte DynamicRezoThreshold;
+
+    [FieldOffset(0x4C)] public float GraphicsRezoScale;
+
+    [FieldOffset(0x54)] public byte GraphicsRezoUpscaleType;
+
+    [FieldOffset(0x56)] public bool GrassEnableDynamicInterference;
+}

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Render/OffscreenRenderingManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Render/OffscreenRenderingManager.cs
@@ -1,3 +1,6 @@
+using FFXIVClientStructs.FFXIV.Client.Graphics.Kernel;
+using FFXIVClientStructs.FFXIV.Client.System.Resource.Handle;
+
 namespace FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 
 // Client::Graphics::Render::OffscreenRenderingManager
@@ -6,4 +9,9 @@ namespace FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 [StructLayout(LayoutKind.Explicit, Size = 0x190)]
 public unsafe partial struct OffscreenRenderingManager {
     [FieldOffset(0xC8), FixedSizeArray] internal FixedSizeArray4<Pointer<Camera>> _cameras;
+
+    [FieldOffset(0x148)] public ShaderPackageResourceHandle* PrimitiveVSHandle;
+    [FieldOffset(0x150)] public ShaderPackageResourceHandle* PrimitivePSHandle;
+    [FieldOffset(0x158)] public ShaderPackage* PrimitiveVSPackage;
+    [FieldOffset(0x160)] public ShaderPackage* PrimitivePSPackage;
 }

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Render/RenderTargetManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Render/RenderTargetManager.cs
@@ -5,50 +5,181 @@ namespace FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 // Client::Graphics::Render::RenderTargetManager
 //   Client::Graphics::Singleton
 //   Client::Graphics::Kernel::Notifier
-// WARNING: THIS IS OUT OF DATE
 [GenerateInterop]
 [Inherits<Notifier>]
-[StructLayout(LayoutKind.Explicit, Size = 0x4A0)]
+[StructLayout(LayoutKind.Explicit, Size = 0x710)]
 public unsafe partial struct RenderTargetManager {
-
-    // the first 65 fields seem to be render target pointers
-    [FieldOffset(0x20), FixedSizeArray] internal FixedSizeArray64<Pointer<Texture>> _renderTargets;
-
-    // specific ones i can name
-    // offscreen renderer is used to render models for UI elements like the character window
-    [FieldOffset(0x1E0), CExportIgnore] public Texture* OffscreenRenderTarget_1;
-    [FieldOffset(0x1E8), CExportIgnore] public Texture* OffscreenRenderTarget_2;
-    [FieldOffset(0x1F0), CExportIgnore] public Texture* OffscreenRenderTarget_3;
-    [FieldOffset(0x1F8), CExportIgnore] public Texture* OffscreenRenderTarget_4;
-    [FieldOffset(0x200), CExportIgnore] public Texture* OffscreenGBuffer;
-    [FieldOffset(0x208), CExportIgnore] public Texture* OffscreenDepthStencil;
-
-    [FieldOffset(0x210), CExportIgnore]
-    public Texture* OffscreenRenderTarget_Unk1; // these are related to offscreen renderer due to their size
-
-    [FieldOffset(0x218), CExportIgnore] public Texture* OffscreenRenderTarget_Unk2;
-    [FieldOffset(0x220), CExportIgnore] public Texture* OffscreenRenderTarget_Unk3;
-
-    [FieldOffset(0x248)] public uint Resolution_Width;
-    [FieldOffset(0x24C)] public uint Resolution_Height;
-    [FieldOffset(0x250)] public uint ShadowMap_Width;
-    [FieldOffset(0x254)] public uint ShadowMap_Height;
-    [FieldOffset(0x258)] public uint NearShadowMap_Width;
-    [FieldOffset(0x25C)] public uint NearShadowMap_Height;
-    [FieldOffset(0x260)] public uint FarShadowMap_Width;
-    [FieldOffset(0x264)] public uint FarShadowMap_Height;
-    [FieldOffset(0x268)] public bool UnkBool_1;
-
-    [FieldOffset(0x270), FixedSizeArray] internal FixedSizeArray49<Pointer<Texture>> _renderTargets2;
-
-    [FieldOffset(0x470)] public ushort DynamicResolutionActualTargetHeight; // seems to copy TargetHeight into ActualTargetHeight?
-    [FieldOffset(0x472)] public ushort DynamicResolutionTargetHeight;
-    [FieldOffset(0x474)] public ushort DynamicResolutionMaximumHeight;
-    [FieldOffset(0x476)] public ushort DynamicResolutionMinimumHeight;
-
     [StaticAddress("48 8B 05 ?? ?? ?? ?? 48 8B 70 70 48 85 F6 74 09 48 8B 06 48 8B CE FF 50 10", 3, isPointer: true)]
     public static partial RenderTargetManager* Instance();
 
+    [FieldOffset(0x20), FixedSizeArray] internal FixedSizeArray5<Pointer<Texture>> _unk20;
+    [FieldOffset(0x48), FixedSizeArray] internal FixedSizeArray5<Pointer<Texture>> _unk48; // Light
+    [FieldOffset(0x70)] internal Texture* Unk70;
+    [FieldOffset(0x78)] internal Texture* Unk78; // depends on byte at GraphicsConfig+0x43
+    [FieldOffset(0x80)] internal Texture* Unk80;
+    [FieldOffset(0x88)] internal Texture* Unk88;
+    [FieldOffset(0x90)] internal Texture* Unk90;
+    [FieldOffset(0x98), FixedSizeArray] internal FixedSizeArray5<Pointer<Texture>> _unk98; // Hair
+    [FieldOffset(0xC0), FixedSizeArray] internal FixedSizeArray5<Pointer<Texture>> _unkC0;
+    [FieldOffset(0xE8)] internal Texture* UnkE8;
+    [FieldOffset(0xF0)] internal Texture* UnkF0; // null?
+    [FieldOffset(0xF8)] internal Texture* UnkF8; // null?
+    [FieldOffset(0x100)] internal Texture* Unk100;
+    [FieldOffset(0x108)] internal Texture* Unk108;
+    [FieldOffset(0x110)] internal Texture* Unk110;
+    [FieldOffset(0x118)] internal Texture* Unk118;
+    [FieldOffset(0x120)] internal Texture* Unk120;
+    [FieldOffset(0x128)] internal Texture* Unk128;
+    [FieldOffset(0x130)] internal Texture* Unk130;
+    [FieldOffset(0x138)] internal Texture* Unk138;
+    [FieldOffset(0x140)] internal Texture* Unk140;
+    [FieldOffset(0x148)] internal Texture* Unk148;
+    [FieldOffset(0x150)] internal Texture* Unk150; // null?
+    [FieldOffset(0x158)] internal Texture* Unk158;
+    [FieldOffset(0x160), FixedSizeArray] internal FixedSizeArray4<Pointer<Texture>> _unk160;
+    [FieldOffset(0x180)] internal Texture* Unk180;
+    [FieldOffset(0x188), FixedSizeArray] internal FixedSizeArray20<Pointer<Texture>> _unk188;
+    [FieldOffset(0x228)] internal Texture* Unk228;
+    [FieldOffset(0x230), FixedSizeArray] internal FixedSizeArray4<Pointer<Texture>> _unk230;
+    [FieldOffset(0x250)] internal Texture* Unk250;
+    [FieldOffset(0x258)] internal Texture* Unk258;
+    [FieldOffset(0x260)] internal Texture* Unk260;
+    [FieldOffset(0x268)] internal Texture* Unk268;
+    [FieldOffset(0x270)] internal Texture* Unk270;
+    [FieldOffset(0x278)] internal Texture* Unk278;
+    [FieldOffset(0x280)] internal Texture* Unk280;
+    [FieldOffset(0x288)] internal Texture* Unk288;
+    [FieldOffset(0x290)] internal Texture* Unk290;
+    [FieldOffset(0x298)] internal Texture* Unk298;
+    [FieldOffset(0x2A0), FixedSizeArray] internal FixedSizeArray3<Pointer<Texture>> _unk2A0;
+    [FieldOffset(0x2B8), FixedSizeArray] internal FixedSizeArray2<Pointer<Texture>> _unk2B8;
+    [FieldOffset(0x2C8)] internal Texture* Unk2C8;
+    /// <remarks> Use <see cref="GetCharaViewTexture(uint)"/> instead. </remarks>
+    [FieldOffset(0x2D0), FixedSizeArray] internal FixedSizeArray8<Pointer<Texture>> _charaViewTextures; // resulting image
+    // CharaView targets:
+    [FieldOffset(0x310)] internal Texture* Unk310;
+    [FieldOffset(0x318)] internal Texture* Unk318;
+    [FieldOffset(0x320)] internal Texture* Unk320;
+    [FieldOffset(0x328)] internal Texture* Unk328;
+    [FieldOffset(0x330)] internal Texture* Unk330;
+    [FieldOffset(0x338)] internal Texture* Unk338; // null?
+    [FieldOffset(0x340)] internal Texture* Unk340; // null?
+    [FieldOffset(0x348)] internal Texture* Unk348; // null?
+    [FieldOffset(0x350)] internal Texture* Unk350; // null?
+    [FieldOffset(0x358)] internal Texture* Unk358; // null?
+    [FieldOffset(0x360)] internal Texture* Unk360;
+    [FieldOffset(0x368)] internal Texture* Unk368;
+    [FieldOffset(0x370)] internal Texture* Unk370;
+    [FieldOffset(0x378)] internal Texture* Unk378; // temp target for ui when changing graphic settings
+    // CharaView hair targets:
+    [FieldOffset(0x380)] internal Texture* Unk380;
+    [FieldOffset(0x388)] internal Texture* Unk388;
+    [FieldOffset(0x390)] internal Texture* Unk390;
+    [FieldOffset(0x398)] internal Texture* Unk398; // null?
+    [FieldOffset(0x3A0)] internal Texture* Unk3A0; // null?
+    [FieldOffset(0x3A8)] internal Texture* Unk3A8; // null?
+    [FieldOffset(0x3B0)] internal Texture* Unk3B0; // null?
+    [FieldOffset(0x3B8)] internal Texture* Unk3B8; // null?
+    [FieldOffset(0x3C0)] internal Texture* Unk3C0; // null?
+    [FieldOffset(0x3C8)] internal Texture* Unk3C8; // null?
+    [FieldOffset(0x3D0)] internal Texture* Unk3D0;
+    [FieldOffset(0x3D8)] internal Texture* Unk3D8;
+    [FieldOffset(0x3E0)] internal Texture* Unk3E0;
+    [FieldOffset(0x3E8), FixedSizeArray] internal FixedSizeArray2<Pointer<Texture>> _unk3E8;
+    [FieldOffset(0x3F8), FixedSizeArray] internal FixedSizeArray2<Pointer<Texture>> _unk3F8;
+    [FieldOffset(0x408), FixedSizeArray] internal FixedSizeArray3<Pointer<Texture>> _unk408;
+    [FieldOffset(0x420)] internal Texture* Unk420;
+    [FieldOffset(0x428)] internal Texture* Unk428;
+    [FieldOffset(0x430)] public uint Resolution_Width;
+    [FieldOffset(0x434)] public uint Resolution_Height;
+    [FieldOffset(0x438)] public uint ShadowMap_Width;
+    [FieldOffset(0x43C)] public uint ShadowMap_Height;
+    [FieldOffset(0x440)] public uint NearShadowMap_Width;
+    [FieldOffset(0x444)] public uint NearShadowMap_Height;
+    [FieldOffset(0x448)] public uint FarShadowMap_Width;
+    [FieldOffset(0x44C)] public uint FarShadowMap_Height;
+    [FieldOffset(0x450)] public bool UnkBool_1;
+
+    [FieldOffset(0x4A8)] internal Texture* Unk4A8;
+    [FieldOffset(0x4B0)] internal Texture* Unk4B0;
+
+    [FieldOffset(0x4C0)] internal Texture* Unk4C0;
+    [FieldOffset(0x4C8)] internal Texture* Unk4C8;
+    [FieldOffset(0x4D0)] internal Texture* Unk4D0;
+    [FieldOffset(0x4D8)] internal Texture* Unk4D8;
+    [FieldOffset(0x4E0)] internal Texture* Unk4E0;
+    [FieldOffset(0x4E8)] internal Texture* Unk4E8;
+
+    [FieldOffset(0x528)] internal Texture* Unk528;
+    [FieldOffset(0x530)] internal Texture* Unk530;
+
+    [FieldOffset(0x540)] internal Texture* Unk540;
+    [FieldOffset(0x548)] internal Texture* Unk548;
+    [FieldOffset(0x550)] internal Texture* Unk550;
+    [FieldOffset(0x558)] internal Texture* Unk558;
+    [FieldOffset(0x560)] internal Texture* Unk560;
+    [FieldOffset(0x568)] internal Texture* Unk568;
+    [FieldOffset(0x570)] internal Texture* Unk570;
+    [FieldOffset(0x578)] internal Texture* Unk578; // apparently BackBuffer, see 48 89 87 ?? ?? ?? ?? 48 8B 47 ?? 48 89 87 ?? ?? ?? ?? 8B 06
+    [FieldOffset(0x580)] internal Texture* Unk580;
+    [FieldOffset(0x588)] internal Texture* Unk588;
+    [FieldOffset(0x590)] internal Texture* Unk590;
+    [FieldOffset(0x598)] internal Texture* Unk598;
+    [FieldOffset(0x5A0)] internal Texture* Unk5A0;
+    [FieldOffset(0x5A8)] internal Texture* Unk5A8;
+    [FieldOffset(0x5B0)] internal Texture* Unk5B0;
+    [FieldOffset(0x5B8)] internal Texture* Unk5B8;
+    [FieldOffset(0x5C0)] internal Texture* Unk5C0;
+    [FieldOffset(0x5C8)] internal Texture* Unk5C8;
+    [FieldOffset(0x5D0)] internal Texture* Unk5D0;
+    [FieldOffset(0x5D8)] internal Texture* Unk5D8;
+    [FieldOffset(0x5E0)] internal Texture* Unk5E0;
+    [FieldOffset(0x5E8)] internal Texture* Unk5E8;
+    [FieldOffset(0x5F0)] internal Texture* Unk5F0;
+    [FieldOffset(0x5F8)] internal Texture* Unk5F8;
+    [FieldOffset(0x600)] internal Texture* Unk600;
+    [FieldOffset(0x608)] internal Texture* Unk608;
+    [FieldOffset(0x610)] internal Texture* Unk610;
+    [FieldOffset(0x618)] internal Texture* Unk618;
+    [FieldOffset(0x620)] internal Texture* Unk620;
+    [FieldOffset(0x628)] internal Texture* Unk628;
+    [FieldOffset(0x630)] internal Texture* Unk630;
+    [FieldOffset(0x638)] internal Texture* Unk638;
+    [FieldOffset(0x640)] internal Texture* Unk640;
+    [FieldOffset(0x648)] internal Texture* Unk648;
+    [FieldOffset(0x650)] internal Texture* Unk650;
+    [FieldOffset(0x658)] internal Texture* Unk658;
+    [FieldOffset(0x660)] internal Texture* Unk660;
+    [FieldOffset(0x668)] internal Texture* Unk668;
+    [FieldOffset(0x670)] internal Texture* Unk670;
+    [FieldOffset(0x678)] internal nint Unk678;
+    [FieldOffset(0x680)] internal nint Unk680;
+    // bunch of floats
+    [FieldOffset(0x6E0)] public float FrametimeAverage;
+
+    [FieldOffset(0x6EC)] public float GraphicsRezoScale;
+
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 4F 30 48 8B D0 FF 57 38")]
     public partial Texture* GetCharaViewTexture(uint clientObjectIndex);
+
+    // obsoletes
+
+    // in array _charaViewTextures:
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal. Use GetCharaViewTexture instead.")][FieldOffset(0x1E0)] public Texture* OffscreenRenderTarget_1;
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal. Use GetCharaViewTexture instead.")][FieldOffset(0x1E8)] public Texture* OffscreenRenderTarget_2;
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal. Use GetCharaViewTexture instead.")][FieldOffset(0x1F0)] public Texture* OffscreenRenderTarget_3;
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal. Use GetCharaViewTexture instead.")][FieldOffset(0x1F8)] public Texture* OffscreenRenderTarget_4;
+    // stuff nobody needs:
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal.")][FieldOffset(0x20), FixedSizeArray] internal FixedSizeArray64<Pointer<Texture>> _renderTargets;
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal.")][FieldOffset(0x200)] public Texture* OffscreenGBuffer;
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal.")][FieldOffset(0x208)] public Texture* OffscreenDepthStencil;
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal.")][FieldOffset(0x210)] public Texture* OffscreenRenderTarget_Unk1;
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal.")][FieldOffset(0x218)] public Texture* OffscreenRenderTarget_Unk2;
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal.")][FieldOffset(0x220)] public Texture* OffscreenRenderTarget_Unk3;
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal.")][FieldOffset(0x270), FixedSizeArray] internal FixedSizeArray49<Pointer<Texture>> _renderTargets2;
+    // couldn't find these:
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal.")][FieldOffset(0x470)] public ushort DynamicResolutionActualTargetHeight; // seems to copy TargetHeight into ActualTargetHeight?
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal.")][FieldOffset(0x472)] public ushort DynamicResolutionTargetHeight;
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal.")][FieldOffset(0x474)] public ushort DynamicResolutionMaximumHeight;
+    [Obsolete("RenderTargetManager was not updated since Dawntrail release. This field is scheduled for removal.")][FieldOffset(0x476)] public ushort DynamicResolutionMinimumHeight;
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4943,6 +4943,7 @@ classes:
         base: Client::Graphics::Singleton
     funcs:
         0x140420620: ctor
+        0x14009E990: SetShadowVisibilityType
   Client::Graphics::Render::Camera:
     vtbls:
       - ea: 0x141EDA9C0
@@ -4989,6 +4990,7 @@ classes:
   Client::Graphics::Render::OffscreenRenderingManager:
     instances:
       - ea: 0x142729450
+        pointer: True
     vtbls:
       - ea: 0x141EDAC10
     funcs:
@@ -5107,6 +5109,7 @@ classes:
   Client::Graphics::Render::LightingManager:
     instances:
       - ea: 0x14258C5A8
+        pointer: True
     vtbls:
       - ea: 0x141EDB258
         base: Client::Graphics::Singleton
@@ -5123,8 +5126,8 @@ classes:
       - ea: 0x141EDB288
         base: Client::Graphics::Kernel::Notifier
     funcs:
-#fail       0x1403CDB40: ctor
-#fail       0x1403CD8E0: Initialize
+      0x14049B410: ctor
+      0x14049B7E0: Initialize
       0x14042CDB0: GetCharaViewTexture
   Client::Graphics::PostEffect::PostEffectChain:
     vtbls:


### PR DESCRIPTION
Preface: It's a bunch of nothing.

Wanted to check in on CharaView rendering again, but ended up just updating RenderTargetManager, which wasn't updated for Dawntrail. I tried to map fields, but sadly I lack the knowledge of graphics engine internals, which is why I couldn't name anything and simply set all unk fields to internal so they can at least be used with the structimporter. (Stupidly enough the generated FixedSizeArray Spans are public... not my fault.)
I couldn't find the DynamicResolution height fields - they probably were replaced by aspect ratio floats.

Also, I added the GraphicsConfig struct. Most fields are updated from ConfigOptions, which is where I got the names from (see `48 89 5C 24 ?? 48 89 74 24 ?? 57 48 81 EC 90 04 00 00`).