### PR TITLE
Add LogoutCallbackInterface

### DIFF
--- a/FFXIVClientStructs/FFXIV/Application/Network/LogoutCallbackInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Application/Network/LogoutCallbackInterface.cs
@@ -1,0 +1,13 @@
+namespace FFXIVClientStructs.FFXIV.Application.Network;
+
+[GenerateInterop(isInherited: true)]
+[StructLayout(LayoutKind.Explicit, Size = 0x08)]
+public unsafe partial struct LogoutCallbackInterface {
+    [VirtualFunction(1)] public partial void OnLogout(LogoutParams* logoutParams);
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x08)]
+    public struct LogoutParams {
+        [FieldOffset(0x0)] public int Type; // 2 opens the Dialogue box
+        [FieldOffset(0x4)] public int Code; // 10000 for normal logout, 90002 for disconnect (lost connection)
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Application/Network/LogoutCallbackInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Application/Network/LogoutCallbackInterface.cs
@@ -1,6 +1,7 @@
 namespace FFXIVClientStructs.FFXIV.Application.Network;
 
 [GenerateInterop(isInherited: true)]
+[VirtualTable("48 8D 05 ?? ?? ?? ?? 66 89 69 ?? 48 89 41 ?? 48 8D 05", 3)]
 [StructLayout(LayoutKind.Explicit, Size = 0x08)]
 public unsafe partial struct LogoutCallbackInterface {
     [VirtualFunction(1)] public partial void OnLogout(LogoutParams* logoutParams);

--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/ShopEventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/ShopEventHandler.cs
@@ -103,6 +103,9 @@ public unsafe partial struct ShopEventHandler {
     [Inherits<AtkModuleInterface.AtkEventInterface>]
     [StructLayout(LayoutKind.Explicit, Size = 0x30)]
     public unsafe partial struct AgentProxy {
+        [StaticAddress("48 8D 15 ?? ?? ?? ?? 48 8B C8 E8 ?? ?? ?? ?? 45 33 C9", 3)]
+        public static partial AgentProxy* Instance();
+
         [FieldOffset(0x10)] public ShopEventHandler* Handler;
         [FieldOffset(0x18)] public uint AddonId;
     }

--- a/FFXIVClientStructs/FFXIV/Client/LayoutEngine/LayoutWorld.cs
+++ b/FFXIVClientStructs/FFXIV/Client/LayoutEngine/LayoutWorld.cs
@@ -29,7 +29,7 @@ public unsafe partial struct LayoutWorld {
     [FieldOffset(0x220)] public StdMap<Utf8String, Pointer<byte>>* RsvMap;
 
     [MemberFunction("E8 ?? ?? ?? ?? 45 33 F6 44 89 B7")]
-    public partial void UnloadPrefetchLayout();
+    public partial void UnloadPrefetchLayout(); // TODO: this should be static
 
     [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 8B 41 20"), GenerateStringOverloads]
     public partial void LoadPrefetchLayout(int type, byte* bgName, byte layerEntryType, uint levelId, uint territoryTypeId, GameMain* gameMain, uint cfcId);

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
@@ -1,3 +1,4 @@
+using FFXIVClientStructs.FFXIV.Application.Network;
 using FFXIVClientStructs.FFXIV.Application.Network.WorkDefinitions;
 using FFXIVClientStructs.FFXIV.Client.Network;
 using FFXIVClientStructs.FFXIV.Client.System.String;
@@ -12,7 +13,7 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 // ctor "E8 ?? ?? ?? ?? EB 03 48 8B C5 45 33 C9 48 89 47 20"
 [Agent(AgentId.Lobby)]
 [GenerateInterop]
-[Inherits<AgentInterface>]
+[Inherits<AgentInterface>, Inherits<LogoutCallbackInterface>(0x30)]
 [StructLayout(LayoutKind.Explicit, Size = 0x1E68)]
 [VirtualTable("48 8D 05 ?? ?? ?? ?? 48 89 69 ?? 48 89 01 4C 8B E1", 3)]
 public unsafe partial struct AgentLobby {
@@ -65,11 +66,15 @@ public unsafe partial struct AgentLobby {
 
     [FieldOffset(0x1198)] public ulong SelectedCharacterContentId;
 
+    [FieldOffset(0x11A3)] public bool LogoutShouldCloseGame;
+
     [FieldOffset(0x12A0)] public bool TemporaryLocked; // "Please wait and try logging in later."
 
     [FieldOffset(0x12B8)] public ulong RequestContentId;
 
     [FieldOffset(0x1E14)] public bool HasShownCharacterNotFound; // "The character you last logged out with in this play environment could not be found on the current data center."
+
+    [FieldOffset(0x12D8)] public LogoutCallbackInterface.LogoutParams LogoutParams;
 
     // TODO: everything below here is wrong
 
@@ -89,6 +94,9 @@ public unsafe partial struct AgentLobby {
 
     [MemberFunction("E8 ?? ?? ?? ?? C6 87 ?? ?? ?? ?? ?? 66 C7 87 ?? ?? ?? ?? ?? ??")]
     public partial void OpenLoginWaitDialog(int position);
+
+    [MemberFunction("40 56 41 56 41 57 48 83 EC 40 80 B9")]
+    public partial void HandleLogout(bool isExiting, byte a3); // a3 is some kind of frame-based countdown for the lobby
 }
 
 [GenerateInterop]

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkMessageBoxManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkMessageBoxManager.cs
@@ -1,0 +1,18 @@
+using FFXIVClientStructs.FFXIV.Common.Component.Excel;
+
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
+
+// Component::GUI::AtkMessageBoxManager
+//   Common::Component::Excel::ExcelSheetWaiter
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0x90)]
+public unsafe partial struct AtkMessageBoxManager {
+    [FieldOffset(0x60)] public ExcelSheet* ErrorSheet;
+    [FieldOffset(0x68)] public byte* OkText;
+    [FieldOffset(0x70)] public byte* CancelText;
+    [FieldOffset(0x78)] public byte* YesText;
+    [FieldOffset(0x80)] public byte* NoText;
+    [FieldOffset(0x88)] public byte Unk88;
+    [FieldOffset(0x89)] public byte Unk89;
+    [FieldOffset(0x8A)] public byte Unk8A;
+}

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkModule.cs
@@ -32,6 +32,7 @@ public unsafe partial struct AtkModule {
     [FieldOffset(0x7280)] internal StdVector<nint> CallbackHandlerFunctions;
     //[FieldOffset(0x72A0)] internal StdMap<?,?> AgentAddonMapping; // maybe?
 
+    [FieldOffset(0x72B0)] public AtkMessageBoxManager* AtkMessageBoxManager;
     [FieldOffset(0x72B8)] public TextService TextService;
     [FieldOffset(0x72E8)] public AtkTextInput TextInput;
     [FieldOffset(0x7FA8)] internal Utf8String Unk7FA8;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1,6 +1,11 @@
 version: 2024.08.21.0000.0000
 
 globals:
+  0x141E98A7C: g_FloatHalf # 0.5f
+  0x141E98A94: g_FloatOne # 1f
+  0x141E98A98: g_FloatOneAndAHalf # 1.5f
+  0x141E98A9C: g_FloatSix # 6f
+  0x141E98AA0: g_FloatTwenty # 20f
   0x141E99B6C: g_ConfigFileName
   0x141EA5DF0: g_UIColorTable
   0x141EF5330: g_HUDScaleTable
@@ -70,7 +75,8 @@ globals:
   0x14256FD30: g_OodleDelete
   0x14256FD40: g_OodlePrintf
   0x14272CB08: g_MacroTime
-  0x142BE6868: g_SQEX::CDev::Engine::Sd::Driver::SoundDriver
+  0x142791070: g_LogoutCountdownAddonId
+  0x142791076: g_LogoutShouldCloseGame
   0x142BE6900: ?hkaSkeletonMapperClass@@3VhkClass@@B
   0x142BE6980: ?hkaAnimationContainerClass@@3VhkClass@@B
   0x142BE79E0: ?hkReferencedObjectClass@@3VhkClass@@B
@@ -3713,6 +3719,8 @@ classes:
       0x1400F2360: IsUIVisible
       0x140686F20: DecRefNumberArrayData
       0x140686F80: DecRefStringArrayData
+      0x140687AF0: SetupAtkMessageBoxManager
+      0x140687C30: SetAtkMessageBoxManagerTexts
       0x14068B3C0: GetAtkFontCodeModule
   Client::UI::ExdSheetWaiter:
     vtbls:
@@ -4721,6 +4729,7 @@ classes:
         base: Client::UI::Agent::AgentInterface
     funcs:
       0x1402CAD30: ctor
+      0x1402CD260: HandleLogout
 #fail      0x140B14D50: Finalize
       0x1402D1010: UpdateLobbyUIStage
       0x1402D1EB0: UpdateCharaSelectDisplay
@@ -16467,6 +16476,9 @@ classes:
     vtbls:
       - ea: 0x14227AF90
         base: SQEX::CDev::Engine::Sd::Driver::ISoundDriver
+    instances:
+      - ea: 0x142BE6868
+        pointer: True
   SQEX::CDev::Engine::Sd::Driver::ToolBankController:
     vtbls:
       - ea: 0x14227B1E0


### PR DESCRIPTION
- When Logout or Exit Game is clicked in the system menu, both end up in `AgentLobby.HandleLogout` (after the countdown is over, if there is one).
- When the server closes the connection, or the game loses connection, `LogoutCallbackInterface.OnLogout` is fired with the error code.