### PR TITLE
AtkEvent system changes

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkEventDispatcher.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkEventDispatcher.cs
@@ -1,14 +1,27 @@
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
+// Component::GUI::AtkEventDispatcher
+[GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x28)]
 public unsafe partial struct AtkEventDispatcher {
     [FieldOffset(0)] public AtkEventManager* AtkEventManager;
     [FieldOffset(0x8)] public StdVector<Pointer<AtkEvent>> Events;
-    // [FieldOffset(0x20)] public byte Unk20;
+    [FieldOffset(0x20)] public byte Unk20;
 
-    // [MemberFunction("E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 4C 8B 74 24")]
-    // public partial void DispatchEvent(nint a2);
+    /// <returns>A bool indicating if the event was handled.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 4C 8B 74 24")]
+    public partial bool DispatchEvent(Event* evt);
 
-    // [MemberFunction("E8 ?? ?? ?? ?? 48 8B 5B 20 41 B2 01")]
-    // public partial void RemoveEvent(nint a2);
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 5B 20 41 B2 01")]
+    public partial void RemoveEvent(AtkEvent* atkEvent);
+
+    // Component::GUI::AtkEventDispatcher::Event
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 0x30)]
+    public partial struct Event {
+        [FieldOffset(0x0)] public AtkEventState State;
+        // AtkEventState.UnkFlags1 are saved in this field (as uint), whenever AtkEventStateFlags.Unk4 is set.
+        [FieldOffset(0x4)] public uint UnkFlags;
+        [FieldOffset(0x8)] public AtkEventData EventData;
+    }
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkEventManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkEventManager.cs
@@ -7,8 +7,8 @@ public unsafe partial struct AtkEventManager {
     [FieldOffset(0x0)] public AtkEvent* Event; // linked list of events using AtkEvent->NextEvent
 
     [MemberFunction("E8 ?? ?? ?? ?? F6 45 0C 20 75 22")]
-    public partial void RegisterEvent(AtkEventType eventType, uint eventParam, AtkResNode* nodeParam, AtkEventTarget* target, AtkEventListener* listener, bool systemEvent);
+    public partial AtkEvent* RegisterEvent(AtkEventType eventType, uint eventParam, AtkResNode* nodeParam, AtkEventTarget* target, AtkEventListener* listener, bool systemEvent);
 
     [MemberFunction("E8 ?? ?? ?? ?? F6 43 0C 20")]
-    public partial void UnregisterEvent(AtkEventType eventType, uint eventParam, AtkEventListener* listener, bool systemEvent);
+    public partial bool UnregisterEvent(AtkEventType eventType, uint eventParam, AtkEventListener* listener, bool systemEvent);
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkSimpleTween.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkSimpleTween.cs
@@ -43,10 +43,10 @@ public unsafe partial struct AtkSimpleTween : ICreatable {
     /// Only <see cref="AtkEventType.TweenProgress"/> and <see cref="AtkEventType.TweenComplete"/> will be dispatched.
     /// </remarks>
     [MemberFunction("48 83 EC 48 0F B6 44 24 ?? 4C 8B D1")]
-    public partial void RegisterEvent(AtkEventType eventType, uint eventParam, AtkEventListener* listener, AtkResNode* nodeParam, bool systemEvent);
+    public partial AtkValue* RegisterEvent(AtkEventType eventType, uint eventParam, AtkEventListener* listener, AtkResNode* nodeParam, bool systemEvent);
 
     [MemberFunction("0F B6 44 24 ?? 48 83 C1 40")]
-    public partial void UnregisterEvent(AtkEventType eventType, uint eventParam, AtkEventListener* listener, bool systemEvent);
+    public partial bool UnregisterEvent(AtkEventType eventType, uint eventParam, AtkEventListener* listener, bool systemEvent);
 
     [MemberFunction("48 83 EC 28 0F 57 C0 83 FA 08")]
     public partial float GetNodeValue(SimpleTweenValueType type);

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5782,6 +5782,8 @@ classes:
     funcs:
       0x1406210A0: ctor
       0x1406210E0: Finalize
+      0x1406212E0: Stop
+      0x1406212F0: StopAndReset
 #fail       0x140510930: Update
   Component::GUI::AtkGroupManager:
     vtbls:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1728,6 +1728,9 @@ classes:
     funcs:
       0x140620B90: DispatchEvent
       0x140621000: RemoveEvent
+  Component::GUI::AtkEventDispatcher::Event:
+    funcs:
+      0x140620190: ctor
   Component::GUI::AtkTooltipArgs:
     funcs:
       0x140622AC0: ctor


### PR DESCRIPTION
Lost track multiple times, so I'm not sure about the AtkEventStateFlags anymore.

By the way, it's correct, that ReceiveEvent is passed a word. The game uses the first 2 bytes of AtkEventState and masks it with 0xFF before passing it. Since it doesn't change anything for us, it can stay AtkEventType.