### PR TITLE
Add LinkData (for AtkTextNode/AtkEventData)

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/LogViewer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/LogViewer.cs
@@ -31,4 +31,7 @@ public unsafe partial struct LogViewer {
     [FieldOffset(0xD9)] public byte IsScrolledBottom;
 
     [FieldOffset(0xF9)] public byte IsContextMenuShown;
+
+    [MemberFunction("48 85 D2 0F 84 ?? ?? ?? ?? 4C 8B DC 55 56 41 55 49 8D AB")]
+    public partial void HandleLinkClick(LinkData* linkData);
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkEventData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkEventData.cs
@@ -2,8 +2,9 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
 [CExporterStructUnion]
 [StructLayout(LayoutKind.Explicit, Size = 0x28)]
-public partial struct AtkEventData {
+public unsafe partial struct AtkEventData {
     [FieldOffset(0x00)] public AtkListItemData ListItemData;
+    [FieldOffset(0x00)] public LinkData* LinkData;
 }
 
 public partial struct AtkEventData {

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
@@ -143,12 +143,12 @@ public unsafe struct LinkData {
     [FieldOffset(0x1E)] public ushort Unk1E;
     [FieldOffset(0x20)] public uint Unk20;
     // These are the 3 link payload parameters. Usually SeStrings have int expressions.
-    [FieldOffset(0x24)] public int IntValue1;
-    [FieldOffset(0x24), CExportIgnore] public uint UIntValue1;
-    [FieldOffset(0x28)] public int IntValue2;
-    [FieldOffset(0x28), CExportIgnore] public uint UIntValue2;
-    [FieldOffset(0x2C)] public int IntValue3;
-    [FieldOffset(0x2C), CExportIgnore] public uint UIntValue3;
+    [FieldOffset(0x24), CExporterUnion("Value1")] public int IntValue1;
+    [FieldOffset(0x24), CExporterUnion("Value1")] public uint UIntValue1;
+    [FieldOffset(0x28), CExporterUnion("Value2")] public int IntValue2;
+    [FieldOffset(0x28), CExporterUnion("Value2")] public uint UIntValue2;
+    [FieldOffset(0x2C), CExporterUnion("Value3")] public int IntValue3;
+    [FieldOffset(0x2C), CExporterUnion("Value3")] public uint UIntValue3;
     [FieldOffset(0x30)] public ulong UnkAndBackgroundColor;
 
     // length from the start of the text in AtkTextNode or so. not sure

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
@@ -135,8 +135,9 @@ public unsafe struct LinkData {
     [FieldOffset(0x0C)] public int UnkC;
     /// <remarks> To be read until link terminator. </remarks>
     [FieldOffset(0x10)] public byte* Payload;
-    /// <remarks> First 3 bytes are PayloadEnd(?) and last byte is <see cref="LinkType"/> </remarks>
-    [FieldOffset(0x18), CExportIgnore] public uint PayloadEndAndLinkType;
+    /// <remarks> Length from the start of the text in the AtkTextNode. </remarks>
+    [FieldOffset(0x18)] public ushort PayloadEnd;
+
     /// <remarks> The type of the Link payload. See LinkMacroPayloadType in Lumina. </remarks>
     [FieldOffset(0x1B)] public byte LinkType;
     [FieldOffset(0x1C)] public ushort Unk1C;
@@ -149,10 +150,7 @@ public unsafe struct LinkData {
     [FieldOffset(0x28), CExporterUnion("Value2")] public uint UIntValue2;
     [FieldOffset(0x2C), CExporterUnion("Value3")] public int IntValue3;
     [FieldOffset(0x2C), CExporterUnion("Value3")] public uint UIntValue3;
-    [FieldOffset(0x30)] public ulong UnkAndBackgroundColor;
+    [FieldOffset(0x30)] public uint LinkColor;
 
-    // length from the start of the text in AtkTextNode or so. not sure
-    // public uint PayloadEnd => PayloadEndAndLinkType & 0xFFFFFF;
-
-    public uint BackgroundColor => (uint)(UnkAndBackgroundColor & 0xFFFFFF | 0x40000000);
+    public uint BackgroundColor => (uint)(LinkColor & 0xFFFFFF | 0x40000000);
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
@@ -22,9 +22,7 @@ public unsafe partial struct AtkTextNode : ICreatable {
     [FieldOffset(0xBC)] public ByteColor BackgroundColor;
     [FieldOffset(0xC0)] public Utf8String NodeText; // stores a copy of OriginalTextPointer
     [FieldOffset(0x128)] public byte* OriginalTextPointer; // set to the original argument of SetText even though the string is copied to the node
-
-    [FieldOffset(0x130)] public void* UnkPtr_1;
-
+    [FieldOffset(0x130)] public StdList<Pointer<LinkData>>* LinkData;
     // if text is "asdf" and you selected "sd" this is 2, 3
     [FieldOffset(0x138)] public uint SelectStart;
     [FieldOffset(0x13C)] public uint SelectEnd;
@@ -127,4 +125,30 @@ public enum FontType : byte {
     TrumpGothic = 0x3,
     Jupiter = 0x4,
     JupiterLarge = 0x5,
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x38)]
+public unsafe struct LinkData {
+    [FieldOffset(0x00)] public int Unk0;
+    [FieldOffset(0x04)] public int Unk4;
+    [FieldOffset(0x08)] public int Unk8;
+    [FieldOffset(0x0C)] public int UnkC;
+    /// <remarks> To be read until link terminator. </remarks>
+    [FieldOffset(0x10)] public byte* Payload;
+    /// <remarks> First 3 bytes are PayloadEnd(?) and last byte is <see cref="LinkType"/> </remarks>
+    [FieldOffset(0x18), CExportIgnore] public uint PayloadEndAndLinkType;
+    /// <remarks> The type of the Link payload. See LinkMacroPayloadType in Lumina. </remarks>
+    [FieldOffset(0x1B)] public byte LinkType;
+    [FieldOffset(0x1C)] public ushort Unk1C;
+    [FieldOffset(0x1E)] public ushort Unk1E;
+    [FieldOffset(0x20)] public uint Unk20;
+    [FieldOffset(0x24)] public uint UIntValue1;
+    [FieldOffset(0x28)] public uint UIntValue2;
+    [FieldOffset(0x2C)] public uint UIntValue3;
+    [FieldOffset(0x30)] public ulong UnkAndBackgroundColor;
+
+    // length from the start of the text in AtkTextNode or so. not sure
+    // public uint PayloadEnd => PayloadEndAndLinkType & 0xFFFFFF;
+
+    public uint BackgroundColor => (uint)(UnkAndBackgroundColor & 0xFFFFFF | 0x40000000);
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
@@ -129,10 +129,10 @@ public enum FontType : byte {
 
 [StructLayout(LayoutKind.Explicit, Size = 0x38)]
 public unsafe struct LinkData {
-    [FieldOffset(0x00)] public int Unk0;
-    [FieldOffset(0x04)] public int Unk4;
-    [FieldOffset(0x08)] public int Unk8;
-    [FieldOffset(0x0C)] public int UnkC;
+    [FieldOffset(0x00)] public int MinX;
+    [FieldOffset(0x04)] public int MinY;
+    [FieldOffset(0x08)] public int MaxX;
+    [FieldOffset(0x0C)] public int MaxY;
     /// <remarks> To be read until link terminator. </remarks>
     [FieldOffset(0x10)] public byte* Payload;
     /// <remarks> Length from the start of the text in the AtkTextNode. </remarks>

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
@@ -142,9 +142,13 @@ public unsafe struct LinkData {
     [FieldOffset(0x1C)] public ushort Unk1C;
     [FieldOffset(0x1E)] public ushort Unk1E;
     [FieldOffset(0x20)] public uint Unk20;
-    [FieldOffset(0x24)] public uint UIntValue1;
-    [FieldOffset(0x28)] public uint UIntValue2;
-    [FieldOffset(0x2C)] public uint UIntValue3;
+    // These are the 3 link payload parameters. Usually SeStrings have int expressions.
+    [FieldOffset(0x24)] public int IntValue1;
+    [FieldOffset(0x24), CExportIgnore] public uint UIntValue1;
+    [FieldOffset(0x28)] public int IntValue2;
+    [FieldOffset(0x28), CExportIgnore] public uint UIntValue2;
+    [FieldOffset(0x2C)] public int IntValue3;
+    [FieldOffset(0x2C), CExportIgnore] public uint UIntValue3;
     [FieldOffset(0x30)] public ulong UnkAndBackgroundColor;
 
     // length from the start of the text in AtkTextNode or so. not sure

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -6383,6 +6383,7 @@ classes:
       0x14068B400: IsTextInputActive
       0x14068B280: SetUIScene
       0x1400D8C70: PlaySoundEffectHandler
+      0x1406895B0: OpenMapWithMapLinkHandler
       0x1400DAB10: ScdResourceHandler
   Component::GUI::AtkComponentCheckBox:
     vtbls:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -13713,6 +13713,7 @@ classes:
     funcs:
       0x140FC4650: ctor
       0x140FC4CF0: OnRequestedUpdate
+      0x140FC5BC0: HandleLinkClick
   Client::UI::TabController:
     vtbls:
       - ea: 0x141F770E8


### PR DESCRIPTION
Unsure how this all fits together. There is a lot of font stuff involved (to calculate text positions?).

Also, I didn't know how to properly map PayloadEndAndLinkType, so I added CExportIgnoreAttribute to it.
- At `41 8B 4C 24 ?? 41 8B 5C 24` it uses a bitshift to get the payload length:
  `v5 = (int)(*(_DWORD *)&v2->PayloadEndAndLinkMacroPayloadType << 8) >> 8;`
- At other places (e.g. `41 0F BE 7D ?? 83 FF 03`) it gets the `LinkType` directly.

Also, UIntValue1 to 3 are the link parameters, but maybe they should be Int?