### PR TITLE
Update ShellCommandInterface

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/Shell/ShellCommandInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Shell/ShellCommandInterface.cs
@@ -1,4 +1,17 @@
+using FFXIVClientStructs.FFXIV.Client.System.String;
+
 namespace FFXIVClientStructs.FFXIV.Component.Shell;
 
+[GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x08)]
-public struct ShellCommandInterface;
+public unsafe partial struct ShellCommandInterface {
+    [VirtualFunction(1)]
+    public partial int ExecuteCommand(CommandData* commandData, void* source);
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x30)]
+    public struct CommandData {
+        [FieldOffset(0x00)] public ushort TextCommandId;
+
+        [FieldOffset(0x18)] public StdVector<Utf8String> StringArgs;
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Component/Shell/ShellCommandInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Shell/ShellCommandInterface.cs
@@ -6,10 +6,10 @@ namespace FFXIVClientStructs.FFXIV.Component.Shell;
 [StructLayout(LayoutKind.Explicit, Size = 0x08)]
 public unsafe partial struct ShellCommandInterface {
     [VirtualFunction(1)]
-    public partial int ExecuteCommand(CommandData* commandData, void* source);
+    public partial int ExecuteCommand(CommandContext* context, void* source);
 
     [StructLayout(LayoutKind.Explicit, Size = 0x30)]
-    public struct CommandData {
+    public struct CommandContext {
         [FieldOffset(0x00)] public ushort TextCommandId;
 
         [FieldOffset(0x18)] public StdVector<Utf8String> StringArgs;


### PR DESCRIPTION
Regarding the `void* source` arg, aers explained it [here](https://discord.com/channels/581875019861328007/1246473943548825730/1275448441048399965) and further down [here](https://discord.com/channels/581875019861328007/1246473943548825730/1275456248652894311) in #clientstructs-dev of the [XIVLauncher & Dalamud Discord](https://goat.place/).

Regarding the size of the `CommandData` struct, I'm not sure if aers was talking about the same thing [here](https://discord.com/channels/581875019861328007/1246473943548825730/1275457392079011860), but it fits. 🤷‍♂️
I don't know what the additional data is inside it though. Maybe columns from the TextCommand sheet, but I couldn't find anything quickly.