### PR TITLE
Rename CString to StringPointer

### DIFF
--- a/CExporter/Extensions.cs
+++ b/CExporter/Extensions.cs
@@ -104,7 +104,7 @@ public static partial class TypeExtensions {
             _ when type == typeof(Half) => "__int16", // Half is a struct that is 2 bytes long and does not exist in C so we just use __int16
             _ when type == typeof(void*) => "__int64",
             _ when type == typeof(void**) => "__int64*",
-            _ when type == typeof(CString) => "byte*",
+            _ when type == typeof(StringPointer) => "byte*",
             _ => type.SanitizeName()
         };
         return builder.Append(name).Replace("+", ExporterStatics.Separator).Replace(".", ExporterStatics.Separator).ToString();
@@ -115,7 +115,7 @@ public static partial class TypeExtensions {
             _ when type == typeof(sbyte) || type == typeof(byte) || type == typeof(bool) => 1,
             _ when type == typeof(char) || type == typeof(short) || type == typeof(ushort) || type == typeof(Half) => 2,
             _ when type == typeof(int) || type == typeof(uint) || type == typeof(float) => 4,
-            _ when type == typeof(long) || type == typeof(ulong) || type == typeof(double) || type.IsPointer || type.IsFunctionPointer || type.IsUnmanagedFunctionPointer || (type.Name == "Pointer`1" && type.Namespace.AsSpan().SequenceEqual(ExporterStatics.InteropNamespacePrefix)) || type == typeof(CString) => 8,
+            _ when type == typeof(long) || type == typeof(ulong) || type == typeof(double) || type.IsPointer || type.IsFunctionPointer || type.IsUnmanagedFunctionPointer || (type.Name == "Pointer`1" && type.Namespace.AsSpan().SequenceEqual(ExporterStatics.InteropNamespacePrefix)) || type == typeof(StringPointer) => 8,
             _ when type.Name.StartsWith("FixedSizeArray") => type.GetGenericArguments()[0].SizeOf() * int.Parse(type.Name[14..type.Name.IndexOf('`')]),
             _ when type.GetCustomAttribute<InlineArrayAttribute>() is { Length: var length } => type.GetGenericArguments()[0].SizeOf() * length,
             _ when type.IsStruct() && !type.IsGenericType && (type.StructLayoutAttribute?.Value ?? LayoutKind.Sequential) != LayoutKind.Sequential => type.StructLayoutAttribute?.Size ?? (int?)typeof(Unsafe).GetMethod("SizeOf")?.MakeGenericMethod(type).Invoke(null, null) ?? 0,

--- a/FFXIVClientStructs/FFXIV/Component/Completion/CategoryData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Completion/CategoryData.cs
@@ -5,7 +5,7 @@ namespace FFXIVClientStructs.FFXIV.Component.Completion;
 // Component::Completion::CategoryData
 [StructLayout(LayoutKind.Explicit, Size = 0xC0)]
 public struct CategoryData {
-    [FieldOffset(0x08)] public StdVector<CString> CompletionTexts;
+    [FieldOffset(0x08)] public StdVector<StringPointer> CompletionTexts;
     [FieldOffset(0x20)] public StdVector<CompletionDataStruct> CompletionData;
     // [FieldOffset(0x38)] private StdVector<{ 4 bytes }> Unk38;
     [FieldOffset(0x50)] private Utf8String Unk50;

--- a/FFXIVClientStructs/FFXIV/Component/Completion/CompletionModule.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Completion/CompletionModule.cs
@@ -18,7 +18,7 @@ public unsafe partial struct CompletionModule {
     [FieldOffset(0x20)] public RaptureTextModule* RaptureTextModule;
 
     [FieldOffset(0x30)] public StdVector<Pointer<CategoryData>> CategoryData;
-    [FieldOffset(0x48)] public StdVector<CString> CategoryNames;
+    [FieldOffset(0x48)] public StdVector<StringPointer> CategoryNames;
     // [FieldOffset(0x60)] public StdVector<{ 8 bytes }> Unk60;
     [FieldOffset(0x78)] private StdVector<byte> Unk78;
 

--- a/FFXIVClientStructs/Interop/StringPointer.cs
+++ b/FFXIVClientStructs/Interop/StringPointer.cs
@@ -4,7 +4,7 @@ namespace FFXIVClientStructs.Interop;
 
 [CExportIgnore]
 [StructLayout(LayoutKind.Explicit, Size = 0x08)]
-public unsafe struct CString {
+public unsafe struct StringPointer {
     [FieldOffset(0x00)] public byte* Value;
 
     public ReadOnlySpan<byte> AsSpan() => MemoryMarshal.CreateReadOnlySpanFromNullTerminated(Value);
@@ -12,5 +12,5 @@ public unsafe struct CString {
     public override string ToString() => AsSpan().IsEmpty ? string.Empty : Encoding.UTF8.GetString(AsSpan());
     public int Length => AsSpan().Length;
 
-    public static implicit operator byte*(CString cstr) => cstr.Value;
+    public static implicit operator byte*(StringPointer cstr) => cstr.Value;
 }


### PR DESCRIPTION
Renaming the type to better reflect that it's a pointer type.
For reference, Pohky said I can still rename it: https://discord.com/channels/581875019861328007/1246473943548825730/1334184320604176455