### PR TITLE
Update Utf8String.SanitizeString, add GetParts

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
@@ -170,6 +170,9 @@ public unsafe partial struct Utf8String : ICreatable, IDisposable, IStaticNative
     [Obsolete("Use SanitizeString with AllowedEntities enum")]
     public void SanitizeString(ushort flags, Utf8String* characterList) => SanitizeString((AllowedEntities)flags, characterList);
 
+    [MemberFunction("E8 ?? ?? ?? ?? 4C 8B 74 24 ?? 48 8B 74 24 ?? 48 89 5C 24 ?? 48 89 5D 80 49 8B DE 48 C7 45 ?? ?? ?? ?? ?? 4C 3B F6 0F 84 ?? ?? ?? ?? 48 8B 03 80 38 00 74 1F 41 8B C4")]
+    public partial void GetParts(StdVector<Utf8StringPart>* vector);
+
     public byte GetCharAt(int idx) => idx < 0 ? byte.MinValue : GetCharAt((ulong)idx);
 
     [MemberFunction("E8 ?? ?? ?? ?? 40 80 FF 03 73 18")]
@@ -245,4 +248,12 @@ public enum AllowedEntities : ushort {
     CJK = 1 << 10,
 
     Unknown11 = 1 << 11,
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0xE0)]
+public unsafe struct Utf8StringPart {
+    [FieldOffset(0x00)] public Utf8String Payload;
+    [FieldOffset(0x68)] public Utf8String Text;
+    [FieldOffset(0xD0)] private long UnkD0;
+    [FieldOffset(0xD8)] private long UnkD8;
 }

--- a/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
@@ -227,14 +227,14 @@ public enum AllowedEntities : ushort {
     Numbers = 1 << 2,
 
     /// <summary> Whitespace and special characters </summary>
-    /// <remarks> !&quot;#$%&amp;&apos;()*+,-./:;\&lt;=&gt;?@[\]^_`{|}~¡¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ </remarks>
+    /// <remarks> For example: !&quot;#$%&amp;&apos;()*+,-./:;\&lt;=&gt;?@[\]^_`{|}~¡¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ </remarks>
     SpecialCharacters = 1 << 3,
 
     /// <summary> Includes characters from a list passed to <see cref="Utf8String.SanitizeString(AllowedEntities, Utf8String*)"/>. </summary>
     CharacterList = 1 << 4,
 
-    /// <summary> New line </summary>
-    NewLines = 1 << 5,
+    /// <summary> Anything that's not handled in the alphanumerical filters (presumably). </summary>
+    OtherCharacters = 1 << 5,
 
     /// <summary> SeString payloads </summary>
     Payloads = 1 << 6,
@@ -243,8 +243,7 @@ public enum AllowedEntities : ushort {
     Unknown8 = 1 << 8,
     Unknown9 = 1 << 9, // Only used in Chinese/Korean clients?!
 
-    /// <summary> CJK Unified Ideographs and Hiragana </summary>
-    /// <remarks> Also seems to allow special characters. </remarks>
+    /// <summary> Hiragana, Katakana, CJK Unified Ideographs </summary>
     CJK = 1 << 10,
 
     Unknown11 = 1 << 11,

--- a/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/String/Utf8String.cs
@@ -155,8 +155,20 @@ public unsafe partial struct Utf8String : ICreatable, IDisposable, IStaticNative
     [MemberFunction("48 8B 01 0F B6 04")]
     public partial byte GetCharAt(ulong idx);
 
+    /// <summary>
+    /// Sanitizes the <see cref="Utf8String"/>.
+    /// </summary>
+    /// <param name="flags">
+    /// Flags that define which characters or character groups are allowed in the sanitized string.
+    /// </param>
+    /// <param name="characterList">
+    /// An optional list of ASCII characters that are explicitly allowed in the sanitized string when the <see cref="AllowedEntities.CharacterList"/> flag is set in the <paramref name="flags"/> argument.
+    /// </param>
     [MemberFunction("E8 ?? ?? ?? ?? 48 8D 4C 24 ?? 0F B6 F0 E8 ?? ?? ?? ?? 48 8D 4D C0")]
-    public partial void SanitizeString(ushort flags, Utf8String* characterList);
+    public partial void SanitizeString(AllowedEntities flags, Utf8String* characterList = null);
+
+    [Obsolete("Use SanitizeString with AllowedEntities enum")]
+    public void SanitizeString(ushort flags, Utf8String* characterList) => SanitizeString((AllowedEntities)flags, characterList);
 
     public byte GetCharAt(int idx) => idx < 0 ? byte.MinValue : GetCharAt((ulong)idx);
 
@@ -198,4 +210,39 @@ public unsafe partial struct Utf8String : ICreatable, IDisposable, IStaticNative
         if (item2.IsUsingInlineBuffer)
             item2.StringPtr = (byte*)Unsafe.AsPointer(ref item2.InlineBuffer[0]);
     }
+}
+
+[Flags]
+public enum AllowedEntities : ushort {
+    /// <summary> Uppercase letters (A-Z) </summary>
+    UppercaseLetters = 1 << 0,
+
+    /// <summary> Lowercase letters (a-z) </summary>
+    LowercaseLetters = 1 << 1,
+
+    /// <summary> Numbers (0-9) </summary>
+    Numbers = 1 << 2,
+
+    /// <summary> Whitespace and special characters </summary>
+    /// <remarks> !&quot;#$%&amp;&apos;()*+,-./:;\&lt;=&gt;?@[\]^_`{|}~¡¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ </remarks>
+    SpecialCharacters = 1 << 3,
+
+    /// <summary> Includes characters from a list passed to <see cref="Utf8String.SanitizeString(AllowedEntities, Utf8String*)"/>. </summary>
+    CharacterList = 1 << 4,
+
+    /// <summary> New line </summary>
+    NewLines = 1 << 5,
+
+    /// <summary> SeString payloads </summary>
+    Payloads = 1 << 6,
+
+    Unknown7 = 1 << 7,
+    Unknown8 = 1 << 8,
+    Unknown9 = 1 << 9, // Only used in Chinese/Korean clients?!
+
+    /// <summary> CJK Unified Ideographs and Hiragana </summary>
+    /// <remarks> Also seems to allow special characters. </remarks>
+    CJK = 1 << 10,
+
+    Unknown11 = 1 << 11,
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1860,6 +1860,7 @@ classes:
       0x1417CCAD0: SanitizeString
       0x1417CD170: SanitizeStringCh
       0x1417CD690: SanitizeStringKo
+      0x1417CDB40: GetParts
   Component::GUI::AtkValue:
     funcs:
       0x1405E2E20: ctor_copy # copy constructor

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1858,6 +1858,8 @@ classes:
       0x14005ECB0: FindFirstOfImpl
       0x140753FF0: ToInteger # strtoi for utf8string (str, base)
       0x1417CCAD0: SanitizeString
+      0x1417CD170: SanitizeStringCh
+      0x1417CD690: SanitizeStringKo
   Component::GUI::AtkValue:
     funcs:
       0x1405E2E20: ctor_copy # copy constructor


### PR DESCRIPTION
**Summary:**

- Added an `AllowedEntities` enum for the `Utf8String.SanitizeString` function.
- Added `Utf8String.GetParts`, which extracts the different texts and payloads from a string and adds them to a vector.

---

**Regarding SanitizeString:**

The commonly used flags 0x27F, which I don't know where those comes from, allow the following:
- UppercaseLetters
- LowercaseLetters
- Numbers
- SpecialCharacters
- CharacterList
- NewLines
- Payloads
- Unknown9 (Chinese/Korean client specific?)

---

**GetParts Example:**

```cs
var str = Utf8String.FromSequence(ReadOnlySeString.FromMacroString("<string(gstr1)><string(gstr2)><bold(1)>Hello @ World<bold(0)>"));
var vector = new StdVector<Utf8StringPart>();

str->GetParts(&vector);

foreach (var part in vector)
{
    ImGui.TextUnformatted($"Payload: {new ReadOnlySeStringSpan(part.Payload.AsSpan()).ToString()}");
    ImGui.TextUnformatted($"Text: {new ReadOnlySeStringSpan(part.Text.AsSpan()).ToString()}");
    ImGui.Separator();

    part.Payload.Dtor();
    part.Text.Dtor();
}
```

Renders:

![Screenshot](https://github.com/user-attachments/assets/09b562cb-137b-4945-9f32-d0f9cdb69c97)