### PR TITLE
Fix LoadPrefetchLayout festivals arg

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/LayoutEngine/LayoutWorld.cs
+++ b/FFXIVClientStructs/FFXIV/Client/LayoutEngine/LayoutWorld.cs
@@ -33,8 +33,9 @@ public unsafe partial struct LayoutWorld {
     [MemberFunction("E8 ?? ?? ?? ?? 45 33 F6 44 89 B7")]
     public static partial void UnloadPrefetchLayout();
 
+    /// <remarks> <paramref name="festivals"/> is a pointer to an array of 4 <see cref="GameMain.Festival"/>s. </remarks>
     [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 8B 41 20"), GenerateStringOverloads]
-    public partial void LoadPrefetchLayout(int type, byte* bgName, byte layerEntryType, uint levelId, uint territoryTypeId, GameMain* gameMain, uint cfcId);
+    public partial void LoadPrefetchLayout(int type, byte* bgName, byte layerEntryType, uint levelId, uint territoryTypeId, GameMain.Festival* festivals, uint cfcId);
 
     [MemberFunction("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 84 24 ?? ?? ?? ?? 48 83 B9 ?? ?? ?? ?? ?? 48 8B F1"), GenerateStringOverloads]
     public partial byte* ResolveRsvString(byte* rsvString);


### PR DESCRIPTION
I didn't see this correctly, because it passes GameMain.Instance() to the function and the ActiveFestivals array is at offset 0 in GameMain.
It dereferences the pointer at 1406B9D8D and copying the festivals as _OWORD, so since GameMain.Festival is of size 0x4 it copies all 4 festivals.