### PR TITLE
Remove WorldHelper::World.IsPublic

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/WorldHelper.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/WorldHelper.cs
@@ -18,7 +18,7 @@ public unsafe partial struct WorldHelper {
     [StructLayout(LayoutKind.Explicit, Size = 0x22)]
     public partial struct World {
         [FieldOffset(0x00)] public byte DataCenter;
-        [FieldOffset(0x01)] public bool IsPublic;
-        [FieldOffset(0x02), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _name;
+        [FieldOffset(0x00), Obsolete("This field was removed", true)] public bool IsPublic;
+        [FieldOffset(0x01), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _name;
     }
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -7873,8 +7873,7 @@ classes:
       0: Dtor
     funcs:
       0x14091DF60: ctor
-#       0x1406B26A0: Finalizer # Inlined in dtor
-      0x14091E040: Populate
+      0x14091E000: Finalizer
       0x14091E1D0: GetWorldById
       0x14091E250: GetWorldNameById
       0x14091E2B0: GetWorldIdByName


### PR DESCRIPTION
Looks like the field was removed, so the name was cut off in the beginning.