### PR TITLE
Update data.yml, Add AgentInventoryContext::InventoryContextEvent

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/ShopEventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/ShopEventHandler.cs
@@ -1,11 +1,15 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Common.Component.Excel;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game.Event;
 
+// Client::Game::Event::ShopEventHandler
+//   Client::Game::Event::EventHandler
+//   Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
 [GenerateInterop]
-[Inherits<EventHandler>]
+[Inherits<EventHandler>, Inherits<AgentInventoryContext.InventoryContextEvent>]
 [StructLayout(LayoutKind.Explicit, Size = 0x32F0)]
 public unsafe partial struct ShopEventHandler {
     // 0x210: second base class, related to context menu integration for selling items

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHousingPlant.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHousingPlant.cs
@@ -5,9 +5,10 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 // Client::UI::Agent::AgentHousingPlant
 //   Client::UI::Agent::AgentInterface
 //     Component::GUI::AtkModuleInterface::AtkEventInterface
+//   Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
 [Agent(AgentId.HousingPlant)]
 [GenerateInterop]
-[Inherits<AgentInterface>]
+[Inherits<AgentInterface>, Inherits<AgentInventoryContext.InventoryContextEvent>]
 [StructLayout(LayoutKind.Explicit, Size = 0x950)]
 public unsafe partial struct AgentHousingPlant {
     [FieldOffset(0x40)] public uint ContextAddonId;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentInventoryContext.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentInventoryContext.cs
@@ -60,4 +60,8 @@ public unsafe partial struct AgentInventoryContext {
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 83 C4 ?? 5B C3 8B 83")]
     public partial void LowerItemQuality(InventoryItem* itemSlot, InventoryType inventory, int slot, uint addonId);
+
+    [GenerateInterop(isInherited: true)]
+    [StructLayout(LayoutKind.Explicit, Size = 0x8)]
+    public partial struct InventoryContextEvent; // contains 2 vfs
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -9344,6 +9344,10 @@ classes:
     vtbls:
       - ea: 0x141F38BB0
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F38C28
+        base: Client::UI::Agent::AgentContext::AgentContextUpdateChecker
+      - ea: 0x141F38C30
+        base: Client::UI::Info::InfoEventHandlerInterface
     funcs:
       0x1402FB620: ctor
   Client::UI::Agent::AgentFreeCompanyProfile:
@@ -9365,14 +9369,20 @@ classes:
     vtbls:
       - ea: 0x141F38F28
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F38FA0
+        base: Client::UI::Info::InfoEventHandlerInterface
   Client::UI::Agent::AgentFreeCompanyCrestEditor:
     vtbls:
       - ea: 0x141F38FA8
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F39020
+        base: Client::UI::Info::InfoEventHandlerInterface
   Client::UI::Agent::AgentFreeCompanyCrestDecal:
     vtbls:
       - ea: 0x141F39028
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F390A0
+        base: Client::UI::Info::InfoEventHandlerInterface
     funcs:
       0x140309B30: ctor
       0x140309C10: Finalizer
@@ -9557,7 +9567,7 @@ classes:
         base: Client::UI::Agent::AgentContext::AgentContextUpdateChecker
       - ea: 0x142080270
         base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
-      - ea: 0x141F382A8
+      - ea: 0x142080280
         base: Client::UI::Info::InfoEventHandlerInterface
     funcs:
       0x14149F440: ctor
@@ -9864,6 +9874,8 @@ classes:
     vtbls:
       - ea: 0x141F3ADD0
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F3AE48
+        base: Client::UI::Info::InfoEventHandlerInterface
     funcs:
       0x14033D9E0: ctor
   Client::UI::Agent::AgentCurrency:
@@ -10220,6 +10232,8 @@ classes:
     vtbls:
       - ea: 0x141FC76C0
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FC7738
+        base: Client::UI::Info::InfoEventHandlerInterface
     funcs:
       0x140E131C0: ctor
       0x140E13300: Finalizer
@@ -10368,6 +10382,8 @@ classes:
     vtbls:
       - ea: 0x141F3B508
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F3B580
+        base: Client::UI::Info::InfoEventHandlerInterface
 #    funcs:
 #       0x1402AF1F0: ctor # inlined
   Client::UI::Agent::AgentPvPTeamOrganization:
@@ -10502,6 +10518,8 @@ classes:
     vtbls:
       - ea: 0x1420808C8
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x142080940
+        base: Client::UI::Info::InfoEventHandlerInterface
     funcs:
       0x1414CEED0: ctor
       0x1414CEF70: Finalizer
@@ -10629,6 +10647,9 @@ classes:
     vtbls:
       - ea: 0x141F38228
         base: Client::UI::Agent::AgentInterface
+  Client::UI::Info::InfoEventHandlerInterface:
+    vtbls:
+      - ea: 0x141F382A8
   Client::UI::Agent::AgentEmjSetting:
     vtbls:
       - ea: 0x141FC2800

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -9107,6 +9107,10 @@ classes:
     vtbls:
       - ea: 0x141FC5410
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FC5490
+        base: Client::Game::UI::GameEventCallback
+      - ea: 0x141FC54A0
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x140D54060: ctor
       0x140D54190: Finalizer
@@ -9922,6 +9926,8 @@ classes:
     vtbls:
       - ea: 0x142080798
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x142080810
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x1414CA850: ctor
       0x1414CA9D0: Finalizer
@@ -9980,6 +9986,8 @@ classes:
     vtbls:
       - ea: 0x141F39310
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F39438
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x14032BC90: ctor
       0x14032BE90: Finalizer
@@ -10410,6 +10418,8 @@ classes:
     vtbls:
       - ea: 0x141FC8998
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FC8A10
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x140E94D90: ctor
       0x140E94E50: Finalizer
@@ -10499,6 +10509,8 @@ classes:
     vtbls:
       - ea: 0x141FAB6F8
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FAB770
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x140BA38D0: ctor
   Client::UI::Agent::AgentReconstructionBuyback:
@@ -10675,6 +10687,8 @@ classes:
     vtbls:
       - ea: 0x141FC6240
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FC62D8
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x140DC85F0: ctor
   Client::UI::Agent::AgentHugeCraftworksSupplyResult:
@@ -10687,12 +10701,16 @@ classes:
     vtbls:
       - ea: 0x141F9DD30
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F9DDA8
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x140A88E90: ctor
   Client::UI::Agent::AgentBankaCraftworksSupply:
     vtbls:
       - ea: 0x141FC8CB8
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FC8D30
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x140EA13F0: ctor
   Client::UI::Agent::AgentCircleInvite:
@@ -10796,6 +10814,8 @@ classes:
     vtbls:
       - ea: 0x141FABEA8
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FABF20
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x140BBFBD0: ctor
   Client::UI::Agent::AgentHwdGathererInspectionItemCount:
@@ -11587,6 +11607,10 @@ classes:
     vtbls:
       - ea: 0x142081830
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x1420818A8
+        base: Client::UI::Agent::AgentContext::AgentContextUpdateChecker
+      - ea: 0x1420818B0
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x1415102A0: ctor
   Client::UI::Agent::AgentArchiveItem:
@@ -12653,6 +12677,10 @@ classes:
     vtbls:
       - ea: 0x142085F40
         base: Client::Game::Event::EventHandler
+      - ea: 0x1420867A8
+        base: Client::UI::Agent::AgentContext::AgentContextUpdateChecker
+      - ea: 0x142085F28
+        base: Component::GUI::AtkModuleInterface::AtkEventInterface
   Client::Game::Event::TopicSelectEventHandler: # 0x32
     vtbls:
       - ea: 0x142123850

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2762,7 +2762,7 @@ classes:
       0x14006AA30: GetConfigOption
       0x14006A9E0: SetConfigOption
       0x14006AF20: RegisterChangeEvent
-      0x14006AF90: UnRegisterChangeEvent
+      0x14006AF90: UnregisterChangeEvent
   Common::Configuration::UIConfig:
     vtbls:
       - ea: 0x141F0A080
@@ -8973,6 +8973,8 @@ classes:
     vtbls:
       - ea: 0x141FC56B0
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FC5728
+        base: Common::Configuration::ConfigBase::ChangeEventInterface
     funcs:
       0x140D756C0: ctor
       0x140D76610: Finalizer
@@ -9166,6 +9168,8 @@ classes:
     vtbls:
       - ea: 0x141FC5CD0
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FC5D48
+        base: Common::Configuration::ConfigBase::ChangeEventInterface
     funcs:
       0x140DB3590: ctor
   Client::UI::Agent::AgentHowToNotice:
@@ -9314,6 +9318,10 @@ classes:
     vtbls:
       - ea: 0x141F38B10
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F38B88
+        base: Client::UI::Misc::ConfigModule::ConfigEventInterface
+      - ea: 0x141F38B98
+        base: Client::UI::Agent::AgentContext::AgentContextUpdateChecker
     funcs:
       0x1402E5E00: Finalizer
   Client::UI::Agent::AgentGoldSaucerReward:
@@ -9397,6 +9405,8 @@ classes:
     vtbls:
       - ea: 0x141FC5DD0
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FC5E48
+        base: Common::Configuration::ConfigBase::ChangeEventInterface
     funcs:
       0x140DB4A50: ctor
       0x140DB4AC0: Finalizer
@@ -9478,6 +9488,8 @@ classes:
     vtbls:
       - ea: 0x141FC81E0
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FC8258
+        base: Common::Configuration::ConfigBase::ChangeEventInterface
     funcs:
       0x140E4A980: ctor
       0x140E4B100: Finalizer
@@ -11230,6 +11242,8 @@ classes:
     vtbls:
       - ea: 0x141F37548
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F37618
+        base: Client::UI::Misc::ConfigModule::ConfigEventInterface
     funcs:
       0x1402B0420: ctor
   Client::UI::Agent::AgentConfigSystem:
@@ -11260,6 +11274,8 @@ classes:
     vtbls:
       - ea: 0x141F37D18
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141FC83A0
+        base: Common::Configuration::ConfigBase::ChangeEventInterface
   Client::UI::Agent::AgentHudLayout:
     vtbls:
       - ea: 0x141FC6070

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4934,6 +4934,8 @@ classes:
     vtbls:
       - ea: 0x141F38A88
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F38B00
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x1402E2BF0: ctor
       0x1402E2CF0: Finalizer
@@ -4941,6 +4943,10 @@ classes:
     vtbls:
       - ea: 0x141F38E98
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F38F10
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
+      - ea: 0x141F38F20
+        base: Client::UI::Info::InfoEventHandlerInterface
     funcs:
       0x1403005B0: ctor
       0x140300770: Finalizer # inlined @ 0x1403CD9F0
@@ -9009,6 +9015,9 @@ classes:
         base: Client::UI::Agent::AgentInterface
     funcs:
       0x140A828F0: ctor
+  Client::UI::Agent::AgentInventoryContext::InventoryContextEvent:
+    vtbls:
+      - ea: 0x141F36778
   Client::UI::Agent::AgentInventoryContext:
     vtbls:
       - ea: 0x141F36788
@@ -9113,6 +9122,8 @@ classes:
     vtbls:
       - ea: 0x141F9ED58
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F9EDD0
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x140AA69B0: ctor
       0x140AA6A80: Finalizer
@@ -9260,6 +9271,8 @@ classes:
     vtbls:
       - ea: 0x141F9D650
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F9D6C8
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x140A68450: ctor
       0x140A68650: Finalizer
@@ -9536,6 +9549,12 @@ classes:
     vtbls:
       - ea: 0x1420801F0
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x142080268
+        base: Client::UI::Agent::AgentContext::AgentContextUpdateChecker
+      - ea: 0x142080270
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
+      - ea: 0x141F382A8
+        base: Client::UI::Info::InfoEventHandlerInterface
     funcs:
       0x14149F440: ctor
       0x14149FC60: Finalizer
@@ -9567,6 +9586,8 @@ classes:
     vtbls:
       - ea: 0x142080518
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x142080590
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x1414C1F80: ctor
   Client::UI::Agent::AgentPersonalRoomPortal:
@@ -9598,6 +9619,8 @@ classes:
     vtbls:
       - ea: 0x142080698
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x142080710
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x1414C65A0: ctor
   Client::UI::Agent::AgentTreasureHunt:
@@ -9673,6 +9696,8 @@ classes:
     vtbls:
       - ea: 0x141F9D740
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F9D7B8
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x140A6FF30: ctor
       0x140A70040: Finalizer
@@ -9702,6 +9727,8 @@ classes:
     vtbls:
       - ea: 0x141F9EDE0
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x141F9EE58
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x140AA7BB0: ctor
   Client::UI::Agent::AgentRelicSphereUpgrade:
@@ -12377,6 +12404,8 @@ classes:
     vtbls:
       - ea: 0x142083C78
         base: Client::Game::Event::EventHandler
+      - ea: 0x1420844E0
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
     funcs:
       0x141591F80: ctor
       0x141592310: CreateInstance
@@ -12506,6 +12535,8 @@ classes:
     vtbls:
       - ea: 0x142085670
         base: Client::Game::Event::EventHandler
+      - ea: 0x142085ED8
+        base: Client::UI::Agent::AgentInventoryContext::InventoryContextEvent
   Client::Game::InstanceContent::ContentTalkEventHandler:
     vtbls:
       - ea: 0x14211D2A8


### PR DESCRIPTION
Just for inheritance. Didn't look into what it does.

But I noticed that the ctor for `AgentAquariumSetting` sets it vtable to +8. Not sure what's going on there, doesn't make sense.