### PR TITLE
Partial AgentLobby and AtkComponentList offset fixes

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLobby.cs
@@ -31,7 +31,7 @@ public unsafe partial struct AgentLobby {
 
     [FieldOffset(0x1110)] public sbyte ServiceAccountIndex;
 
-    [FieldOffset(0x1118)] public ulong HoveredCharacterContentId;
+    [FieldOffset(0x1180)] public ulong HoveredCharacterContentId;
     [FieldOffset(0x1120)] public byte DataCenter;
 
     [FieldOffset(0x1122)] public short WorldIndex; // index in CurrentDataCenterWorlds
@@ -54,9 +54,9 @@ public unsafe partial struct AgentLobby {
 
     [FieldOffset(0x1164)] public byte LobbyUpdateStage;
 
-    [FieldOffset(0x1167)] public byte LobbyUIStage;
+    [FieldOffset(0x11D7)] public byte LobbyUIStage;
 
-    [FieldOffset(0x1170)] public long IdleTime;
+    [FieldOffset(0x11E0)] public long IdleTime;
 
     [FieldOffset(0x1190)] public int QueuePosition;
 

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentList.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentList.cs
@@ -14,7 +14,7 @@ public unsafe partial struct AtkComponentList : ICreatable {
     [FieldOffset(0xC0)] public AtkComponentListItemRenderer* FirstAtkComponentListItemRenderer;
     [FieldOffset(0xC8)] public AtkComponentScrollBar* AtkComponentScrollBarC8;
     [FieldOffset(0xF0)] public ListItem* ItemRendererList;
-    [FieldOffset(0x118)] public int ListLength;
+    [FieldOffset(0x120)] public int ListLength;
     [FieldOffset(0x12C)] public int SelectedItemIndex; // 0-N, -1 when none.
     [FieldOffset(0x130)] public int HeldItemIndex; // 0-N, -1 when none. While mouse is held down.
 


### PR DESCRIPTION
`AgentLobby` got shifted by `0x68` somewhere after `LobbySheet` and a further `0x8` somewhere after `HoveredCharacterContentId`
`AtkComponentList` also had some stuff shifted after `ItemRendererList`

Things might have been rearranged too didn't dive too deep to figure stuff out.