### PR TITLE
Add RaptureAtkModule.OpenMapWithMapLink

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
@@ -88,6 +88,9 @@ public unsafe partial struct RaptureAtkModule {
     [VirtualFunction(58)]
     public partial void Update(float delta);
 
+    [VirtualFunction(63), GenerateStringOverloads]
+    public partial bool OpenMapWithMapLink(byte* mapLink);
+
     public bool IsUiVisible {
         get => !RaptureAtkUnitManager.AtkUnitManager.Flags.HasFlag(AtkUnitManagerFlags.UiHidden);
         set => SetUiVisibility(value);


### PR DESCRIPTION
Used by GameGui in Dalamud.

Can replace https://github.com/goatcorp/Dalamud/blob/fea5b3b563ba9b42b6d03881ac27d6c95ef75800/Dalamud/Game/Gui/GameGui.cs#L139-L166
with 
```cs
public unsafe bool OpenMapWithMapLink(MapLinkPayload mapLink)
{
    return RaptureAtkModule.Instance()->OpenMapWithMapLink(mapLink.DataString);
}
```