### PR TITLE
Rename AtkValue type Texture to Pointer

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkValue.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkValue.cs
@@ -18,7 +18,9 @@ public enum ValueType {
     WideString = 0x9, // 2 bytes per character (UTF-16)
     String8 = 0xA, // assumed to be a const char*
     Vector = 0xB,
+    [Obsolete("Renamed to Pointer")]
     Texture = 0xC,
+    Pointer = 0xC,
     AtkValues = 0xD,
 
     TypeMask = 0xF,
@@ -44,7 +46,9 @@ public unsafe partial struct AtkValue : ICreatable, IDisposable {
     [FieldOffset(0x8), CExporterUnion("Value")] public byte* String;
     [FieldOffset(0x8), CExporterUnion("Value")] public char* WideString; // C# uses UTF-16 for char, which makes it easy for us to use it here
     [FieldOffset(0x8), CExporterUnion("Value")] public StdVector<AtkValue>* Vector;
+    [Obsolete("Renamed to Pointer")]
     [FieldOffset(0x8), CExporterUnion("Value")] public Texture* Texture;
+    [FieldOffset(0x8), CExporterUnion("Value")] public void* Pointer;
     [FieldOffset(0x8), CExporterUnion("Value")] public AtkValue* AtkValues;
 
     public AtkValue() => Ctor();
@@ -165,7 +169,7 @@ public unsafe partial struct AtkValue : ICreatable, IDisposable {
             ValueType.WideString => Marshal.PtrToStringUni((nint)WideString) ?? string.Empty,
             ValueType.String8 => Marshal.PtrToStringUTF8((nint)String) ?? string.Empty,
             ValueType.Vector or ValueType.ManagedVector => Vector != null ? Vector->ToString() : "null",
-            ValueType.Texture => $"0x{(nint)Texture:X}",
+            ValueType.Pointer => $"0x{(nint)Pointer:X}",
             ValueType.AtkValues => $"0x{(nint)AtkValues:X}",
             _ => BitConverter.ToString(BitConverter.GetBytes((ulong)String)).Replace("-", " ")
         };


### PR DESCRIPTION
The type 0xC is used in `Component::GUI::AtkModule_PlaySoundEffectHandler`, which makes them a general pointer type now.