### PR TITLE
Add LuaTexts to LuaEventHandler

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/CustomTalkEventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/CustomTalkEventHandler.cs
@@ -1,0 +1,9 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game.Event;
+
+// Client::Game::Event::CustomTalkEventHandler
+//   Client::Game::Event::LuaEventHandler
+//     Client::Game::Event::EventHandler
+[GenerateInterop]
+[Inherits<LuaEventHandler>]
+[StructLayout(LayoutKind.Explicit, Size = 0x4C0)]
+public partial struct CustomTalkEventHandler;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/LuaEventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/LuaEventHandler.cs
@@ -13,4 +13,12 @@ public unsafe partial struct LuaEventHandler {
     [FieldOffset(0x218)] public LuaScriptLoader<LuaEventHandler> LuaScriptLoader;
     [FieldOffset(0x240)] public Utf8String LuaClass;
     [FieldOffset(0x2A8)] public Utf8String LuaKey;
+
+    [FieldOffset(0x310)] public StdMap<uint, LuaEventHandlerLuaText> LuaTexts;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0xD0)]
+public struct LuaEventHandlerLuaText {
+    [FieldOffset(0x00)] public Utf8String Key;
+    [FieldOffset(0x68)] public Utf8String Value;
 }


### PR DESCRIPTION
The lua scripts use enums that map the Key from the added LuaEventHandlerLuaText struct to the Key from the StdMap as value.

![Script Decomp](https://github.com/user-attachments/assets/c7cbd3c2-f410-45ea-a66d-06452fda7a34)

When they are handled, these values resolve to the strings in this StdMap, usually texts from `custom/` sheets.

![Example](https://github.com/user-attachments/assets/26011017-3048-4b57-9f5c-b62bf36de733)