### PR TITLE
Add CharamakeAvatarSaveDataContainer

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/Configuration/CharamakeAvatarSaveDataContainer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Configuration/CharamakeAvatarSaveDataContainer.cs
@@ -1,0 +1,82 @@
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
+
+namespace FFXIVClientStructs.FFXIV.Client.Game;
+
+// Client::System::Configuration::CharamakeAvatarSaveDataContainer
+[StructLayout(LayoutKind.Explicit, Size = 0x9EB8)]
+public partial struct CharamakeAvatarSaveDataContainer {
+    [FieldOffset(0x0000)] public FixedContainer Release;       // FFXIV_CHARA_
+    [FieldOffset(0x3218)] public FixedContainer Beta;          // FFXIV_CHARA_BETA
+    [FieldOffset(0x6430)] public FixedContainer Benchmark;     // FFXIV_CHARA_BENCH
+    [FieldOffset(0x9648)] public FreeTrialContainer FreeTrial; // FFXIV_CHARA_FT
+    [FieldOffset(0x9E18)] public VariableContainer Variable;   // files in FINAL FANTASY XIV\user\00000000 ?!
+
+    [GenerateInterop(isInherited: true)]
+    [StructLayout(LayoutKind.Explicit, Size = 0x08)]
+    public unsafe partial struct ContainerInterface {
+        [VirtualFunction(1)]
+        public partial bool IsSlotValid(byte slotIndex);
+
+        [VirtualFunction(2)]
+        public partial SavedAppearanceSlot* GetSlot(byte slotIndex);
+
+        // [VirtualFunction(3)]
+        // public partial SavedFreeTrialAppearanceSlot* GetFreeTrialSlot(byte slotIndex);
+
+        [VirtualFunction(4)]
+        public partial uint GetValidSlotCount();
+
+        [VirtualFunction(5)]
+        public partial uint UpdateValidSlotCount();
+
+        [VirtualFunction(6)]
+        public partial uint GetMaxSlotCount();
+    }
+
+    // Client::System::Configuration::CharamakeAvatarSaveDataContainer::FixedContainer
+    //   Client::System::Configuration::CharamakeAvatarSaveDataContainer::ContainerInterface
+    [GenerateInterop]
+    [Inherits<ContainerInterface>]
+    [StructLayout(LayoutKind.Explicit, Size = 0x3218)]
+    public partial struct FixedContainer {
+        [FieldOffset(0x08), FixedSizeArray] internal FixedSizeArray40<SavedAppearanceSlot> _slots;
+    }
+
+    // Client::System::Configuration::CharamakeAvatarSaveDataContainer::FreeTrialContainer
+    //   Client::System::Configuration::CharamakeAvatarSaveDataContainer::ContainerInterface
+    [GenerateInterop]
+    [Inherits<ContainerInterface>]
+    [StructLayout(LayoutKind.Explicit, Size = 0x7D0)]
+    public partial struct FreeTrialContainer;
+
+    // Client::System::Configuration::CharamakeAvatarSaveDataContainer::VariableContainer
+    //   Client::System::Configuration::CharamakeAvatarSaveDataContainer::ContainerInterface
+    [GenerateInterop]
+    [Inherits<ContainerInterface>]
+    [StructLayout(LayoutKind.Explicit, Size = 0x30)]
+    public partial struct VariableContainer;
+
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 0x140)]
+    public partial struct SavedAppearanceSlot {
+        [FieldOffset(0x00)] public uint Magic; // Should be 0x2013_FF14
+        [FieldOffset(0x04)] public uint Version;
+        [FieldOffset(0x08)] public uint CustomizeDataHash;
+
+        [FieldOffset(0x10)] public CustomizeData CustomizeData;
+
+        [FieldOffset(0x2C)] public int Timestamp;
+        [FieldOffset(0x30), FixedSizeArray(isString: true)] internal FixedSizeArray64<byte> _label;
+
+        [FieldOffset(0x134)] public SavedAppearanceSlotStatus Status;
+
+        [FieldOffset(0x13C)] public byte SlotIndex;
+    }
+}
+
+public enum SavedAppearanceSlotStatus {
+    Empty = 0,
+    Valid = 1,
+    InvalidVersion = 2, // when Version is > 8
+    InvalidCustomizeData = 3, // when CustomizeDataHash doesn't match
+}

--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
@@ -26,7 +26,9 @@ public unsafe partial struct Framework {
 
     [FieldOffset(0x0010)] public SystemConfig SystemConfig;
     [FieldOffset(0x0460)] public DevConfig DevConfig;
+    [Obsolete("Use CharamakeAvatarSaveData")]
     [FieldOffset(0x0570)] public SavedAppearanceManager* SavedAppearanceData;
+    [FieldOffset(0x0570)] public CharamakeAvatarSaveDataContainer* CharamakeAvatarSaveData;
     [FieldOffset(0x0580)] public byte ClientLanguage;
     [FieldOffset(0x0581)] public byte Region;
     [FieldOffset(0x0588)] public Cursor* Cursor;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -8190,7 +8190,7 @@ classes:
         base: Client::System::Configuration::CharamakeAvatarSaveDataContainer::ContainerInterface
   Client::System::Configuration::CharamakeAvatarSaveDataContainer::SavedAppearanceSlot:
     funcs:
-        0x1407CA330: CalculateCustomizeDataHash
+      0x1407CA330: CalculateCustomizeDataHash
   Client::Game::Object::GameObject:
     vtbls:
       - ea: 0x141F7E5A0

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -8164,16 +8164,33 @@ classes:
       0x1418C9CD0: ToggleCharacterVisibility
       0x1418C9FB0: ApplyCameraPositions
       0x1418CA470: SetCameraPosition
-  Client::Game::SavedAppearanceManager:
+  Client::System::Configuration::CharamakeAvatarSaveDataContainer::ContainerInterface:
     vtbls:
-      - ea: 0x141F7D640
+      - ea: 0x141F7D5E0
     vfuncs:
       0: Dtor
-      1: IsSlotCreated
+      1: IsSlotValid
       2: GetSlot
+      4: GetValidSlotCount
+      5: UpdateValidSlotCount
       6: GetSlotCount
+  Client::System::Configuration::CharamakeAvatarSaveDataContainer::FixedContainer:
+    vtbls:
+      - ea: 0x141F7D640
+        base: Client::System::Configuration::CharamakeAvatarSaveDataContainer::ContainerInterface
     funcs:
-      0x1407C84A0: ctor
+      0x1407C9720: ctor
+  Client::System::Configuration::CharamakeAvatarSaveDataContainer::FreeTrialContainer:
+    vtbls:
+      - ea: 0x141F7D6A0
+        base: Client::System::Configuration::CharamakeAvatarSaveDataContainer::ContainerInterface
+  Client::System::Configuration::CharamakeAvatarSaveDataContainer::VariableContainer:
+    vtbls:
+      - ea: 0x141F7D700
+        base: Client::System::Configuration::CharamakeAvatarSaveDataContainer::ContainerInterface
+  Client::System::Configuration::CharamakeAvatarSaveDataContainer::SavedAppearanceSlot:
+    funcs:
+        0x1407CA330: CalculateCustomizeDataHash
   Client::Game::Object::GameObject:
     vtbls:
       - ea: 0x141F7E5A0


### PR DESCRIPTION
- Obsoletes the SavedAppearanceData struct.
- Struct names are from the csv, except for FreeTrialContainer which didn't exist back then.
- Didn't really do much to SavedAppearanceSlot - just added the CustomizeDataHash and Timestamp fields, and replaced the bool IsCreated with a Status enum.