### PR TITLE
Fix offset in ContentDirector

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
@@ -15,7 +15,7 @@ public partial struct ContentDirector {
 
     [FieldOffset(0x578)] public DutyActionManager DutyActionManager;
 
-    [FieldOffset(0xCF0)] public float ContentTimeLeft;
+    [FieldOffset(0xD40)] public float ContentTimeLeft;
 
     /// <summary>
     /// Gets the max time for the content in seconds

--- a/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
@@ -9,7 +9,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
 // ctor "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8B F9 E8 ?? ?? ?? ?? 33 ED 48 8D 05 ?? ?? ?? ?? 48 89 07 48 8D 8F"
 [GenerateInterop(isInherited: true)]
 [Inherits<Director>]
-[StructLayout(LayoutKind.Explicit, Size = 0xD30)]
+[StructLayout(LayoutKind.Explicit, Size = 0xD80)]
 public partial struct ContentDirector {
     [FieldOffset(0x53A)] public byte ContentTypeRowId;
 


### PR DESCRIPTION
This also got shifted by +0x50. This is required for the Distant Seas timer (see https://github.com/NotNite/DistantSeas/issues/12).