### PR TITLE
Update Portrait/Adventurer Plate structs

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/LookAtContainer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/LookAtContainer.cs
@@ -18,7 +18,7 @@ public unsafe partial struct LookAtContainer {
 
     [FieldOffset(0xBB0)] public byte FaceCameraFlag; // looks like a bitfield but only with one bit used
 
-    [FieldOffset(0xBB4)] public Vector2 BannerHeadDirection;
+    [FieldOffset(0xBB4)] public Vector2 BannerHeadDirection; // TODO: these are of type Client::Game::Control::MoveControl::SplineVector2
     [FieldOffset(0xBBC)] public Vector2 BannerEyeDirection;
     [FieldOffset(0xBC4)] public BannerCameraFollowFlags BannerCameraFollowFlag;
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/CharaCard.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/CharaCard.cs
@@ -1,6 +1,135 @@
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+
 namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 
 // Client::Game::UI::CharaCard
 [StructLayout(LayoutKind.Explicit, Size = 0x1E8)]
-public struct CharaCard;
-// contains temporary data when sending banner updates to the server
+public struct CharaCard {
+    [FieldOffset(0x000)] public BannerData TempBannerData; // used temporarily when sending the packet
+    [FieldOffset(0x034)] public BannerData CurrentBannerData;
+    [FieldOffset(0x068)] public CharaCardData TempCharaCardData;
+    [FieldOffset(0x124)] public CharaCardData CurrentCharaCardData;
+    [FieldOffset(0x1E0)] public CharaCardFlags Flags;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x40)]
+public struct BannerData {
+    [FieldOffset(0x00)] public byte HasData;
+    [FieldOffset(0x01)] public byte Expression;
+    [FieldOffset(0x02)] public byte CameraZoom;
+    [FieldOffset(0x03)] public byte DirectionalLightingColorRed;
+    [FieldOffset(0x04)] public byte DirectionalLightingColorGreen;
+    [FieldOffset(0x05)] public byte DirectionalLightingColorBlue;
+    [FieldOffset(0x06)] public byte DirectionalLightingBrightness;
+    [FieldOffset(0x07)] public byte AmbientLightingColorRed;
+    [FieldOffset(0x08)] public byte AmbientLightingColorGreen;
+    [FieldOffset(0x09)] public byte AmbientLightingColorBlue;
+    [FieldOffset(0x0A)] public byte AmbientLightingBrightness;
+    [FieldOffset(0x0B)] public byte Flags;
+    [FieldOffset(0x0C)] public ushort BannerTimeline;
+    [FieldOffset(0x0D)] public ushort AnimationProgress;
+    [FieldOffset(0x0F)] public ushort HeadDirectionY;
+    [FieldOffset(0x11)] public ushort HeadDirectionX;
+    [FieldOffset(0x13)] public ushort EyeDirectionY;
+    [FieldOffset(0x15)] public ushort EyeDirectionX;
+    [FieldOffset(0x17)] public ushort CameraPositionX;
+    [FieldOffset(0x19)] public ushort CameraPositionY;
+    [FieldOffset(0x1B)] public ushort CameraPositionZ;
+    [FieldOffset(0x1D)] public ushort CameraTargetX;
+    [FieldOffset(0x1F)] public ushort CameraTargetY;
+    [FieldOffset(0x21)] public ushort CameraTargetZ;
+    [FieldOffset(0x23)] public ushort ImageRotation;
+    [FieldOffset(0x25)] public ushort DirectionalLightingVerticalAngle;
+    [FieldOffset(0x27)] public ushort DirectionalLightingHorizontalAngle;
+    [FieldOffset(0x29)] public ushort BannerDecoration;
+    [FieldOffset(0x2B)] public ushort BannerBg;
+    [FieldOffset(0x2D)] public ushort BannerFrame;
+    [FieldOffset(0x2F)] public uint Checksum;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0xBC)]
+public partial struct CharaCardData {
+    [FieldOffset(0x00)] public Data8Struct Data8;
+    [FieldOffset(0x52)] public Data16Struct Data16;
+    [FieldOffset(0x88)] public Data32Struct Data32;
+
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 0x52)]
+    public partial struct Data8Struct {
+        [FieldOffset(0x00), CExportIgnore, FixedSizeArray] internal FixedSizeArray82<byte> _data;
+
+        [FieldOffset(0x00)] public byte Version;
+        [FieldOffset(0x01)] public byte Expression;
+        [FieldOffset(0x02)] public byte CameraZoom;
+        [FieldOffset(0x03)] public byte DirectionalLightingColorRed;
+        [FieldOffset(0x04)] public byte DirectionalLightingColorGreen;
+        [FieldOffset(0x05)] public byte DirectionalLightingColorBlue;
+        [FieldOffset(0x06)] public byte DirectionalLightingBrightness;
+        [FieldOffset(0x07)] public byte AmbientLightingColorRed;
+        [FieldOffset(0x08)] public byte AmbientLightingColorGreen;
+        [FieldOffset(0x09)] public byte AmbientLightingColorBlue;
+        [FieldOffset(0x0A)] public byte AmbientLightingBrightness;
+        [FieldOffset(0x0B)] public byte ClassJobId;
+        [FieldOffset(0x0C)] public CustomizeData CustomizeData;
+        [FieldOffset(0x26), FixedSizeArray] internal FixedSizeArray12<byte> _itemStain0Ids;
+        [FieldOffset(0x32)] public BannerGearVisibilityFlag GearVisibilityFlag;
+        [FieldOffset(0x33)] public byte TopBorder;
+        [FieldOffset(0x34)] public byte BottomBorder;
+        [FieldOffset(0x35)] public byte PreferredClassJobId;
+        [FieldOffset(0x36), FixedSizeArray] internal FixedSizeArray3<byte> _activeHoursWeekdays;
+        [FieldOffset(0x39), FixedSizeArray] internal FixedSizeArray3<byte> _activeHoursWeekends;
+        [FieldOffset(0x3C), FixedSizeArray] internal FixedSizeArray6<byte> _playStyles;
+        [FieldOffset(0x42)] public byte Flags; // &1 == WasResetDueToFantasia; &2 == Visible to No One
+        [FieldOffset(0x43)] public byte Unk43;
+        [FieldOffset(0x44)] public byte PrivacyFlags; // &1 == Friends Only
+        [FieldOffset(0x45), FixedSizeArray] internal FixedSizeArray12<byte> _itemStain1Ids;
+        [FieldOffset(0x51)] public byte Unk51;
+    }
+
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 0x36)]
+    public partial struct Data16Struct {
+        [FieldOffset(0x00), CExportIgnore, FixedSizeArray] internal FixedSizeArray27<ushort> _data;
+
+        [FieldOffset(0x00)] public ushort BannerTimeline;
+        [FieldOffset(0x02)] public ushort AnimationProgress;
+        [FieldOffset(0x04)] public ushort HeadDirectionY;
+        [FieldOffset(0x06)] public ushort HeadDirectionX;
+        [FieldOffset(0x08)] public ushort EyeDirectionY;
+        [FieldOffset(0x0A)] public ushort EyeDirectionX;
+        [FieldOffset(0x0C)] public ushort CameraPositionX;
+        [FieldOffset(0x0E)] public ushort CameraPositionY;
+        [FieldOffset(0x10)] public ushort CameraPositionZ;
+        [FieldOffset(0x12)] public ushort CameraTargetX;
+        [FieldOffset(0x14)] public ushort CameraTargetY;
+        [FieldOffset(0x16)] public ushort CameraTargetZ;
+        [FieldOffset(0x18)] public ushort ImageRotation;
+        [FieldOffset(0x1A)] public ushort DirectionalLightingVerticalAngle;
+        [FieldOffset(0x1C)] public ushort DirectionalLightingHorizontalAngle;
+        [FieldOffset(0x1E)] public ushort BannerDecoration;
+        [FieldOffset(0x20)] public ushort BannerBg;
+        [FieldOffset(0x22)] public ushort BannerFrame;
+        [FieldOffset(0x24)] public ushort TitleId;
+        [FieldOffset(0x26)] public ushort BasePlate;
+        [FieldOffset(0x28), FixedSizeArray] internal FixedSizeArray5<ushort> _decorations;
+        [FieldOffset(0x32), FixedSizeArray] internal FixedSizeArray2<ushort> _glassesIds;
+    }
+
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 0x34)]
+    public partial struct Data32Struct {
+        [FieldOffset(0x00), CExportIgnore, FixedSizeArray] internal FixedSizeArray13<uint> _data;
+
+        [FieldOffset(0x00)] public uint Timestamp; // what for?
+        [FieldOffset(0x04), FixedSizeArray] internal FixedSizeArray12<uint> _itemIds;
+    }
+}
+
+[Flags]
+public enum CharaCardFlags {
+    None = 0,
+    HasCurrentBannerData = 1,
+    HasCurrentCharaCardData = 2,
+    HasCurrentCharaCardDataTimestamp = 4,
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/CharaCard.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/CharaCard.cs
@@ -73,7 +73,7 @@ public partial struct CharaCardData {
         [FieldOffset(0x0B)] public byte ClassJobId;
         [FieldOffset(0x0C)] public CustomizeData CustomizeData;
         [FieldOffset(0x26), FixedSizeArray] internal FixedSizeArray12<byte> _itemStain0Ids;
-        [FieldOffset(0x32)] public BannerGearVisibilityFlag GearVisibilityFlag;
+        [FieldOffset(0x32)] public byte GearVisibilityFlag;
         [FieldOffset(0x33)] public byte TopBorder;
         [FieldOffset(0x34)] public byte BottomBorder;
         [FieldOffset(0x35)] public byte PreferredClassJobId;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/CharaCard.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/CharaCard.cs
@@ -13,7 +13,7 @@ public struct CharaCard {
     [FieldOffset(0x1E0)] public CharaCardFlags Flags;
 }
 
-[StructLayout(LayoutKind.Explicit, Size = 0x40)]
+[StructLayout(LayoutKind.Explicit, Size = 0x34)]
 public struct BannerData {
     [FieldOffset(0x00)] public byte HasData;
     [FieldOffset(0x01)] public byte Expression;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/CharaCard.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/CharaCard.cs
@@ -28,24 +28,24 @@ public struct BannerData {
     [FieldOffset(0x0A)] public byte AmbientLightingBrightness;
     [FieldOffset(0x0B)] public byte Flags;
     [FieldOffset(0x0C)] public ushort BannerTimeline;
-    [FieldOffset(0x0D)] public ushort AnimationProgress;
-    [FieldOffset(0x0F)] public ushort HeadDirectionY;
-    [FieldOffset(0x11)] public ushort HeadDirectionX;
-    [FieldOffset(0x13)] public ushort EyeDirectionY;
-    [FieldOffset(0x15)] public ushort EyeDirectionX;
-    [FieldOffset(0x17)] public ushort CameraPositionX;
-    [FieldOffset(0x19)] public ushort CameraPositionY;
-    [FieldOffset(0x1B)] public ushort CameraPositionZ;
-    [FieldOffset(0x1D)] public ushort CameraTargetX;
-    [FieldOffset(0x1F)] public ushort CameraTargetY;
-    [FieldOffset(0x21)] public ushort CameraTargetZ;
-    [FieldOffset(0x23)] public ushort ImageRotation;
-    [FieldOffset(0x25)] public ushort DirectionalLightingVerticalAngle;
-    [FieldOffset(0x27)] public ushort DirectionalLightingHorizontalAngle;
-    [FieldOffset(0x29)] public ushort BannerDecoration;
-    [FieldOffset(0x2B)] public ushort BannerBg;
-    [FieldOffset(0x2D)] public ushort BannerFrame;
-    [FieldOffset(0x2F)] public uint Checksum;
+    [FieldOffset(0x0E)] public ushort AnimationProgress;
+    [FieldOffset(0x10)] public ushort HeadDirectionY;
+    [FieldOffset(0x12)] public ushort HeadDirectionX;
+    [FieldOffset(0x14)] public ushort EyeDirectionY;
+    [FieldOffset(0x16)] public ushort EyeDirectionX;
+    [FieldOffset(0x18)] public ushort CameraPositionX;
+    [FieldOffset(0x1A)] public ushort CameraPositionY;
+    [FieldOffset(0x1C)] public ushort CameraPositionZ;
+    [FieldOffset(0x1E)] public ushort CameraTargetX;
+    [FieldOffset(0x20)] public ushort CameraTargetY;
+    [FieldOffset(0x22)] public ushort CameraTargetZ;
+    [FieldOffset(0x24)] public ushort ImageRotation;
+    [FieldOffset(0x26)] public ushort DirectionalLightingVerticalAngle;
+    [FieldOffset(0x28)] public ushort DirectionalLightingHorizontalAngle;
+    [FieldOffset(0x2A)] public ushort BannerDecoration;
+    [FieldOffset(0x2C)] public ushort BannerBg;
+    [FieldOffset(0x2E)] public ushort BannerFrame;
+    [FieldOffset(0x30)] public uint Checksum;
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0xBC)]

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
@@ -46,7 +46,7 @@ public unsafe partial struct UIState {
     [FieldOffset(0xB690)] public NpcTrade NpcTrade;
     [FieldOffset(0xB9B8)] public DirectorTodo DirectorTodo;
     [FieldOffset(0xBB00)] public DirectorTodo FateDirectorTodo;
-    [FieldOffset(0xBC48)] internal DirectorTodo UnkThirdTodo; // 7.1: a third one?
+    [FieldOffset(0xBC48)] public DirectorTodo MassivePcContentTodo;
     [FieldOffset(0xBD90)] public Map Map;
     [FieldOffset(0xFD90)] public MarkingController MarkingController;
     [FieldOffset(0x10070)] public LimitBreakController LimitBreakController;
@@ -71,7 +71,7 @@ public unsafe partial struct UIState {
     [FieldOffset(0x17E80)] public CharaCard CharaCard;
     // ItemAction Unlocks
     [FieldOffset(0x180C0)] public ClientSelectDataConfigFlags ClientSelectDataConfigFlags;
-    //[FieldOffset(0x180C2)] public ushort CharaViewGlamourIdFlag(s);
+    [FieldOffset(0x180C2)] public ushort CurrentGlamourErrorsBitmask;
     [FieldOffset(0x180C4)] public ushort CurrentItemLevel; // as shown in the Character window
     // [FieldOffset(0x180C8)] public long ?; // something regarding FreeCompanyCrest?
     [FieldOffset(0x180D0)] public long NextMapAllowanceTimestamp;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerEditor.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerEditor.cs
@@ -74,23 +74,21 @@ public unsafe partial struct AgentBannerEditorState {
     [FieldOffset(0x90)] public Dataset Accents;
     [FieldOffset(0xC0)] public Dataset Poses;
     [FieldOffset(0xF0)] public Dataset Expressions;
-
-    // 7.0: new filters here
-
+    [FieldOffset(0x120)] internal FixedSizeArray11<CharaCardDesignCategoryEntry> _charaCardDesignCategoryEntries;
+    [FieldOffset(0x1D0)] internal FixedSizeArray11<Pointer<CharaCardDesignCategoryEntry>> _charaCardDesignCategoryEntryPointers;
+    [FieldOffset(0x228)] public int NumCharaCardDesignCategoryEntries;
     [FieldOffset(0x230)] public BannerModuleEntry BannerEntry;
-
-    // presumably a struct of size 0x64
-    [FieldOffset(0x350), FixedSizeArray] internal FixedSizeArray14<uint> _itemIds;
-    [FieldOffset(0x388), FixedSizeArray] internal FixedSizeArray14<byte> _stain0Ids;
-    [FieldOffset(0x396), FixedSizeArray] internal FixedSizeArray14<byte> _stain1Ids;
-    [FieldOffset(0x3A4), FixedSizeArray] internal FixedSizeArray2<ushort> _glassesIds;
-    [FieldOffset(0x3A8)] public uint Checksum;
-    [FieldOffset(0x3AC)] public BannerGearVisibilityFlag GearVisibilityFlag;
+    [FieldOffset(0x2C0)] public BannerModuleEntry BannerEntryBackup; // BannerEntry is saved here when opening one of those Lists (e.g. "Display Backgrounds List"), and is restored when cancelling out.
+    [FieldOffset(0x350)] public BannerGearData GearData;
+    [FieldOffset(0x350), FixedSizeArray, Obsolete("Use GearData.ItemIds")] internal FixedSizeArray14<uint> _itemIds;
+    [FieldOffset(0x388), FixedSizeArray, Obsolete("Use GearData.Stain1Ids")] internal FixedSizeArray14<byte> _stain0Ids;
+    [FieldOffset(0x396), FixedSizeArray, Obsolete("Use GearData.Stain2Ids")] internal FixedSizeArray14<byte> _stain1Ids;
+    [FieldOffset(0x3A4), FixedSizeArray, Obsolete("Use GearData.GlassesIds")] internal FixedSizeArray2<ushort> _glassesIds;
+    [FieldOffset(0x3A8), Obsolete("Use GearData.Checksum")] public uint Checksum;
+    [FieldOffset(0x3AC), Obsolete("Use GearData.GearVisibilityFlag")] public BannerGearVisibilityFlag GearVisibilityFlag;
     [FieldOffset(0x3B0), Obsolete("Renamed to EnabledGearsetIndex. This is the index of a RaptureGearsetModule.Entries list, which only contains enabled entries.")] public byte GearsetIndex;
-    [FieldOffset(0x3B0)] public byte EnabledGearsetIndex;
-    [FieldOffset(0x3B1)] public byte ClassJobId;
-    //[FieldOffset(0x3B2)] public byte UnkByteOrBool;
-    //[FieldOffset(0x3B3)] public byte UnkByteOrBool;
+    [FieldOffset(0x3B0), Obsolete("Use GearData.EnabledGearsetIndex")] public byte EnabledGearsetIndex;
+    [FieldOffset(0x3B1), Obsolete("Use GearData.ClassJobId")] public byte ClassJobId;
     [FieldOffset(0x3B8)] public AgentBannerEditor* AgentBannerEditor;
     [FieldOffset(0x3C0)] public UIModule* UIModule;
     [FieldOffset(0x3C8)] public CharaViewPortrait* CharaView;
@@ -118,4 +116,10 @@ public unsafe partial struct AgentBannerEditorState {
 
     [MemberFunction("E8 ?? ?? ?? ?? 32 C0 EB 3F")]
     public partial void SetHasChanged(bool hasDataChanged);
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x10)]
+    public struct CharaCardDesignCategoryEntry {
+        [FieldOffset(0x00), CExporterExcel("CharaCardDesignCategory")] public void* Row;
+        [FieldOffset(0x08)] public byte RowId;
+    }
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerInterface.cs
@@ -1,6 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
-using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerPreview.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentBannerPreview.cs
@@ -1,0 +1,25 @@
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
+// Client::UI::Agent::AgentBannerPreview
+//   Client::UI::Agent::AgentInterface
+//     Component::GUI::AtkModuleInterface::AtkEventInterface
+[Agent(AgentId.BannerPreview)]
+[GenerateInterop]
+[Inherits<AgentInterface>]
+[StructLayout(LayoutKind.Explicit, Size = 0x30)]
+public unsafe partial struct AgentBannerPreview {
+    [FieldOffset(0x28)] public AgentBannerPreviewState* State;
+}
+
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0x3F8)]
+public unsafe partial struct AgentBannerPreviewState {
+    [FieldOffset(0)] public BannerGearData GearData;
+    [FieldOffset(0x64)] public BannerModuleEntry BannerModuleEntry;
+
+    [FieldOffset(0xF8)] public AgentBannerPreview* AgentPtr;
+    [FieldOffset(0x100)] public UIModule* UIModulePtr;
+    [FieldOffset(0x108)] public CharaViewPortrait* CharaViewPortraitPtr;
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
@@ -1,4 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.Graphics.Kernel;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
@@ -25,49 +26,149 @@ public unsafe partial struct AgentCharaCard {
     private partial void OpenCharaCardForObject(GameObject* gameObject);
     public void OpenCharaCard(GameObject* gameObject) => OpenCharaCardForObject(gameObject);
 
+    [MemberFunction("40 55 53 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 85 ?? ?? ?? ?? 48 83 79")]
+    private partial void OpenCharaCardForPacket(CharaCardPacket* packet);
+
     // Client::UI::Agent::AgentCharaCard::Storage
+    [GenerateInterop]
     [StructLayout(LayoutKind.Explicit, Size = 0x9B0)]
     public unsafe partial struct Storage {
-        [FieldOffset(0x4)] public uint EntityId;
-        [FieldOffset(0x8)] public ulong ContentId;
-
+        [FieldOffset(0x00)] public byte Flag0;
+        [FieldOffset(0x01)] public byte Flag1;
+        [FieldOffset(0x02)] public byte Flag2;
+        [FieldOffset(0x03)] public byte Flag3;
+        [FieldOffset(0x04)] public uint EntityId;
+        [FieldOffset(0x08)] public ulong AccountId;
+        [FieldOffset(0x10)] public ulong ContentId;
+        [FieldOffset(0x18)] public bool IsNotCreated; // Addon#15092
+        [FieldOffset(0x19)] public bool WasResetDueToFantasia; // Addon#15093
+        [FieldOffset(0x1A)] public bool CanEdit;
         [FieldOffset(0x1B)] public bool InvertPortraitPlacement;
-        [FieldOffset(0x1C)] public byte BasePlate; // CharaCardBase sheet
-        [FieldOffset(0x22)] public byte Backing; // CharaCardDecoration sheet
-        [FieldOffset(0x1E)] public byte TopBorder; // CharaCardHeader sheet
-        [FieldOffset(0x1F)] public byte BottomBorder; // CharaCardHeader sheet
-        [FieldOffset(0x24)] public byte PatternOverlay; // CharaCardDecoration sheet
-        [FieldOffset(0x26)] public byte PortraitFrame; // CharaCardDecoration sheet
-        [FieldOffset(0x28)] public byte PlateFrame; // CharaCardDecoration sheet
-        [FieldOffset(0x2A)] public byte Accent; // CharaCardDecoration sheet
+        [FieldOffset(0x1C)] public PlateDesign PlateDesign;
+        [FieldOffset(0x1C), Obsolete("Use PlateDesign.BasePlate")] public ushort BasePlate; // CharaCardBase RowId
+        [FieldOffset(0x1E), Obsolete("Use PlateDesign.TopBorder")] public byte TopBorder; // CharaCardHeader RowId
+        [FieldOffset(0x1F), Obsolete("Use PlateDesign.BottomBorder")] public byte BottomBorder; // CharaCardHeader RowId
+        [FieldOffset(0x22), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public ushort Backing; // CharaCardDecoration RowId
+        [FieldOffset(0x24), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public ushort PatternOverlay; // CharaCardDecoration RowId
+        [FieldOffset(0x26), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public ushort PortraitFrame; // CharaCardDecoration RowId
+        [FieldOffset(0x28), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public ushort PlateFrame; // CharaCardDecoration RowId
+        [FieldOffset(0x2A), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public ushort Accent; // CharaCardDecoration RowId
+        [FieldOffset(0x2C)] public byte NumPlayStyles;
+        /// <remarks> CharaCardPlayStyle RowIds </remarks>
+        [FieldOffset(0x2D), FixedSizeArray] internal FixedSizeArray6<byte> _playStyles;
 
+        [FieldOffset(0x38)] internal long Unk38;
+        [FieldOffset(0x40)] internal int Unk40;
+        [FieldOffset(0x44)] internal int Unk44;
+        [FieldOffset(0x48)] internal int Unk48;
+        [FieldOffset(0x4C)] internal int Unk4C;
+        [FieldOffset(0x50)] public uint ActiveHoursWeekdays;
+        [FieldOffset(0x54)] public uint ActiveHoursWeekends;
+
+        [FieldOffset(0x58)] public ushort BannerBg;
+        [FieldOffset(0x5A)] public ushort BannerFrame;
+        [FieldOffset(0x5C)] public ushort BannerDecoration;
+        //[FieldOffset(0x5E)] public ushort padding?;
         [FieldOffset(0x60)] public Utf8String Name;
         [FieldOffset(0xC8)] public ushort WorldId;
         [FieldOffset(0xCA)] public byte ClassJobId;
-
+        [FieldOffset(0xCB)] public byte GrandCompany;
         [FieldOffset(0xCC)] public byte GcRank;
-
+        [FieldOffset(0xCD)] public byte Sex;
+        [FieldOffset(0xCE)] public byte PreferredClassJobId;
+        //[FieldOffset(0xCF)] public byte padding?;
         [FieldOffset(0xD0)] public ushort Level;
         [FieldOffset(0xD2)] public ushort TitleId;
-
+        // [FieldOffset(0xD4)] public uint padding?;
+        [FieldOffset(0xD8)] public CrestData FreeCompanyCrestData; // not checked
         [FieldOffset(0xE0)] public Utf8String FreeCompany;
         [FieldOffset(0x148)] public Utf8String SearchComment;
         [FieldOffset(0x1B0)] public Utf8String SearchCommentRaw; // contains unresolved AutoTranslatePayloads
+        [FieldOffset(0x218)] public uint BannerBgIconId;
+        [FieldOffset(0x21C)] public uint TopBorderIconId;
+        [FieldOffset(0x220)] public uint BottomBorderIconId;
+        [FieldOffset(0x224)] internal bool Unk224;
+        [FieldOffset(0x225)] internal bool Unk225;
+        [FieldOffset(0x226)] internal bool Unk226;
+        [FieldOffset(0x227)] internal bool Unk227;
+        [FieldOffset(0x22C), FixedSizeArray] internal FixedSizeArray5<Decoration> _decorations;
 
-        [FieldOffset(0x258)] public uint Activity1IconId;
-        [FieldOffset(0x260)] public Utf8String Activity1Name;
-        [FieldOffset(0x2C8)] public uint Activity2IconId;
-        [FieldOffset(0x2D0)] public Utf8String Activity2Name;
-        [FieldOffset(0x338)] public uint Activity3IconId;
-        [FieldOffset(0x340)] public Utf8String Activity3Name;
-        [FieldOffset(0x3A8)] public uint Activity4IconId;
-        [FieldOffset(0x3B0)] public Utf8String Activity4Name;
-        [FieldOffset(0x418)] public uint Activity5IconId;
-        [FieldOffset(0x420)] public Utf8String Activity5Name;
-        [FieldOffset(0x488)] public uint Activity6IconId;
-        [FieldOffset(0x490)] public Utf8String Activity6Name;
+        [FieldOffset(0x258), FixedSizeArray] internal FixedSizeArray6<Activity> _activities;
+        [FieldOffset(0x258), Obsolete("Use Activities[1].IconId")] public uint Activity1IconId;
+        [FieldOffset(0x260), Obsolete("Use Activities[1].Name")] public Utf8String Activity1Name;
+        [FieldOffset(0x2C8), Obsolete("Use Activities[2].IconId")] public uint Activity2IconId;
+        [FieldOffset(0x2D0), Obsolete("Use Activities[2].Name")] public Utf8String Activity2Name;
+        [FieldOffset(0x338), Obsolete("Use Activities[3].IconId")] public uint Activity3IconId;
+        [FieldOffset(0x340), Obsolete("Use Activities[3].Name")] public Utf8String Activity3Name;
+        [FieldOffset(0x3A8), Obsolete("Use Activities[4].IconId")] public uint Activity4IconId;
+        [FieldOffset(0x3B0), Obsolete("Use Activities[4].Name")] public Utf8String Activity4Name;
+        [FieldOffset(0x418), Obsolete("Use Activities[5].IconId")] public uint Activity5IconId;
+        [FieldOffset(0x420), Obsolete("Use Activities[5].Name")] public Utf8String Activity5Name;
+        [FieldOffset(0x488), Obsolete("Use Activities[6].IconId")] public uint Activity6IconId;
+        [FieldOffset(0x490), Obsolete("Use Activities[6].Name")] public Utf8String Activity6Name;
+        [FieldOffset(0x4F8)] public uint BannerFrameIconId;
+        [FieldOffset(0x4FC)] public uint BannerDecorationIconId;
+        // When EditAddonId is closed without saving, these fields are used:
+        [FieldOffset(0x500)] public PlateDesign BackupPlateDesign;
+        [FieldOffset(0x510)] public bool BackupInvertPortraitPlacement;
+
+        // bunch of ExcelSheetWaiters
 
         [FieldOffset(0x540)] public CharaViewPortrait CharaView;
         [FieldOffset(0x960)] public Texture* PortraitTexture;
+        [FieldOffset(0x968)] public ExportedPortraitData PortraitData;
+        /// <remarks> CharaCardEditMenu, CharaCardDesignSetting, BannerEditor, CharaCardProfileSetting </remarks>
+        [FieldOffset(0x99C)] public uint EditAddonId;
+        /// <remarks> To display Addon#15091, Addon#15092 or Addon#15093 </remarks>
+        [FieldOffset(0x9A0)] public uint SelectOkAddonId;
+        [FieldOffset(0x9A4)] public uint InputSearchCommentAddonId;
+        [FieldOffset(0x9A8)] public uint PermissionSettingAddonId;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x70)]
+    public struct Activity {
+        [FieldOffset(0x00)] public uint IconId;
+        [FieldOffset(0x08)] public Utf8String Name;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x8)]
+    public struct Decoration {
+        [FieldOffset(0x00)] public byte Index;
+        [FieldOffset(0x01)] public byte Unk1;
+        [FieldOffset(0x04)] public uint IconId;
+    }
+
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 0x10)]
+    public partial struct PlateDesign {
+        /// <remarks> CharaCardBase RowId </remarks>
+        [FieldOffset(0x00)] public ushort BasePlate;
+        /// <remarks> CharaCardHeader RowId </remarks>
+        [FieldOffset(0x02)] public byte TopBorder;
+        /// <remarks> CharaCardHeader RowId </remarks>
+        [FieldOffset(0x03)] public byte BottomBorder;
+        [FieldOffset(0x04)] public byte NumDecorations;
+        /// <remarks> CharaCardDecoration RowIds </remarks>
+        [FieldOffset(0x06), FixedSizeArray] internal FixedSizeArray5<ushort> _decorations;
+    }
+
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 0x1E6)]
+    public partial struct CharaCardPacket {
+        [FieldOffset(0x000)] public CrestData FreeCompanyCrestData; // guessed
+        [FieldOffset(0x008)] public ulong AccountId;
+        [FieldOffset(0x010)] public ulong ContentId;
+        [FieldOffset(0x018)] public uint EntityId;
+        [FieldOffset(0x01C)] public uint SomeState;
+        [FieldOffset(0x020)] public ushort WorldId;
+        [FieldOffset(0x022)] public ushort Level;
+        [FieldOffset(0x024)] public byte ClassJobId;
+        [FieldOffset(0x025)] public byte Sex;
+        [FieldOffset(0x026)] public byte GrandCompany;
+        [FieldOffset(0x027)] public byte GcRank;
+        [FieldOffset(0x028)] public CharaCardData CharaCardData;
+        [FieldOffset(0x0E4), FixedSizeArray] internal FixedSizeArray193<byte> _searchComment;
+        [FieldOffset(0x1A5), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _name;
+        [FieldOffset(0x1C5), FixedSizeArray(isString: true)] internal FixedSizeArray22<byte> _freeCompany; // length unknown; copied from InfoProxyFreeCompany
     }
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentCharaCard.cs
@@ -45,14 +45,14 @@ public unsafe partial struct AgentCharaCard {
         [FieldOffset(0x1A)] public bool CanEdit;
         [FieldOffset(0x1B)] public bool InvertPortraitPlacement;
         [FieldOffset(0x1C)] public PlateDesign PlateDesign;
-        [FieldOffset(0x1C), Obsolete("Use PlateDesign.BasePlate")] public ushort BasePlate; // CharaCardBase RowId
+        [FieldOffset(0x1C), Obsolete("Use PlateDesign.BasePlate")] public byte BasePlate; // CharaCardBase RowId
         [FieldOffset(0x1E), Obsolete("Use PlateDesign.TopBorder")] public byte TopBorder; // CharaCardHeader RowId
         [FieldOffset(0x1F), Obsolete("Use PlateDesign.BottomBorder")] public byte BottomBorder; // CharaCardHeader RowId
-        [FieldOffset(0x22), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public ushort Backing; // CharaCardDecoration RowId
-        [FieldOffset(0x24), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public ushort PatternOverlay; // CharaCardDecoration RowId
-        [FieldOffset(0x26), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public ushort PortraitFrame; // CharaCardDecoration RowId
-        [FieldOffset(0x28), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public ushort PlateFrame; // CharaCardDecoration RowId
-        [FieldOffset(0x2A), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public ushort Accent; // CharaCardDecoration RowId
+        [FieldOffset(0x22), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public byte Backing; // CharaCardDecoration RowId
+        [FieldOffset(0x24), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public byte PatternOverlay; // CharaCardDecoration RowId
+        [FieldOffset(0x26), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public byte PortraitFrame; // CharaCardDecoration RowId
+        [FieldOffset(0x28), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public byte PlateFrame; // CharaCardDecoration RowId
+        [FieldOffset(0x2A), Obsolete("Not a fixed field. Iterate over PlateDesign.Decorations")] public byte Accent; // CharaCardDecoration RowId
         [FieldOffset(0x2C)] public byte NumPlayStyles;
         /// <remarks> CharaCardPlayStyle RowIds </remarks>
         [FieldOffset(0x2D), FixedSizeArray] internal FixedSizeArray6<byte> _playStyles;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/BannerHelper.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/BannerHelper.cs
@@ -1,0 +1,162 @@
+using FFXIVClientStructs.FFXIV.Client.Game.Character;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using FFXIVClientStructs.FFXIV.Common.Math;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
+
+[GenerateInterop]
+[Inherits<HelperInterface>]
+[StructLayout(LayoutKind.Explicit, Size = 0x50)]
+public unsafe partial struct BannerHelper {
+    [FieldOffset(0x10)] public DefaultBannerPreset DefaultBannerPreset;
+    [FieldOffset(0x48)] public bool IsDefaultPresetLoaded;
+    [FieldOffset(0x49)] public bool IsPortraitClientObjectSetUp; // For CharaViewPortrait, ClientObject 248, EventNpc 1023070
+    /// <remarks> True when EditingPortrait condition is set while editing/viewing local Banners. </remarks>
+    [FieldOffset(0x4A)] public bool IsEditingBanner; // 
+    /// <remarks> True when EditingPortrait condition is set while editing/viewing local CharaCard. </remarks>
+    [FieldOffset(0x4B)] public bool IsEditingCharaCard;
+
+    #region CharaView Helpers
+
+    [MemberFunction("48 89 5C 24 ?? 57 48 83 EC 30 41 0F B7 40")]
+    public partial void ExportedPortraitData_ApplyBannerModuleEntry(ExportedPortraitData* to, BannerModuleEntry* from);
+
+    [MemberFunction("41 80 38 00 75 08")]
+    public partial void CharaViewCharacterData_ApplyCharaCardData(CharaViewCharacterData* to, CharaCardData* from);
+
+    #endregion
+
+    #region BannerData Helpers
+
+    [MemberFunction("E8 ?? ?? ?? ?? 4C 8B 75 28 49 8B 8E")]
+    public partial void RequestCurrentBannerData();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 0F 84 ?? ?? ?? ?? 49 8B 4F 28 4C 89 6C 24")]
+    public partial bool HasCurrentBannerData();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8D 55 B0 48 8B CF E8 ?? ?? ?? ?? 48 8B BC 24")]
+    public partial void BannerData_ApplyBannerModuleEntry(BannerData* to, BannerModuleEntry* from);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B AC 24 ?? ?? ?? ?? 48 8B 4C 24 ?? 48 33 CC E8 ?? ?? ?? ?? 48 83 C4 60")]
+    public partial bool SendBannerData(BannerData* bannerData);
+
+    #endregion
+
+    #region CharaCardData Helpers
+
+    [MemberFunction("E8 ?? ?? ?? ?? 49 8B 6E 28")]
+    public partial void RequestCurrentCharaCard();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 17 48 8B 4F 28")]
+    public partial bool HasCurrentCharaCard();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 4C 48 8D 54 24")]
+    public partial bool HasCharaCardCreated();
+
+    [MemberFunction("C6 02 03 41 0F B7 41")]
+    public partial void CharaCardData_ApplyCharaViewCharacterDataAndBannerModuleEntry(CharaCardData* to, CharaViewCharacterData* from1, BannerModuleEntry* from2);
+
+    [MemberFunction("48 89 5C 24 ?? 41 80 78")]
+    public partial void CharaCardData_ApplyCharaViewCharacterData(CharaCardData* to, CharaViewCharacterData* from);
+
+    [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 8B 4B 28 41 B8")]
+    public partial bool SendCharaCardData(CharaCardData* charaCardData, CharaCardDataChangeReason reason);
+
+    #endregion
+
+    #region BannerGearData Helpers
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8D 43 54")]
+    public partial void BannerGearData_ApplyClassJobIdAndGearVisibilityFromGearset(BannerGearData* bannerGearData);
+
+    [MemberFunction("40 53 48 83 EC 40 0F B6 42 63")]
+    public partial bool BannerGearData_ApplyGearFromGearset(BannerGearData* bannerGearData);
+
+    [MemberFunction("E8 ?? ?? ?? ?? FE C3 41 3A DE")]
+    public partial void BannerGearData_UpdateGearsetChecksum(BannerGearData* bannerGearData);
+
+    #endregion
+
+    #region BannerModuleEntry Helpers
+
+    [MemberFunction("41 0F B7 40 ?? 4C 8B D2")]
+    public partial void BannerModuleEntry_ApplyDefaultBannerPreset(BannerModuleEntry* to, DefaultBannerPreset* from);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8D 4B 64 48 8D 54 24")]
+    public partial void BannerModuleEntry_ApplyBannerData(BannerModuleEntry* to, BannerData* from);
+
+    [MemberFunction("E8 ?? ?? ?? ?? EB 12 4D 8B C6")]
+    public partial void BannerModuleEntry_ApplyCharaCardData(BannerModuleEntry* to, CharaCardData* from);
+
+    [MemberFunction("41 0F B6 80 ?? ?? ?? ?? 88 42 60")]
+    public partial void BannerModuleEntry_ApplyRaceGenderHeightTribe(BannerModuleEntry* bannerModuleEntry, Character* character);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 88 44 24 22 40 84 ED")]
+    public partial bool BannerModuleEntry_IsCurrentCharaCardBannerOutdated(BannerModuleEntry* bannerModuleEntry, bool logError); // not exactly sure
+
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 1D 4C 8D 44 24")]
+    public partial bool BannerModuleEntry_IsCharacterDataOutdated(BannerModuleEntry* bannerModuleEntry, bool logError);
+
+    #endregion
+}
+
+[GenerateInterop(isInherited: true)]
+[StructLayout(LayoutKind.Explicit, Size = 0x34)]
+public partial struct ExportedPortraitData {
+    [FieldOffset(0x0)] public HalfVector4 CameraPosition;
+    [FieldOffset(0x8)] public HalfVector4 CameraTarget;
+    [FieldOffset(0x10)] public short ImageRotation;
+    [FieldOffset(0x12)] public byte CameraZoom;
+    [FieldOffset(0x14)] public ushort BannerTimeline;
+    [FieldOffset(0x18)] public float AnimationProgress;
+    [FieldOffset(0x1C)] public byte Expression;
+    [FieldOffset(0x1E)] public HalfVector2 HeadDirection;
+    [FieldOffset(0x22)] public HalfVector2 EyeDirection;
+    [FieldOffset(0x26)] public byte DirectionalLightingColorRed;
+    [FieldOffset(0x27)] public byte DirectionalLightingColorGreen;
+    [FieldOffset(0x28)] public byte DirectionalLightingColorBlue;
+    [FieldOffset(0x29)] public byte DirectionalLightingBrightness;
+    [FieldOffset(0x2A)] public short DirectionalLightingVerticalAngle;
+    [FieldOffset(0x2C)] public short DirectionalLightingHorizontalAngle;
+    [FieldOffset(0x2E)] public byte AmbientLightingColorRed;
+    [FieldOffset(0x2F)] public byte AmbientLightingColorGreen;
+    [FieldOffset(0x30)] public byte AmbientLightingColorBlue;
+    [FieldOffset(0x31)] public byte AmbientLightingBrightness;
+    [FieldOffset(0x32)] public ushort BannerBg;
+}
+
+[GenerateInterop]
+[Inherits<ExportedPortraitData>]
+[StructLayout(LayoutKind.Explicit, Size = 0x38)]
+public partial struct DefaultBannerPreset {
+    [FieldOffset(0x34)] public ushort BannerFrame;
+    [FieldOffset(0x36)] public ushort BannerDecoration;
+}
+
+[StructLayout(LayoutKind.Explicit, Size = 0x64)]
+public struct BannerGearData {
+    [FieldOffset(0x00), FixedSizeArray] internal FixedSizeArray14<uint> _itemIds;
+    [FieldOffset(0x38), FixedSizeArray] internal FixedSizeArray14<byte> _stain0Ids;
+    [FieldOffset(0x46), FixedSizeArray] internal FixedSizeArray14<byte> _stain1Ids;
+    [FieldOffset(0x54), FixedSizeArray] internal FixedSizeArray2<ushort> _glassesIds;
+    [FieldOffset(0x58)] public uint Checksum;
+    [FieldOffset(0x5C)] public BannerGearVisibilityFlag GearVisibilityFlag;
+    [FieldOffset(0x60)] public byte EnabledGearsetIndex;
+    [FieldOffset(0x61)] public byte ClassJobId;
+}
+
+[Flags]
+public enum BannerGearVisibilityFlag : uint {
+    None = 0,
+    HeadgearHidden = 1 << 0,
+    WeaponHidden = 1 << 1,
+    VisorClosed = 1 << 2,
+}
+
+public enum CharaCardDataChangeReason {
+    Banner = 1,
+    Design = 2,
+    Profile = 3,
+    Permissions = 4,
+    SearchComment = 5, // Only when plate wasn't created yet?!
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/BannerModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/BannerModule.cs
@@ -36,7 +36,7 @@ public unsafe partial struct BannerModule {
     /// </summary>
     /// <returns>Data->NextId</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 83 F8 6E 7D 58")]
-    public partial byte GetNextId();
+    public partial byte GetNextId(); // TODO: returns int
 
     /// <summary>
     /// Get the Banner entry by Id.
@@ -115,12 +115,4 @@ public unsafe partial struct BannerModuleEntry {
     /// <param name="gearVisibilityFlag">Gear Visibility Flags</param>
     [MemberFunction("E8 ?? ?? ?? ?? 89 43 58 48 8B 4D F0")]
     public static partial uint GenerateChecksum(uint* itemIds, byte* stainIds, ushort* glassesIds, BannerGearVisibilityFlag gearVisibilityFlag);
-}
-
-[Flags]
-public enum BannerGearVisibilityFlag : uint {
-    None = 0,
-    HeadgearHidden = 1 << 0,
-    WeaponHidden = 1 << 1,
-    VisorClosed = 1 << 2,
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/CharaView.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/CharaView.cs
@@ -127,13 +127,11 @@ public unsafe partial struct CharaViewModelData {
 public unsafe partial struct CharaViewCharacterData : ICreatable {
     [FieldOffset(0)] public CustomizeData CustomizeData;
     // Unk 2 bytes
-    [Obsolete("Use GlassesId")]
-    [FieldOffset(0x1A)] public ushort Glasses0Id;
-    [Obsolete("Use GlassesId")]
-    [FieldOffset(0x1C)] public ushort Glasses1Id;
     [FieldOffset(0x1C), FixedSizeArray] internal FixedSizeArray14<uint> _itemIds;
     [FieldOffset(0x54), FixedSizeArray] internal FixedSizeArray14<byte> _itemStain0Ids;
     [FieldOffset(0x62), FixedSizeArray] internal FixedSizeArray14<byte> _itemStain1Ids;
+    [FieldOffset(0x70), Obsolete("Use GlassesIds[0]")] public ushort Glasses0Id;
+    [FieldOffset(0x72), Obsolete("Use GlassesIds[1]")] public ushort Glasses1Id;
     [FieldOffset(0x70), FixedSizeArray] internal FixedSizeArray2<ushort> _glassesIds;
     [FieldOffset(0x74)] public byte ClassJobId;
     [FieldOffset(0x75)] public bool HeadgearHidden;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/CharaView.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/CharaView.cs
@@ -26,8 +26,10 @@ public unsafe partial struct CharaView : ICreatable {
     [FieldOffset(0x20)] public Camera* Camera;
     //[FieldOffset(0x28)] public nint Unk28; // float CharacterRotation?
     [FieldOffset(0x30)] public AgentInterface* Agent; // for example: AgentTryOn
-    //[FieldOffset(0x38)] public nint AgentCallbackReady; // if set, called when State changes to Ready
-    //[FieldOffset(0x40)] public nint AgentCallback; // not investigated, used inside vf7 and vf11
+    /// <remarks> (AgentInterface* agent, Texture* charaViewTexture) -> void </remarks>
+    [FieldOffset(0x38)] public nint AgentCallbackReady; // if set, called when State changes to Ready
+    /// <remarks> (AgentInterface* agent) -> Client::Game::Character::Character* </remarks>
+    [FieldOffset(0x40)] public nint AgentCallbackGetCharacter;
     [FieldOffset(0x48)] public CharaViewModelData ModelData;
     [Obsolete("Completely wrong. Use ModelData", true)]
     [FieldOffset(0x48)] public CharaViewCharacterData CharacterData;
@@ -60,6 +62,21 @@ public unsafe partial struct CharaView : ICreatable {
     [VirtualFunction(3)]
     public partial void ResetPositions();
 
+    [VirtualFunction(4)]
+    public partial void SetCameraDistance(float deltaDistance);
+
+    [VirtualFunction(5)]
+    public partial void SetCameraYawAndPitch(float deltaRotation, float deltaPitch);
+
+    [VirtualFunction(6)]
+    public partial void SetCameraXAndY(float deltaX, float deltaY);
+
+    [VirtualFunction(8)]
+    public partial void OnReady();
+
+    [VirtualFunction(10)]
+    public partial void Update();
+
     [MemberFunction("E8 ?? ?? ?? ?? 4D 8B CD 45 8B C4"), Obsolete("Completely wrong. Use SetModelData", true)]
     public partial void SetCustomizeData(CharaViewCharacterData* data);
 
@@ -73,10 +90,10 @@ public unsafe partial struct CharaView : ICreatable {
     public partial Character* GetCharacter();
 
     [MemberFunction("E8 ?? ?? ?? ?? 49 8D 4F 10 88 85")]
-    public partial bool IsAnimationPaused();
+    public partial bool IsAnimationPaused(); // TODO: While this works on CharaView, this is part of CharaViewPortrait. Move it there.
 
     [MemberFunction("E8 ?? ?? ?? ?? B2 01 48 8B CF E8 ?? ?? ?? ?? 32 C0")]
-    public partial void ToggleAnimationPlayback(bool paused);
+    public partial void ToggleAnimationPlayback(bool paused); // TODO: While this works on CharaView, this is part of CharaViewPortrait. Move it there.
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 45 77 48 8D 4D 87")]
     public partial void UnequipGear(bool hasCharacterData = false, bool characterLoaded = true);
@@ -109,15 +126,15 @@ public unsafe partial struct CharaViewModelData {
 [StructLayout(LayoutKind.Explicit, Size = 0x78)]
 public unsafe partial struct CharaViewCharacterData : ICreatable {
     [FieldOffset(0)] public CustomizeData CustomizeData;
-    [FieldOffset(0x1A), FixedSizeArray] internal FixedSizeArray2<ushort> _glassesIds;
-    [Obsolete("Use GlassesIds[0]")]
+    // Unk 2 bytes
+    [Obsolete("Use GlassesId")]
     [FieldOffset(0x1A)] public ushort Glasses0Id;
-    [Obsolete("Use GlassesIds[1]")]
+    [Obsolete("Use GlassesId")]
     [FieldOffset(0x1C)] public ushort Glasses1Id;
-    [FieldOffset(0x1E), FixedSizeArray] internal FixedSizeArray14<uint> _itemIds;
-    [FieldOffset(0x56), FixedSizeArray] internal FixedSizeArray14<byte> _itemStain0Ids; // unsure if correct
-    [FieldOffset(0x64), FixedSizeArray] internal FixedSizeArray14<byte> _itemStain1Ids; // unsure if correct
-
+    [FieldOffset(0x1C), FixedSizeArray] internal FixedSizeArray14<uint> _itemIds;
+    [FieldOffset(0x54), FixedSizeArray] internal FixedSizeArray14<byte> _itemStain0Ids;
+    [FieldOffset(0x62), FixedSizeArray] internal FixedSizeArray14<byte> _itemStain1Ids;
+    [FieldOffset(0x70), FixedSizeArray] internal FixedSizeArray2<ushort> _glassesIds;
     [FieldOffset(0x74)] public byte ClassJobId;
     [FieldOffset(0x75)] public bool HeadgearHidden;
     [Obsolete("Renamed to HeadgearHidden")]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/CharaViewPortrait.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/CharaViewPortrait.cs
@@ -1,4 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.System.Memory;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using FFXIVClientStructs.FFXIV.Common.Math;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
@@ -42,6 +43,12 @@ public unsafe partial struct CharaViewPortrait : ICreatable {
     [FieldOffset(0x400)] public bool CharacterVisible;
     [FieldOffset(0x401)] public bool CharaViewPortraitCharacterDataCopied;
     [FieldOffset(0x402)] public bool CharaViewPortraitCharacterLoaded;
+    [FieldOffset(0x403)] public bool IsAnimationPauseStatePending;
+    [FieldOffset(0x404)] public bool PendingAnimationPauseState;
+
+    [FieldOffset(0x408)] public AgentInterface* EventAgent;
+    [FieldOffset(0x410)] public int AgentEventId;
+    [FieldOffset(0x418)] public ulong AgentEventKind;
 
     public static CharaViewPortrait* Create()
         => IMemorySpace.GetUISpace()->Create<CharaViewPortrait>();
@@ -49,20 +56,20 @@ public unsafe partial struct CharaViewPortrait : ICreatable {
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B F8 45 33 C0")]
     public partial void Ctor();
 
+    /// <summary>
+    /// Sets up the CharaViewPortrait.
+    /// </summary>
+    /// <param name="clientObjectId">The ClientObjectId to use.</param>
+    /// <param name="characterData">The character data.</param>
+    /// <param name="agent">An optional agent pointer.<br/>If set, vf8 will send an event with the given <paramref name="agentEventId"/> (as int in AtkValue[0]) containing a pointer to the CharaViewTexture (as int64 in AtkValue[1]).</param>
+    /// <param name="agentEventId">An id passed as int in AtkValue[0] of the event.</param>
+    /// <param name="agentEventKind">The eventKind parameter passed to agent->ReceiveEvent.</param>
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 43 10 C6 80 ?? ?? ?? ?? ?? 48 8B 4B 10")]
-    public partial void Setup(uint clientObjectId, CharaViewCharacterData* characterData, long a4, int a5, long a6); // a4 is set to +0x3A8, a5 is set to +0x3B0, a6 is set to +0x3B8
-
-    [VirtualFunction(4)]
-    public partial void SetCameraDistance(float deltaDistance);
-
-    [VirtualFunction(5)]
-    public partial void SetCameraYawAndPitch(float deltaRotation, float deltaPitch);
-
-    [VirtualFunction(6)]
-    public partial void SetCameraXAndY(float deltaX, float deltaY);
-
-    [VirtualFunction(10)]
-    public partial void Update();
+    public partial void Setup(uint clientObjectId, CharaViewCharacterData* characterData, AgentInterface* agent, int agentEventId, ulong agentEventKind);
+    
+    [Obsolete("Use Setup with correct types.")]
+    public void Setup(uint clientObjectId, CharaViewCharacterData* characterData, long a4, int a5, long a6)
+        => Setup(clientObjectId, characterData, (AgentInterface*)a4, a5, (ulong)a6);
 
     [MemberFunction("E8 ?? ?? ?? ?? EB 89 48 8B 8F")]
     public partial void ResetCamera(); // sets position, target, zoom etc.
@@ -129,28 +136,4 @@ public unsafe partial struct CharaViewPortrait : ICreatable {
 
     [MemberFunction("E8 ?? ?? ?? ?? 0F B6 45 A4")]
     public partial void ToggleGearVisibility(bool hideVisor, bool hideWeapon, bool closeVisor);
-}
-
-[StructLayout(LayoutKind.Explicit, Size = 0x34)]
-public unsafe struct ExportedPortraitData {
-    [FieldOffset(0x0)] public HalfVector4 CameraPosition;
-    [FieldOffset(0x8)] public HalfVector4 CameraTarget;
-    [FieldOffset(0x10)] public short ImageRotation;
-    [FieldOffset(0x12)] public byte CameraZoom;
-    [FieldOffset(0x14)] public ushort BannerTimeline;
-    [FieldOffset(0x18)] public float AnimationProgress;
-    [FieldOffset(0x1C)] public byte Expression;
-    [FieldOffset(0x1E)] public HalfVector2 HeadDirection;
-    [FieldOffset(0x22)] public HalfVector2 EyeDirection;
-    [FieldOffset(0x26)] public byte DirectionalLightingColorRed;
-    [FieldOffset(0x27)] public byte DirectionalLightingColorGreen;
-    [FieldOffset(0x28)] public byte DirectionalLightingColorBlue;
-    [FieldOffset(0x29)] public byte DirectionalLightingBrightness;
-    [FieldOffset(0x2A)] public short DirectionalLightingVerticalAngle;
-    [FieldOffset(0x2C)] public short DirectionalLightingHorizontalAngle;
-    [FieldOffset(0x2E)] public byte AmbientLightingColorRed;
-    [FieldOffset(0x2F)] public byte AmbientLightingColorGreen;
-    [FieldOffset(0x30)] public byte AmbientLightingColorBlue;
-    [FieldOffset(0x31)] public byte AmbientLightingBrightness;
-    [FieldOffset(0x32)] public ushort BannerBg;
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/CurrencySettingsHelper.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/CurrencySettingsHelper.cs
@@ -1,9 +1,9 @@
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 
 [GenerateInterop]
+[Inherits<HelperInterface>]
 [StructLayout(LayoutKind.Explicit, Size = 0x18)]
 public unsafe partial struct CurrencySettingsHelper {
-    [FieldOffset(0x8)] public UIModule* UIModule;
     [FieldOffset(0x10), FixedSizeArray] internal FixedSizeArray5<byte> _rotation;
     [FieldOffset(0x15)] public byte NumEntries;
     [FieldOffset(0x16)] public bool HasEntries;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/HelperInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/HelperInterface.cs
@@ -1,0 +1,16 @@
+namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
+
+[GenerateInterop(isInherited: true)]
+[StructLayout(LayoutKind.Explicit, Size = 0x10)]
+public unsafe partial struct HelperInterface {
+    [FieldOffset(0x8)] public UIModule* UIModule;
+
+    [VirtualFunction(1)]
+    public partial void OnLogin();
+
+    [VirtualFunction(2)]
+    public partial void OnLogout();
+
+    [VirtualFunction(3)]
+    public partial void Update();
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureGearsetModule.cs
@@ -17,6 +17,7 @@ public unsafe partial struct RaptureGearsetModule {
         return uiModule == null ? null : uiModule->GetRaptureGearsetModule();
     }
 
+    [FieldOffset(0x48)] public UIModule* UIModulePtr;
     [FieldOffset(0x50), FixedSizeArray] internal FixedSizeArray100<GearsetEntry> _entries;
 
     [FieldOffset(0xB5D0)] public int CurrentGearsetIndex;
@@ -146,8 +147,17 @@ public unsafe partial struct RaptureGearsetModule {
     /// <param name="gearsetId">The ID of the gearset.</param>
     /// <returns>Returns <c>true</c> if the gearset has a Banner linked to it, <c>false</c> otherwise.</returns>
     /// <remarks>Equivalent to Flags.HasFlag(GearsetFlag.Exists) &amp;&amp; BannerIndex != 0.</remarks>
-    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 4F 0F B6 D3")]
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 68 48 8B 4F 48")]
     public partial bool HasLinkedBanner(byte gearsetId);
+
+    /// <summary>
+    /// Check if a specified gearset has a Banner linked to it.
+    /// </summary>
+    /// <param name="enabledGearsetIndex">The position of the list.</param>
+    /// <returns>Returns <c>true</c> if the gearset has a Banner linked to it, <c>false</c> otherwise.</returns>
+    /// <remarks>Equivalent to Flags.HasFlag(GearsetFlag.Exists) &amp;&amp; BannerIndex != 0.</remarks>
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 4F 0F B6 D3")]
+    public partial bool HasLinkedBannerByEnabledIndex(byte enabledGearsetIndex);
 
     /// <summary>
     /// Resolves the index of a GearsetEntry array that only contains enabled gearsets to the index in the actual <see cref="Entries"/> array.
@@ -269,7 +279,8 @@ public unsafe partial struct RaptureGearsetModule {
         [FieldOffset(0x36)] public byte BannerIndex;
         [FieldOffset(0x37)] public GearsetFlag Flags;
         [FieldOffset(0x38), FixedSizeArray] internal FixedSizeArray14<GearsetItem> _items;
-        [FieldOffset(0x1C0)] public ushort GlassesId;
+        [FieldOffset(0x1C0), Obsolete("Use GlassesIds[0]")] public ushort GlassesId;
+        [FieldOffset(0x1C0), FixedSizeArray] internal FixedSizeArray2<ushort> _glassesIds;
 
         [UnscopedRef] public ref GearsetItem GetItem(GearsetItemIndex index) => ref Items[(int)index];
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/UIModuleHelpers.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/UIModuleHelpers.cs
@@ -1,7 +1,8 @@
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 
-[StructLayout(LayoutKind.Explicit, Size = 0x10)]
+[StructLayout(LayoutKind.Explicit, Size = 0x20)]
 public unsafe struct UIModuleHelpers {
+    // Technically an array of 4 HelperInterface*
     [FieldOffset(0x0)] public CurrencySettingsHelper* CurrencySettingsHelper;
-    // [FieldOffset(0x8)] public BannerModuleHelper* BannerModuleHelper;
+    [FieldOffset(0x8)] public BannerHelper* BannerHelper;
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
@@ -21,6 +21,7 @@ public unsafe partial struct RaptureAtkModule {
     }
 
     [FieldOffset(0x82C0)] public ushort UiMode; // 0 = In Lobby, 1 = In Game
+    [FieldOffset(0x82C2)] public ushort UISetupStage; // unsure
 
     [FieldOffset(0x8338)] internal Utf8String Unk8338;
     [FieldOffset(0x83A0), FixedSizeArray] internal FixedSizeArray6<Utf8String> _unkArray;
@@ -58,6 +59,13 @@ public unsafe partial struct RaptureAtkModule {
 
     [FieldOffset(0x296D0)] internal ExcelSheet* AddonParamSheet;
     [FieldOffset(0x296D8)] public AtkTexture CharaViewDefaultBackgroundTexture; // "ui/common/CharacterBg.tex" (or _hr1 variant)
+
+    [FieldOffset(0x296F4)] public uint LoginSummonCompanionId;
+    [FieldOffset(0x296F8)] public float LoginSummonCompanionCountdown;
+    /// <remarks> Only for Region 5 </remarks>
+    [FieldOffset(0x296FC)] public float HourTimer;
+    /// <remarks> Only for Region 5 </remarks>
+    [FieldOffset(0x29700)] public int HoursPlayed;
 
     [FieldOffset(0x29718)] internal nint ShellCommands; // only 1 function to open links?
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/UIInputModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIInputModule.cs
@@ -2,4 +2,6 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 
 // Client::UI::UIInputModule
 [StructLayout(LayoutKind.Explicit, Size = 0xF0)]
-public unsafe partial struct UIInputModule;
+public unsafe partial struct UIInputModule {
+    [FieldOffset(0x08)] public UIModule* UIModulePtr;
+}

--- a/FFXIVClientStructs/FFXIV/Component/Exd/ExdModule.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Exd/ExdModule.cs
@@ -42,5 +42,5 @@ public unsafe partial struct ExdModule {
     public static partial void* GetItemRowById(uint itemId);
 
     [MemberFunction("40 53 48 83 EC 20 0F B6 41 29")]
-    public static partial byte GetBannerConditionUnlockState(void* row);
+    public static partial byte GetBannerConditionUnlockState(void* row); // TODO: returns int
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -110,6 +110,7 @@ functions:
   0x1400682D0: GetMyDocumentsFolder #as UTF8String
   0x1400A4F90: GetPerformanceFrequency
   0x1400A6380: CreateDirectoryRecursive
+  0x1400B5AE0: Client::UI::GetUIConst
   0x1400B5BC0: Client::UI::IsValidPlayerCharacterName
   0x1400B61F0: Client::UI::RoundFloatToUInt
   0x1400B6530: Client::UI::PlaySoundEffect # this is a static function in the UI namespace, arg1 is the SE
@@ -172,6 +173,8 @@ functions:
   0x1400BAB40: OpenWebURL
   0x14081D470: GetUIModule
   0x140906E40: ToObjStrId
+  0x1409AC4F0: GenerateItemsChecksum # for Banners
+  0x1409AC640: GenerateEquippedItemsChecksum # for Banners; unused
   0x140CBDEC0: IsExportedGatheringPointTimed  # static, value of ExportedGatheringPoint.GatheringPointType
   0x140D61610: ConvertRawToMapPosX
   0x140D616A0: ConvertRawToMapPosY
@@ -403,6 +406,8 @@ functions:
   0x1415F1B00: ProcessPacketUIModulePacket
   0x14180F920: ProcessPacketCountdown
   0x14180F990: ProcessPacketCountdownCancel
+  0x140A1A5D0: ProcessPacketCurrentBannerData
+  0x140A1A5F0: ProcessPacketCurrentCharaCardData
   0x140A18770: CreatePacketTargetIfQueued
   0x140A1A370: InitIdScramble
   0x140C44CB0: IsInMordionGaol # if this returns true, i'm sorry for you
@@ -2176,6 +2181,7 @@ classes:
         pointer: False
     funcs:
       0x1409ACBD0: HandleExaminePacket
+      0x1409AD200: Clear
       0x1409AD460: RequestByEntityId
   Client::Game::UI::NpcTrade:
     instances:
@@ -2607,6 +2613,20 @@ classes:
         pointer: False
     funcs:
       0x1409DAB20: ctor
+      0x1409DACC0: RequestCurrentBannerData
+      0x1409DACF0: SendBannerData
+      0x1409DAE70: SetTempBannerData
+      0x1409DAEB0: RequestCharaCardForGameObject
+      0x1409DAF30: RequestCharaCardForContentId
+      0x1409DB0B0: RequestCharaCardForLocalPlayer
+      0x1409DB130: SendCharaCardData
+      0x1409DB560: HandleCurrentBannerDataPacket
+      0x1409DB590: HandleCurrentCharaCardDataPacket
+      0x1409DBBC0: HandleBannerDataUpdatePacket
+      0x1409DBCA0: HandleCharaCardUpdatePacket
+      0x1409DBF10: HandleClearCurrentBannerDataPacket
+      0x1409DBF40: HandleCharaCardTimestampPacket
+      0x1409DC060: Initialize
   Client::Game::ActionManager:
     instances:
       - ea: 0x142806000
@@ -5182,11 +5202,14 @@ classes:
       0x14023D130: Finalizer
       0x14023D440: CloseContextAddons
       0x14023D5C0: CloseAddon
-      0x14023D6B0: GetAgentByInternalId
-      0x14023D730: GetAgentInventoryContext
-      0x14023D710: GetAgentContext
-      0x14023D780: GetAddonTextById
       0x14023D600: IsAddonReady
+      0x14023D6B0: GetAgentByInternalId
+      0x14023D6E0: GetAgentByInternalId_2
+      0x14023D710: GetAgentContext
+      0x14023D730: GetAgentInventoryContext
+      0x14023D780: GetAddonTextById
+      0x14023D7B0: FormatAddonTextInt
+      0x14023D7F0: FormatAddonTextString
   Client::UI::Misc::ConfigModule::ConfigEventInterface:
     vtbls:
       - ea: 0x141F37720
@@ -6980,8 +7003,10 @@ classes:
       0x140657E70: HandleInput
       0x140658280: IsTextInputActive
       0x140658100: SetUIScene
-      0x1400D2EA0: PlaySoundEffectHandler
-      0x140656430: OpenMapWithMapLinkHandler
+      0x140655660: SubscribeAtkArrayDataHandler # 5
+      0x140655700: UnsubscribeAtkArrayDataHandler # 6
+      0x1400D2EA0: PlaySoundEffectHandler # 21
+      0x140656430: OpenMapWithMapLinkHandler # 14
       0x1400D4DA0: ScdResourceHandler
       0x1400DC1E0: SetRemappedIconId
   Component::GUI::AtkComponentCheckBox:
@@ -7678,7 +7703,7 @@ classes:
       48: GetAchievementListModule
       49: GetGroupPoseModule
       50: GetFieldMarkerModule
-      51: GetUnkFieldMarkerModuleMap # FieldMarkerModule+0xC78
+      51: GetExcelSheetPreloader # ?
       52: GetMycNoteModule
       53: GetOrnamentListModule
       54: GetMycItemModule
@@ -7996,6 +8021,18 @@ classes:
   Client::UI::Misc::HelperInterface:
     vtbls:
       - ea: 0x141F8C4A0
+    vfuncs:
+      0: Dtor
+      1: OnLogin
+      2: OnLogout
+      3: Update
+  Client::UI::Misc::UIModuleHelpers:
+    funcs:
+      0x140966280: ctor
+      0x1409663C0: Finalizer
+      0x140966420: PropagateOnLogin
+      0x140966460: PropagateOnLogout
+      0x1409664A0: PropagateUpdate
   Client::UI::Misc::CurrencySettingHelper:
     vtbls:
       - ea: 0x141F8C4E0
@@ -8004,10 +8041,63 @@ classes:
       0x140968E20: GetDefaultCurrencySetting
       0x140968D00: GetRotationArray
       0x140968D10: GetRotationCount
-  Client::UI::Misc::BannerModuleHelper:
+  Client::UI::Misc::BannerHelper:
     vtbls:
       - ea: 0x141F8C4C0
         base: Client::UI::Misc::HelperInterface
+    funcs:
+      0x140966590: ctor
+      0x1409665D0: Finalizer
+      0x1409665F0: CreatePortraitClientObject
+      0x140966690: DestroyPortraitClientObject
+      0x140966710: GetIsPortraitClientObjectSetUp
+      0x140966720: TryCopyCurrentBannerData
+      0x140966770: BannerData_ApplyBannerModuleEntry
+      0x140966900: BannerData_ApplyBannerModuleEntryIfNotDefault
+      0x140966B00: SendBannerData
+      0x140966B20: RequestCurrentBannerData
+      0x140966B40: HasCurrentBannerData
+      0x140966B90: TryCopyCurrentCharaCard
+      0x140966CD0: CharaCardData_ApplyCharaViewCharacterDataAndBannerModuleEntry
+      0x140966E00: CharaCardData_ApplyCharaViewCharacterData
+      0x140967160: SendCharaCardData
+      0x140967180: RequestCurrentCharaCard
+      0x1409671A0: HasCurrentCharaCard
+      0x1409671C0: HasCharaCardCreated
+      0x140967210: LogBannerDataUpdateResponse
+      0x140967270: LogCharaCardUpdateResponse
+      0x140967340: OpenCharaCardForPacket
+      0x140967400: ExportedPortraitData_ApplyBannerModuleEntry
+      0x140967570: CharaViewCharacterData_ApplyCharaCardData
+      0x1409677D0: BannerModuleEntry_ApplyDefaultBannerPreset
+      0x140967910: BannerModuleEntry_ApplyBannerData
+      0x140967A30: BannerModuleEntry_ApplyCharaCardData
+      0x140967B50: BannerModuleEntry_ApplyRaceGenderHeightTribe
+      0x140967B90: CanApplyGlamourPlates
+      0x140967BA0: BannerGearData_ApplyClassJobIdAndGearVisibilityFromGearset
+      0x140967C20: BannerGearData_ApplyGearFromGearset
+      0x140967D30: BannerGearData_UpdateGearsetChecksum
+      0x14156D090: BannerModuleEntry_IsOutdated
+      0x140967E70: BannerModuleEntry_IsCurrentCharaCardBannerOutdated
+      0x140967EC0: BannerModuleEntry_IsCharacterDataOutdated
+      0x140967F50: GetDefaultBannerPreset
+      0x140967F60: SetIsEditingBanner
+      0x140967F90: SetIsEditingCharaCard
+      0x140967FC0: TryGetItemDataFromEquippedItems
+  Client::UI::Misc::BannerGearData:
+    funcs:
+      0x1409664E0: ctor
+  Client::UI::Misc::BannerHelper::BannerData: # Instant Portrait
+    funcs:
+      0x1409ABE00: Initialize
+      0x1409ABE30: ImportData
+      0x1409ABF00: ExportData
+      0x1409ABFD0: IsChecksumValid
+  Client::UI::Misc::BannerHelper::CharaCardData: # Adventurer Plate
+    funcs:
+      0x1409AC040: Initialize
+      0x1409AC0C0: ImportData
+      0x1409AC2F0: ExportData
   Client::System::Crypt::SimpleString:
     vtbls:
       - ea: 0x141F77E40
@@ -8370,11 +8460,15 @@ classes:
       0x140793DF0: LinkGlamourPlate
       0x140793F10: RemoveGlamourPlateLink
       0x140794010: HasLinkedGlamourPlate
+      0x140794180: HasLinkedBanner
       0x140794200: GetClassJobIconForGearset
+      0x140794450: ExtractItemData
+      0x1407945E0: ExtractGlassesIds
       0x140794600: GetNumGearsets
+      0x140794640: GetGearsetByEnabledIndex
       0x140794770: GetBannerIndex
       0x1407947D0: SetBannerIndex
-      0x1407948E0: HasLinkedBanner
+      0x1407948E0: HasLinkedBannerByEnabledIndex
       0x140794910: ResolveIdFromEnabledIndex
       0x1407949B0: TryGetIdFromIndex
       0x140794CE0: FindGearsetIdByName
@@ -8499,10 +8593,12 @@ classes:
     funcs:
       0x140799C80: ctor
       0x140799D70: CreateBanner
+      0x140799E50: CreateBannerAtBannerIndex
       0x140799F00: DeleteBanner
       0x14079A020: GetNextId
       0x14079A040: GetBannerById
       0x14079A080: GetBannerIdByBannerIndex
+      0x14079AB50: SetBannerChecksum
   Client::UI::Misc::BannerModuleData:
     #funcs:
       #0x1406AA780: ctor # inlined in Client::UI::Misc::BannerModule_vf8 (0x1407A40D0)
@@ -8510,9 +8606,13 @@ classes:
       #0x1406DF940: DeleteBanner # inlined in Client::UI::Misc::BannerModule.DeleteBanner (0x1407A3430)
   Client::UI::Misc::BannerModuleEntry:
     funcs:
+      0x140799920: ctorRetrurn
       0x140799940: ctor
       0x140799A60: EqualTo
-      0x1409AC4F0: GenerateChecksum # static
+      0x140799BB0: SetBannerTimelineCustomName
+      0x140799BF0: GetFlag
+      0x140799C30: SetFlag
+      0x1407BC0D0: CopyFrom
   Client::UI::Misc::CharaView:
     vtbls:
       - ea: 0x141F88488
@@ -8521,6 +8621,11 @@ classes:
       1: Initialize
       2: Release
       3: ResetPositions
+      4: SetCameraDistance
+      5: SetCameraYawAndPitch
+      6: SetCameraXAndY
+      8: OnReady
+      10: Update
     funcs:
       0x140927920: ctor
       0x140927C60: Finalize2
@@ -8530,8 +8635,6 @@ classes:
       0x140928EA0: SetItemSlotData
       0x1409291A0: ToggleDrawWeapon
       0x1409292C0: GetCharacter
-      0x1418C9EE0: ToggleAnimationPlayback
-      0x1418C9F80: IsAnimationPaused
   Client::UI::Misc::CharaViewModelData:
     funcs:
       0x140927680: ctor
@@ -8554,16 +8657,12 @@ classes:
     vtbls:
       - ea: 0x1421B25F8
         base: Client::UI::Misc::CharaView
-    vfuncs:
-      4: SetCameraDistance
-      5: SetCameraYawAndPitch
-      6: SetCameraXAndY
-      10: Update
     funcs:
       0x1418C83C0: ctor
       0x1418C8620: Setup
       0x1418C90A0: ImportPortraitData
       0x1418C9410: ExportPortraitData
+      0x1418C96C0: GetPortraitCharacterData
       0x1418C9820: ToggleGearVisibility
       0x1418C98B0: SetCameraZoom
       0x1418C9900: ResetCamera
@@ -8576,6 +8675,12 @@ classes:
       0x1418C9D60: SetPoseTimed
       0x1418C9E00: SetPose
       0x1418C9EA0: GetAnimationTime
+      0x1418C9EE0: ToggleAnimationPlayback
+      0x1418C9F80: IsAnimationPaused
+      0x1418C9FB0: SetBannerHeadFollowingCamera
+      0x1418CA010: IsBannerHeadFollowingCamera
+      0x1418CA040: SetBannerEyesFollowingCamera
+      0x1418CA0A0: IsBannerEyesFollowingCamera
       0x1418CA0D0: SetDirectionalLightingColor
       0x1418CA150: SetDirectionalLightingBrightness
       0x1418CA180: SetDirectionalLightingAngle
@@ -8746,6 +8851,7 @@ classes:
     funcs:
       0x1405BD300: ctor
       0x1405DF1A0: Dtor
+      0x1405BF310: GetParamCount
   Client::Game::Control::CharacterLookAtControlParam:
     vtbls:
       - ea: 0x141F647F0
@@ -8953,8 +9059,12 @@ classes:
       - ea: 0x141F805A8
         base: Client::Game::Character::ContainerInterface
     funcs:
-#fail       0x1408BEEA0: ctor
+      0x1408569C0: ctor # inlined in Client::Game::Character::Character_ctor
       0x140856C70: UpdateLookAt
+      0x140858480: SetBannerHeadFollowingCamera
+      0x1408584D0: UpdateBannerHeadDirection
+      0x1408585A0: SetBannerEyesFollowingCamera
+      0x1408585F0: UpdateBannerEyeDirection
   Client::Game::Character::DrawData:
     vtbls:
       - ea: 0x141F61698
@@ -11679,11 +11789,12 @@ classes:
       0x1414D8DB0: OpenForGearset
   Client::UI::Agent::AgentBannerEditorState:
     funcs:
-      0x141576870: Save
       0x14156EF20: GetPresetIndex
-      0x14157A3D0: SetFrame
-      0x14157A180: SetAccent
+      0x141576870: Save
       0x1415774D0: SetHasChanged
+      0x141579A30: ToBannerModuleEntry
+      0x14157A180: SetAccent
+      0x14157A3D0: SetFrame
   Client::UI::Agent::AgentBannerUpdateView:
     vtbls:
       - ea: 0x14207A328
@@ -11992,6 +12103,9 @@ classes:
       0x140BF4020: ctor
       0x140BF4160: OpenCharaCardForContentId
       0x140BF41E0: OpenCharaCardForObject
+      0x140BF4E60: ExportToCharaCardData
+      0x140BF52B0: OpenCharaCardForPacket
+      0x140BF5E90: CreateNewStorage
   Client::UI::Agent::AgentCharaCard::Storage:
     funcs:
 #       0x1409A5330: ctor # inlined @ 140CD2EFC


### PR DESCRIPTION
Added:
- BannerHelper
- CharaCard
- BannerData, CharaCardData, Data8, Data16, Data32 (names from GM command handler)
- AgentBannerPreview
- AgentBannerPreviewState
- HelperInterface

Updated:
- AgentCharaCard
- AgentBannerEditorState
- CharaView
- CharaViewPortrait
- RaptureGearsetModule
- UIModuleHelpers
- data.yml

Closes #1269