### PR TITLE
Add UIGlobals struct

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/GameMain.cs
@@ -47,7 +47,7 @@ public unsafe partial struct GameMain {
     public static partial bool IsInPvPInstance();
 
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 21 48 8B 4F 10")]
-    [Obsolete("Use TerritoryInfo.Instance()->InSanctuary instead. See https://github.com/aers/FFXIVClientStructs/pull/1123 for more information.")]
+    [Obsolete("Moved to UIGlobals.CanApplyGlamourPlates(), but you might want to just use TerritoryInfo.Instance()->InSanctuary instead. See https://github.com/aers/FFXIVClientStructs/pull/1123 for more information.")]
     public static partial bool IsInSanctuary();
 
     [MemberFunction("E8 ?? ?? ?? ?? 41 83 7F ?? ?? 4C 8D 2D")]

--- a/FFXIVClientStructs/FFXIV/Client/UI/UIGlobals.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIGlobals.cs
@@ -1,0 +1,54 @@
+namespace FFXIVClientStructs.FFXIV.Client.UI;
+
+/// <summary>
+/// This struct is a collection of static functions from the Client::UI namespace.
+/// </summary>
+[GenerateInterop]
+public unsafe partial struct UIGlobals {
+    /// <summary>
+    /// Determines whether the player can apply glamour plates in the current territory.
+    /// </summary>
+    /// <param name="checkCastGlamourUnlocked">
+    /// If <c>false</c>, skips the check for whether the player has unlocked the general action "Cast Glamour".
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if the player can apply glamour plates in the current territory; otherwise, <c>false</c>.
+    /// </returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 21 48 8B 4F 10")]
+    public static partial bool CanApplyGlamourPlates(bool checkCastGlamourUnlocked = true);
+
+    /// <summary>
+    /// Determines whether the exported gathering point type is of a timed node or not.
+    /// </summary>
+    /// <param name="gatheringPointType">
+    /// Value of field GatheringPointType of sheet ExportedGatheringPoint.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if it is a timed node; otherwise, <c>false</c>.
+    /// </returns>
+    /// <remarks>
+    /// If it is a timed node, the icon ID from the IconOff field in the GatheringType sheet should be used; otherwise, IconMain.
+    /// </remarks>
+    [MemberFunction("80 F9 07 77")]
+    public static partial bool IsExportedGatheringPointTimed(byte gatheringPointType);
+
+    /// <summary>
+    /// Determines whether the given string is a valid player character name.
+    /// </summary>
+    /// <param name="characterName">The character name of the player to validate.</param>
+    /// <returns>
+    /// <c>true</c> if the character name is valid; otherwise, <c>false</c>.
+    /// </returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 B4 4C 8B CB"), GenerateStringOverloads]
+    public static partial bool IsValidPlayerCharacterName(byte* characterName);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 63 45 80")]
+    public static partial void PlaySoundEffect(uint effectId, nint a2 = 0, nint a3 = 0, byte a4 = 0);
+
+    public static void PlayChatSoundEffect(uint effectId) {
+        if (effectId is < 1 or > 16)
+            throw new ArgumentException("Valid chat sfx values are 1 through 16.");
+
+        PlaySoundEffect(effectId + 36);
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
@@ -107,15 +107,18 @@ public unsafe partial struct UIModule {
     [FieldOffset(0xEDB88)] internal UIInputModule UIInputModule;
     // [FieldOffset(0xEDFE0)] internal Vf70Struct;
 
+    [Obsolete("Moved to UIGlobals.PlaySoundEffect")]
     [MemberFunction("E8 ?? ?? ?? ?? 48 63 45 80")]
     public static partial bool PlaySound(uint effectId, long a2 = 0, long a3 = 0, byte a4 = 0);
 
+    [Obsolete("Moved to UIGlobals.IsValidPlayerCharacterName")]
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 B4 4C 8B CB"), GenerateStringOverloads]
     public static partial bool IsPlayerCharacterName(byte* name);
 
     [MemberFunction("48 89 5C 24 ?? 57 48 83 EC 20 48 8B FA 48 8B D9 45 84 C9")]
     public static partial void ProcessChatBoxEntry(Utf8String* message, nint a4 = 0, bool saveToHistory = false);
 
+    [Obsolete("Moved to UIGlobals.PlayChatSoundEffect")]
     public static void PlayChatSoundEffect(uint effectId) {
         if (effectId is < 1 or > 16)
             throw new ArgumentException("Valid chat sfx values are 1 through 16.");

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -97,7 +97,7 @@ functions:
   0x1400681C0: GetMyDocumentsFolder #as UTF8String
   0x1400A55C0: GetPerformanceFrequency
   0x1400A6970: CreateDirectoryRecursive
-  0x1400B5FB0: Client::UI::IsPlayerCharacterName
+  0x1400B5FB0: Client::UI::IsValidPlayerCharacterName
   0x1400B6800: Client::UI::PlaySoundEffect # this is a static function in the UI namespace, arg1 is the SE
   0x1400B7F50: Client::UI::GetUIColor # (idx, &color, &edgeColor)
   0x1400B7F90: Client::UI::GetNumberAsBoxedChar # (uint) accepts numbers 0-30
@@ -154,7 +154,7 @@ functions:
   0x1400B7D40: IsClassJobAGatherer  # static, (classJobId) -> bool
   0x1400B7ED0: GetClassJobParentId  # static, (classJobId, ClassJobExd*?) -> uint
   0x1400BB2A0: OpenWebURL
-  0x140A00D30: IsGatheringTypeRare  # static, takes RowId of GatheringType
+  0x140A00D30: IsExportedGatheringPointTimed  # static, value of ExportedGatheringPoint.GatheringPointType
   0x140D02AE0: SetCondition
   0x140D03320: IsLocalPlayerLalafell
   0x140E5E5E0: CreateSelectYesno


### PR DESCRIPTION
This PR adds the `UIGlobals` struct, which serves as a central place for storing global static functions from the `Client::UI` namespace.

Some of these global functions were added to other structs in the past, which is why they have been moved to UIGlobals:
- `GameMain.IsInSanctuary`, moved as `CanApplyGlamourPlates` (see also: #1123)
- `UIModule.PlaySound`, moved as `PlaySoundEffect`
- `UIModule.IsPlayerCharacterName`, moved as `IsValidPlayerCharacterName`
- `UIModule.PlayChatSoundEffect`

The entries in the data.yml have also been renamed accordingly, though I did not add the namespace prefix if it was missing.

I've also added the `IsExportedGatheringPointTimed` function (formerly named IsGatheringTypeRare by me in the data.yml) to this struct (because I need it myself), and tried to add some xmldocs to these functions.

While I did not dig into the `PlaySoundEffect` function, which is why I didn't add a comment there, I changed the unknown argument types from `long` to `nint`, because from what I could see both are pointers: a2 is an out parameter for a string and a3 is an out parameter for some kind of instance of a sound effect struct. 🤷‍♂️

Since this is a new struct and the old functions have been obsoleted, there are no breaking changes in this PR.
Please let me know if I did something wrong.