### PR TITLE
Correction of ExcelModuleInterface

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/PronounModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/PronounModule.cs
@@ -2,8 +2,8 @@ using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Common.Component.Excel;
-using FFXIVClientStructs.FFXIV.Component.Excel;
 using FFXIVClientStructs.FFXIV.Component.Text;
+using ExcelModuleInterface = FFXIVClientStructs.FFXIV.Component.Excel.ExcelModuleInterface;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureLogModule.cs
@@ -1,9 +1,9 @@
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Common.Component.Excel;
-using FFXIVClientStructs.FFXIV.Component.Excel;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using FFXIVClientStructs.FFXIV.Component.Log;
+using ExcelModuleInterface = FFXIVClientStructs.FFXIV.Component.Excel.ExcelModuleInterface;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIModule.cs
@@ -3,11 +3,11 @@ using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Info;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using FFXIVClientStructs.FFXIV.Client.UI.Shell;
-using FFXIVClientStructs.FFXIV.Common.Component.Excel;
 using FFXIVClientStructs.FFXIV.Common.Configuration;
 using FFXIVClientStructs.FFXIV.Component.Completion;
 using FFXIVClientStructs.FFXIV.Component.Excel;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using ExcelModuleInterface = FFXIVClientStructs.FFXIV.Component.Excel.ExcelModuleInterface;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI;
 
@@ -29,7 +29,7 @@ public unsafe partial struct UIModule {
     [FieldOffset(0x7EC)] public int CrossWorldLinkshellCycle;
 
     [FieldOffset(0x7F4)] public uint FrameCount;
-    [FieldOffset(0x7F8)] internal ExcelModule* ExcelModule;
+    [FieldOffset(0x7F8)] internal ExcelModuleInterface* ExcelModuleInterface; // this is Component::Excel::ExcelModuleInterface, not Common::Component::Excel::ExcelModuleInterface!
     [FieldOffset(0x800)] internal RaptureTextModule RaptureTextModule;
     [FieldOffset(0x1660)] internal CompletionModule CompletionModule;
     [FieldOffset(0x19D8)] internal RaptureLogModule RaptureLogModule;

--- a/FFXIVClientStructs/FFXIV/Client/UI/UIModuleInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIModuleInterface.cs
@@ -11,7 +11,9 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 [GenerateInterop(isInherited: true)]
 [StructLayout(LayoutKind.Explicit, Size = 8)]
 public unsafe partial struct UIModuleInterface {
+    [Obsolete("Use GetExcelModuleInterface(). The interface is different from the actual ExcelModule class, so we're renaming it to avoid confusion.")]
     [VirtualFunction(5)] public partial ExcelModuleInterface* GetExcelModule();
+    [VirtualFunction(5)] public partial ExcelModuleInterface* GetExcelModuleInterface();
     [VirtualFunction(6)] public partial RaptureTextModule* GetRaptureTextModule();
     [VirtualFunction(7)] public partial RaptureAtkModule* GetRaptureAtkModule();
     [VirtualFunction(8)] internal partial RaptureAtkModule* GetRaptureAtkModule2();

--- a/FFXIVClientStructs/FFXIV/Common/Component/Excel/ExcelModule.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Component/Excel/ExcelModule.cs
@@ -1,15 +1,9 @@
 namespace FFXIVClientStructs.FFXIV.Common.Component.Excel;
 
 // Common::Component::Excel::ExcelModule
+//   Common::Component::Excel::ExcelModuleInterface
+//     Common::Component::Excel::ExcelResourceListener
 [GenerateInterop]
+[Inherits<ExcelModuleInterface>]
 [StructLayout(LayoutKind.Explicit, Size = 0x818)]
-public unsafe partial struct ExcelModule {
-    [VirtualFunction(1)]
-    public partial ExcelSheet* GetSheetByIndex(uint sheetIndex);
-
-    [VirtualFunction(2), GenerateStringOverloads]
-    public partial ExcelSheet* GetSheetByName(byte* sheetName);
-
-    [VirtualFunction(3), GenerateStringOverloads]
-    public partial void LoadSheet(byte* sheetName, byte a3 = 0, byte a4 = 0);
-}
+public partial struct ExcelModule;

--- a/FFXIVClientStructs/FFXIV/Common/Component/Excel/ExcelModuleInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Component/Excel/ExcelModuleInterface.cs
@@ -1,0 +1,30 @@
+namespace FFXIVClientStructs.FFXIV.Common.Component.Excel;
+
+// Common::Component::Excel::ExcelModuleInterface
+//   Common::Component::Excel::ExcelResourceListener
+[GenerateInterop(isInherited: true)]
+[StructLayout(LayoutKind.Explicit, Size = 0x08)]
+public unsafe partial struct ExcelModuleInterface {
+    [VirtualFunction(1)]
+    public partial ExcelSheet* GetSheetByIndex(uint sheetIndex);
+
+    [VirtualFunction(2), GenerateStringOverloads]
+    public partial ExcelSheet* GetSheetByName(byte* sheetName);
+
+    [VirtualFunction(3), GenerateStringOverloads]
+    public partial void LoadSheet(byte* sheetName, byte a3 = 0, byte a4 = 0);
+
+    [VirtualFunction(6)]
+    public partial ExcelLanguage GetLanguage();
+
+    public enum ExcelLanguage {
+        None,
+        Japanese,
+        English,
+        German,
+        French,
+        ChineseSimplified,
+        ChineseTraditional,
+        Korean
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Component/Excel/ExcelModuleInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Excel/ExcelModuleInterface.cs
@@ -14,4 +14,17 @@ public unsafe partial struct ExcelModuleInterface {
 
     [VirtualFunction(2), GenerateStringOverloads]
     public partial ExcelSheet* GetSheetByName(byte* sheetName);
+
+    [VirtualFunction(3)]
+    public partial ExcelLanguage* GetLanguage(); // returns a pointer to ExcelModule->GetLanguage() - 1
+
+    public enum ExcelLanguage {
+        Japanese,
+        English,
+        German,
+        French,
+        ChineseSimplified,
+        ChineseTraditional,
+        Korean
+    }
 }

--- a/FFXIVClientStructs/FFXIV/Component/Text/Localize.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Text/Localize.cs
@@ -1,6 +1,7 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Common.Component.Excel;
 using FFXIVClientStructs.FFXIV.Component.Excel;
+using ExcelModuleInterface = FFXIVClientStructs.FFXIV.Component.Excel.ExcelModuleInterface;
 
 namespace FFXIVClientStructs.FFXIV.Component.Text;
 


### PR DESCRIPTION
The internal field ExcelModule in UIModule was incorrect.
ExcelModule inherits from `Common::Component::Excel::ExcelModuleInterface`, but the field is storing a pointer to `Component::Excel::ExcelModuleInterface` (without the Common:: prefix). It's a different thing.

Changes:
- UIModule vf2 was renamed from `GetExcelModule` to `GetExcelModuleInterface`, though that is still confusing since there are 2 of those.
- The other ExcelModuleInterface (with Common prefix) was added as struct and ExcelModule now inherits from it.
- GetLanguage() vfuncs were added to both interfaces with their respective enums. (I'm not sure if the ExcelLanguage enum with the None value should be living somewhere else, like in ExdModule or ExcelSheet.)

The values for the ExcelLanguage enum were taken from Lumina:
https://github.com/NotAdam/Lumina/blob/master/src/Lumina/Data/Language.cs#L5
