### PR TITLE
Add SetupSteamApi to Framework

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
@@ -169,5 +169,5 @@ public unsafe partial struct Framework {
     /// </summary>
     /// <returns>Returns <c>true</c> if the API was initialized successfully, false otherwise.</returns>
     [MemberFunction("48 89 5C 24 ?? 57 48 81 EC 40 02 00 00 48 8B 05")]
-    public partial byte SetupSteamApi();
+    public partial bool SetupSteamApi();
 }

--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
@@ -160,4 +160,14 @@ public unsafe partial struct Framework {
     /// <returns>Returns true if the API is ready, false otherwise.</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 88 43 08 84 C0 74 16")]
     public partial bool IsSteamApiInitialized();
+
+    /// <summary>
+    /// Set up the Steam API for the current game instance. This is automatically called when `IsSteam=1` is passed to the game,
+    /// but can be called manually in certain cases. Note that this function *will* re-initialize the Steam API, so ensure that
+    /// the state is checked via <see cref="IsSteamApiInitialized"/> before calling it. This method will also set
+    /// <see cref="IsSteamGame"/> to true, though this seemingly has no effect (??).
+    /// </summary>
+    /// <returns>Returns <c>true</c> if the API was initialized successfully, false otherwise.</returns>
+    [MemberFunction("48 89 5C 24 ?? 57 48 81 EC 40 02 00 00 48 8B 05")]
+    public partial byte SetupSteamApi();
 }


### PR DESCRIPTION
Needed so that we can manually call `SetupSteamApi()` from Dalamud/plugins.

The game will automatically tear down the Steam API when shutting itself down, so long as the SteamApi pointer is set (see `Client::System::Framework::Framework_TeardownSteamApi`, inlined in `Framework#Free`.

This method must only be called once per session, so callers need to verify first that `IsSteamApiInitialized` returns `false`, and that `boot/steam_api64.dll` is present. If a Steam API is already present, re-calling this method will reinitialize the API, leading to potentially problematic edge cases.

Likewise, if this method is called when `boot/steam_api64.dll` is not present, it will set the variable `Framework#IsSteamGame` to `true`. However, this does not appear to actually do anything, so perhaps this is safe.