### PR TITLE
Update HousingManager

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/HousingManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/HousingManager.cs
@@ -39,8 +39,27 @@ public unsafe partial struct HousingManager {
     public partial sbyte GetCurrentPlot();
 
     // Unique Identifier
+    [Obsolete("Renamed to GetCurrentIndoorHouseId, as this only returns the HouseId of IndoorTerritory")]
+    public long GetCurrentHouseId() => GetCurrentIndoorHouseId();
+
     [MemberFunction("E8 ?? ?? ?? ?? BA ?? ?? ?? ?? 48 8B F8 8D 4A 02")]
-    public partial long GetCurrentHouseId();
+    public partial long GetCurrentIndoorHouseId();
+
+    /// <summary>
+    /// Gets the TerritoryTypeId of the house the player is currently standing at.<br/>
+    /// For indoor territories that were renovated, this returns the original location.
+    /// </summary>
+    /// <returns></returns>
+    [MemberFunction("48 8B 05 ?? ?? ?? ?? 48 8B 50 08 48 85 D2 74 10")]
+    public static partial uint GetOriginalHouseTerritoryTypeId();
+
+    /// <summary>
+    /// Gets the player owned house ids.
+    /// </summary>
+    /// <param name="type">The type of the estate.</param>
+    /// <param name="sharedEstateIndex">For type <see cref="EstateType.SharedEstate"/> an index must be specified (currently either 0 or 1).</param>
+    [MemberFunction("83 F9 06 77 64")]
+    public static partial long GetOwnedHouseId(EstateType type, int sharedEstateIndex = -1);
 
     /// <summary>
     /// Gets the airship voyage distance and time in pointers
@@ -116,4 +135,17 @@ public unsafe partial struct HousingManager {
     /// <returns>True or False</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 88 45 38")]
     public static partial bool IsSubmarineExplorationExplored(byte point);
+
+    public HousingTerritoryType GetCurrentHousingTerritoryType()
+        => CurrentTerritory != null ? CurrentTerritory->GetTerritoryType() : HousingTerritoryType.None;
+}
+
+public enum EstateType {
+    FreeCompanyEstate = 0,
+    PersonalChambers = 1,
+    PersonalEstate = 2,
+    Unknown3 = 3,
+    SharedEstate = 4,
+    ApartmentBuilding = 5,
+    ApartmentRoom = 6
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/HousingTerritory.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/HousingTerritory.cs
@@ -9,7 +9,8 @@ public unsafe partial struct HousingTerritory { // 6 vfuncs
 }
 
 public enum HousingTerritoryType {
-    Outdoor = 1,
+    None,
+    Outdoor,
     Indoor,
     Workshop
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/IndoorTerritory.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/IndoorTerritory.cs
@@ -8,5 +8,5 @@ namespace FFXIVClientStructs.FFXIV.Client.Game;
 public unsafe partial struct IndoorTerritory {
     [FieldOffset(0x10), FixedSizeArray] internal FixedSizeArray732<HousingFurniture> _furniture;
     [FieldOffset(0x8968)] public HousingObjectManager HousingObjectManager;
-    [FieldOffset(0x96A0)] public uint HouseId; // Combines Ward, Plot, and Room
+    [FieldOffset(0x96A0)] public long HouseId; // Combines Ward, Plot, and Room
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/OutdoorTerritory.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/OutdoorTerritory.cs
@@ -8,7 +8,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game;
 public unsafe partial struct OutdoorTerritory {
     [FieldOffset(0x10), FixedSizeArray] internal FixedSizeArray732<HousingFurniture> _furniture;
     [FieldOffset(0x8968)] public HousingObjectManager HousingObjectManager;
-    [FieldOffset(0x96A0)] public uint HouseId; // Combines Ward, Plot, and Room
+    [FieldOffset(0x96A0)] public long HouseId; // Combines Ward, Plot, and Room
     [FieldOffset(0x96A8)] public sbyte StandingInPlot;
     [FieldOffset(0x96AA)] public sbyte EditingFixturesOfPlot;
     [FieldOffset(0x96B0)] public sbyte EditingFurnishingsOfPlot;

--- a/FFXIVClientStructs/FFXIV/Client/Game/WorkshopTerritory.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/WorkshopTerritory.cs
@@ -11,6 +11,8 @@ public unsafe partial struct WorkshopTerritory {
     [FieldOffset(0x68)] public HousingWorkshopAirshipData Airship;
 
     [FieldOffset(0x2960)] public HousingWorkshopSubmersibleData Submersible;
+
+    [FieldOffset(0xB8B0)] public long HouseId;
 }
 
 [GenerateInterop]

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1357,10 +1357,12 @@ classes:
       0x140C4FDC0: HasHousePermissions
       0x140C4F390: GetCurrentPlot
       0x140C4F440: GetCurrentWard
-      0x140C4FEC0: GetCurrentHouseId
+      0x140C4FEC0: GetCurrentIndoorHouseId
       0x140C50230: GetCurrentRoom
       0x140C4F4A0: GetCurrentFloor # 0 - Ground Level, 1 - Upstairs, 10 - Downstairs
       0x140C4F5D0: GetInvertedBrightness # 0-5, higher is darker
+      0x140C52EE0: GetOwnedHouseId
+      0x140C55B30: GetOriginalHouseTerritoryTypeId
       0x140C7BCE0: IsSubmarineExplorationUnlocked # static
       0x140C7BD20: IsSubmarineExplorationExplored # static
       0x140C7DEF0: GetSubmarineSurveyDuration # (unsigned __int8 point, __int16 speed) -> SurveyDuration (return is time in seconds)


### PR DESCRIPTION
- **Fixed:** `IndoorTerritory.HouseId` and `OutdoorTerritory.HouseId` are long, not uint.
- **Added:** `WorkshopTerritory.HouseId`
- **Added:** `GetOriginalHouseTerritoryTypeId`, which returns the original territory id in case the house (indoor) was renovated. AgentMap uses it.
- **Added:**`GetOwnedHouseId` to get all owned house ids. Telepo uses it.
- **Added:** A little helper `GetCurrentHousingTerritoryType` for convenience.
- **Renamed:** `GetCurrentHouseId` to `GetCurrentIndoorHouseId`, as it only returns the HouseId of IndoorTerritory.