### PR TITLE
Fix offset of AtkArrayData.SubscribedAddonsCount

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkArrayData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkArrayData.cs
@@ -6,8 +6,9 @@ public unsafe partial struct AtkArrayData {
     [FieldOffset(0x8)] public int Size;
     [FieldOffset(0xC), FixedSizeArray] internal FixedSizeArray16<byte> _subscribedAddons;
     [FieldOffset(0x1C)] public byte Unk1C;
-    [FieldOffset(0x1D)] public byte SubscribedAddonsCount;
-    [FieldOffset(0x1E)] public byte Unk1E;
+    [FieldOffset(0x1D)] public byte Unk1D;
+    [FieldOffset(0x1E), Obsolete("Offset of SubscribedAddonsCount was fixed", true)] public byte Unk1E;
+    [FieldOffset(0x1E)] public byte SubscribedAddonsCount;
     /// <remarks>
     /// 0 = No update pending<br/>
     /// 1 = Update subscribed addons (specific flags are checked in AtkUnitManager.UpdateAddonByID)<br/>

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -6330,19 +6330,34 @@ classes:
   Component::GUI::AtkArrayData:
     vtbls:
       - ea: 0x141F66DC8
+    vfuncs:
+      0: Dtor
+      1: FreeManagedData
+    funcs:
+      0x1405E23A0: SortSubscribedAddons
+      0x1405E2420: HasRefs
+      0x1405E2430: IsUnused
+      0x1405E2450: IncRef
+      0x1405E2480: DecRef
   Component::GUI::NumberArrayData:
     vtbls:
       - ea: 0x141F66DD8
         base: Component::GUI::AtkArrayData
     funcs:
-      0x1405E25F0: SetValue
+      0x1405E24A0: ctor
+      0x1405E24E0: Finalizer
+      0x1405E2520: Initialize
       0x1405E2590: SetValueIfDifferent
+      0x1405E25C0: SetValueUnsuppressable
+      0x1405E25F0: SetValue
       0x1405E2620: SetValueForced
   Component::GUI::StringArrayData:
     vtbls:
       - ea: 0x141F66DE8
         base: Component::GUI::AtkArrayData
     funcs:
+      0x1405E2640: Finalizer
+      0x1405E2710: Initialize
       0x1405E28C0: SetValue
       0x1405E2A90: SetValueUtf8
       0x1405E2AF0: SetValueIfDifferent
@@ -6357,6 +6372,7 @@ classes:
         base: Component::GUI::AtkArrayData
     funcs:
       0x140E277E0: SetValue # (this, int index, Client::UI::Agent::MapMarkerBase *marker)
+      0x1405E2D40: HasValueAtIndex
   Component::GUI::AtkServer:
     vtbls:
       - ea: 0x141F66E08


### PR DESCRIPTION
The SubscribedAddons array most likely got bigger, but I still can't find a length in the exe.
Anyhow, that's why the offset of `SubscribedAddonsCount` shifted.