### PR TITLE
Add RaptureShellModule.CancelMacro

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureTextModule.cs
@@ -39,6 +39,12 @@ public unsafe partial struct RaptureTextModule {
     [FieldOffset(0xE30)] internal ExcelSheet* AkatsukiNoteStringSheet;
     [FieldOffset(0xE38)] public int SoundId;
     [FieldOffset(0xE3C)] public int IsJingle;
+    // [FieldOffset(0xE40)] public ExcelSheetWaiter* WeatherReportReplaceIdsLoader;
+    /// <remarks> Array of 4 (WeatherReportReplace row count - 1) * 2 ushorts (PlaceNameSub, PlaceNameParent). </remarks>
+    [FieldOffset(0xE48)] public ushort* WeatherReportReplaceIds;
+    // [FieldOffset(0xE50)] public ExcelSheetWaiter* AkatsukiNoteTitleIdsLoader;
+    /// <remarks> Array of 51 (AkatsukiNote row count) ushorts. Mapping AkatsukiNote RowId to AkatsukiNoteString RowId. </remarks>
+    [FieldOffset(0xE58)] public ushort* AkatsukiNoteTitleIds;
 
     [MemberFunction("E9 ?? ?? ?? ?? 80 EA 20")]
     public partial byte* GetAddonText(uint addonId);

--- a/FFXIVClientStructs/FFXIV/Client/UI/Shell/RaptureShellModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Shell/RaptureShellModule.cs
@@ -56,6 +56,9 @@ public unsafe partial struct RaptureShellModule {
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 8D 4D 28")]
     public partial void ExecuteMacro(RaptureMacroModule.Macro* macro);
 
+    [MemberFunction("E8 ?? ?? ?? ?? EB 42 4C 8B C6")]
+    public partial void CancelMacro();
+
     [MemberFunction("E8 ?? ?? ?? ?? 48 BA ?? ?? ?? ?? ?? ?? ?? ?? 84 C0")]
     public partial bool TryGetMacroIconCommand(RaptureMacroModule.Macro* macro, void* resultsOut);
 

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkInputManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkInputManager.cs
@@ -5,6 +5,10 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 public unsafe partial struct AtkInputManager {
     [FieldOffset(0)] public AtkTextInput* TextInput;
 
+    [FieldOffset(0x08), FixedSizeArray] internal FixedSizeArray2<Pointer<AtkCollisionNode>> _savedMouseClicksCollisionNodes; // maybe more?
+
+    [FieldOffset(0x40), FixedSizeArray] internal FixedSizeArray2<SavedMouseClick> _savedMouseClicks; // maybe more?
+
     [FieldOffset(0x80), FixedSizeArray] internal FixedSizeArray256<FocusEntry> _focusList;
 
     [StructLayout(LayoutKind.Explicit, Size = 0x18)]
@@ -12,5 +16,12 @@ public unsafe partial struct AtkInputManager {
         [FieldOffset(0x0)] public AtkEventListener* AtkEventListener;
         [FieldOffset(0x8)] public AtkEventTarget* AtkEventTarget;
         [FieldOffset(0x10)] public int Unk10;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x8)]
+    public struct SavedMouseClick {
+        [FieldOffset(0x0)] public int Timestamp;
+        [FieldOffset(0x4)] public short X;
+        [FieldOffset(0x6)] public short Y;
     }
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -5638,7 +5638,9 @@ classes:
       0x140598F30: ctor_FromState
       0x140598F80: ctor
       0x140598F60: Finalizer
+      0x140598FB0: Resume
       0x140599850: Yield
+      0x140599860: GetStatus
   Client::Game::Event::LuaActor:
     vtbls:
       - ea: 0x141FA8718
@@ -8244,6 +8246,8 @@ classes:
       0x1405C0140: GetAvailablePoses
       0x1405C0190: Initialize
       0x1405C09C0: SetPose
+      0x1405C0E70: IsEmoting
+      0x1405C0EB0: IsInEmoteLoop
       0x1405C2B40: GetPoseState
       0x1405C3EB0: GetPoseKind
   Client::Game::Control::EmoteController::FindChairInfo:
@@ -8445,6 +8449,7 @@ classes:
       0x140874800: ctor
       0x140877440: Finalizer
       0x140878500: ExecuteMacro
+      0x1408786D0: CancelMacro
       0x140878700: TryGetMacroIconCommand
       0x140878880: ChangeChatChannel
       0x140878D70: SetContextTellTarget
@@ -12313,6 +12318,7 @@ classes:
       0x140C2C920: LuaQuestUnqualified
       0x140C2D480: LuaGetQuestBattleProgress
       0x140C2D930: LuaYesNoQuestBattle
+      0x140C2DB00: GetFestivals
       0x140C2DBC0: LuaSetWeddingFestivalParam
       0x140C2DCE0: LuaGetWeddingReservedFlag
       0x140C2DD60: LuaGetGsWeeklyLotOffsetTime


### PR DESCRIPTION
Was dealing with EventFramework tasks and stumbled upon this. Thought it might be useful for someone.
Technically it just sets MacroCurrentLine to -1 and MacroLocked (and the byte after) to 0.