### PR TITLE
Add LayoutWorld.GetLayoutInstance

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/LayoutEngine/LayoutWorld.cs
+++ b/FFXIVClientStructs/FFXIV/Client/LayoutEngine/LayoutWorld.cs
@@ -30,6 +30,10 @@ public unsafe partial struct LayoutWorld {
     [FieldOffset(0x220)] public StdMap<Utf8String, Pointer<byte>>* RsvMap;
     [FieldOffset(0x228)] public StdMap<ulong, Pointer<byte>>* RsfMap; // Key is v0 index hash, value is always 64 bytes in size
 
+    /// <remarks> Tries to get it from <see cref="ActiveLayout"/> first, then from <see cref="GlobalLayout"/>. </remarks>
+    [MemberFunction("E9 ?? ?? ?? ?? 8B 43 78")]
+    public static partial ILayoutInstance* GetLayoutInstance(InstanceType instanceType, uint instanceId, uint subId = 0);
+
     [MemberFunction("E8 ?? ?? ?? ?? 45 33 F6 44 89 B7")]
     public static partial void UnloadPrefetchLayout();
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -128,6 +128,7 @@ functions:
 #fail   0x1403297E0: GetGlobalTextParameter
   0x140691E20: std::vector<Component::GUI::AtkValue>_SetSize
   0x140E92FD0: GetGameObjectByIndex
+  0x1406FB690: GetLayoutInstance
   0x1408FA950: GetRandomInteger
   0x1408FA9B0: GetRandomFloat
   0x1404C95D0: UpdateAnimFactor
@@ -1327,6 +1328,7 @@ classes:
       0x140390D00: GetMateriaId
       0x1407BEBC0: GetMateriaGrade
       0x1407FE580: ctor
+      0x1407FE5D0: Dtor
       0x1407FE940: GetLinkedItem
       0x1407FEE60: GetConditionPercentage
       0x1407FEEA0: GetStain
@@ -6762,6 +6764,7 @@ classes:
       0x1406AF970: CreateSingleton
       0x1406B09A0: LoadPrefetchLayout
       0x1406B0D50: UnloadManagerLayout
+      0x1406B38C0: GetLayoutInstance
       0x1406B4380: AddRsvString
       0x1406B4620: UnloadRsvMap
       0x1406B4770: ResolveRsvString
@@ -6779,6 +6782,7 @@ classes:
       0x1406B93B0: ctor
       # 0x1405C9C00: SetInteriorFixture # inlined @ 1406CDF00
       0x1406BCCD0: SetActiveFestivals
+      0x1406C5400: GetLayoutInstance
   Client::LayoutEngine::OutdoorAreaLayoutData:
     funcs:
       0x14069EA70: SetFixture # inlined in 0x1406F4B60 (not 100% sure)


### PR DESCRIPTION
I thought adding this should make it easier to get a specific instance than going via the InstancesByType map.
Wasn't sure how to differenciate the static and the non-static by name, so I added the static one under global functions. Seems to fit based on nearby functions. 🤷‍♂️