### PR TITLE
fix `ScreenShot` instance to be a pointer

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/Photo/ScreenShot.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Photo/ScreenShot.cs
@@ -6,7 +6,7 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Photo;
 [Inherits<Client.System.Framework.Task>]
 [StructLayout(LayoutKind.Explicit, Size = 0x288)]
 public unsafe partial struct ScreenShot {
-    [StaticAddress("48 8B 1D ?? ?? ?? ?? 48 85 DB 74 ?? 41 B0", 3)]
+    [StaticAddress("48 8B 1D ?? ?? ?? ?? 48 85 DB 74 ?? 41 B0", 3, isPointer: true)]
     public static partial ScreenShot* Instance();
 
     [FieldOffset(0x38)] public ScreenShotThread* ThreadPtr;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5693,6 +5693,7 @@ classes:
   Client::System::Photo::ScreenShot:
     instances:
       - ea: 0x1427BFB70
+        pointer: true
     vtbls:
       - ea: 0x141F62440
         base: Client::System::Framework::Task


### PR DESCRIPTION
As best seen in `Client::System::Photo::ScreenShot_Setup`