### PR TITLE
Restore missing flags on Character

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -40,6 +40,9 @@ public unsafe partial struct Character {
     // 0x04 = Friend
     [FieldOffset(0x1C62)] public byte RelationFlags;
 
+    // 0x40 = All attacks will be cancelled, character is doing the the 'winded' emote, used in e.g. 'Strange Bedfellows' and 'Combat Evolved' when quest expects an item to be used on the character
+    [FieldOffset(0x1C68)] public byte ActorControlFlags;
+
     [FieldOffset(0x2160)] public Balloon Balloon;
 
     [FieldOffset(0x2268)] public float Alpha;


### PR DESCRIPTION
Was previously `BattleChara.Flags2 & 0x80`, disappeared in one of the 7.1 changes.

From @awgil:

> interesting, it's set by actorcontrol 32
> it's now at offset 0x1C68, value is 0x40

Not really sure what the best name for it is, all things considered, as I'm not sure where else its used.

Tested while doing 'Combat Evolved' (Ultimate Thule aether current quest) on an alt.