### PR TITLE
Update InfoProxyBlacklist

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyBlacklist.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyBlacklist.cs
@@ -17,10 +17,29 @@ public unsafe partial struct InfoProxyBlacklist {
     [FieldOffset(0x13B8)] public StdMap<ulong, int> AccountIdMap;
     [FieldOffset(0x13C8)] public StdMap<ulong, int> ContentIdMap;
 
+    [MemberFunction("48 89 5C 24 ?? 4C 8B 91 ?? ?? ?? ?? 33 C0")]
+    public partial void GetBlockResult(BlockResult* outBlockResult, ulong accountId, ulong contentId);
+
+    [MemberFunction("48 83 EC 48 F6 81 ?? ?? ?? ?? ?? 75 ?? 33 C0 48 83 C4 48")]
+    public partial BlockResultType GetBlockResultType(ulong accountId, ulong contentId);
+
     [StructLayout(LayoutKind.Explicit, Size = 0x18)]
     public struct BlockedCharacter {
         [FieldOffset(0x0)] public byte* Name;
         [FieldOffset(0x8)] public ulong Id; // accountId for new, contentId for old
         [FieldOffset(0x10)] public byte Flag;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x14)]
+    public struct BlockResult {
+        [FieldOffset(0x0)] public BlockResultType Type;
+        [FieldOffset(0x8)] public BlockedCharacter* BlockedCharacterPtr;
+        [FieldOffset(0x10)] public int BlockedCharacterIndex;
+    }
+
+    public enum BlockResultType {
+        NotBlocked = 1,
+        BlockedByAccountId = 2,
+        BlockedByContentId = 3,
     }
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5,6 +5,7 @@ globals:
   0x141EA5DF0: g_UIColorTable
   0x141EF5330: g_HUDScaleTable
   0x142540380: g_ClientInstanceLimit
+  0x142540390: g_EmptyUtf8String # empty Utf8String with just the null terminator
   0x142540400: g_WindowStyle
   0x142541468: g_FPS
   0x142547308: g_LanguageCharArr # byte[] no pointer
@@ -7509,6 +7510,16 @@ classes:
         base: Component::Prohibit::ProhibitModuleInterface
     funcs:
       0x140935430: ctor
+  Client::System::BlacklistManager: # real name is unknown
+    instances:
+      - ea: 0x14258E230
+    vtbls:
+      - ea: 0x141F1F4B0 # maybe platform-specific implementation?
+    funcs:
+      0x140936460: GetBlockResultType
+      0x1409364D0: IsCharacterBlocked
+      0x140936630: GetReplacementName # returns a Utf8String* to the set name that should be displayed instead of the character name
+      0x140936BE0: GetUnknownName # returns a Utf8String* to "Unknown"
   Client::UI::Misc::RaptureHotbarModule:
     vtbls:
       - ea: 0x141F0C360
@@ -8065,7 +8076,7 @@ classes:
       # 0x141313710: ctor # inlined at 0x1408CF5C4
       0x1408A7570: GetCompanionDataID
       0x1408A73B0: SetupCompanion
-  Client::Game::Character::BlacklistProxyContainer: # actually no clue
+  Client::Game::Character::BlacklistProxyContainer: # real name is unknown, probably has nothing to do with blacklist
     vtbls:
       - ea: 0x141F100E0
         base: Client::Game::Character::ContainerInterface

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -3830,6 +3830,8 @@ classes:
         base: Client::UI::Info::InfoProxyPageInterface
     funcs:
       0x1400C39C0: ctor
+      0x1400C56A0: GetBlockResult
+      0x1400C4B10: GetBlockResultType
   Client::UI::Info::InfoProxyDetail:
     vtbls:
       - ea: 0x141EA7460


### PR DESCRIPTION
Adds functions that make it easier to check if a character is blocked.

Regarding data.yml:
Not sure about the name `Client::System::BlacklistManager`. It comes after the ProhibitModule, so it might be a Component instead. It seems to be a proxy for the info proxy blacklist, so it might be platform-specific? Also it seems to be possible to save 23 character name renames. Kinda weird.