### PR TITLE
Correct GameObject TargetableStatus offset

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -30,7 +30,7 @@ public unsafe partial struct GameObject {
     [FieldOffset(0x90)] public byte YalmDistanceFromPlayerX;
     [FieldOffset(0x91)] public byte TargetStatus; // Goes from 6 to 2 when selecting a target and flashing a highlight
     [FieldOffset(0x92)] public byte YalmDistanceFromPlayerZ;
-    [FieldOffset(0x95)] public ObjectTargetableFlags TargetableStatus; // Determines whether the game object can be targeted by the user
+    [FieldOffset(0x96)] public ObjectTargetableFlags TargetableStatus; // Determines whether the game object can be targeted by the user
     [FieldOffset(0xB0)] public Vector3 Position;
     [FieldOffset(0xC0)] public float Rotation;
     [FieldOffset(0xC4)] public float Scale;


### PR DESCRIPTION
`*(byte*) ((nint) (&chara->TargetableStatus) + 1) = 0;` works, but `chara->TargetableStatus = 0` does not, so I bumped the offset by 1.