### PR TITLE
Add HouseId, AgentHousingSignboard, AgentHousingPortal

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/IndoorTerritory.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/IndoorTerritory.cs
@@ -8,5 +8,5 @@ namespace FFXIVClientStructs.FFXIV.Client.Game;
 public unsafe partial struct IndoorTerritory {
     [FieldOffset(0x10), FixedSizeArray] internal FixedSizeArray732<HousingFurniture> _furniture;
     [FieldOffset(0x8968)] public HousingObjectManager HousingObjectManager;
-    [FieldOffset(0x96A0)] public long HouseId; // Combines Ward, Plot, and Room
+    [FieldOffset(0x96A0)] public HouseId HouseId; // Combines Ward, Plot, and Room
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/OutdoorTerritory.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/OutdoorTerritory.cs
@@ -8,7 +8,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game;
 public unsafe partial struct OutdoorTerritory {
     [FieldOffset(0x10), FixedSizeArray] internal FixedSizeArray732<HousingFurniture> _furniture;
     [FieldOffset(0x8968)] public HousingObjectManager HousingObjectManager;
-    [FieldOffset(0x96A0)] public long HouseId; // Combines Ward, Plot, and Room
+    [FieldOffset(0x96A0)] public HouseId HouseId;
     [FieldOffset(0x96A8)] public sbyte StandingInPlot;
     [FieldOffset(0x96AA)] public sbyte EditingFixturesOfPlot;
     [FieldOffset(0x96B0)] public sbyte EditingFurnishingsOfPlot;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -1,4 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.System.String;
+using FFXIVClientStructs.FFXIV.Common.Math;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 
@@ -21,6 +22,9 @@ public unsafe partial struct Map {
     [FieldOffset(0x3EA0)] public StdList<MarkerInfo> TripleTriadMarkers;
     [FieldOffset(0x3EB0)] public StdList<MarkerInfo> CustomTalkMarkers;
     [FieldOffset(0x3F58)] public StdList<MarkerInfo> GemstoneTraderMarkers;
+
+    [MemberFunction("83 FA 3E 0F 83")]
+    public partial void AddHousingMarker(uint index, uint levelId, Vector3* pos, ushort territoryTypeId, int iconId);
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x90)]

--- a/FFXIVClientStructs/FFXIV/Client/Game/WorkshopTerritory.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/WorkshopTerritory.cs
@@ -12,7 +12,7 @@ public unsafe partial struct WorkshopTerritory {
 
     [FieldOffset(0x2960)] public HousingWorkshopSubmersibleData Submersible;
 
-    [FieldOffset(0xB8B0)] public long HouseId;
+    [FieldOffset(0xB8B0)] public HouseId HouseId;
 }
 
 [GenerateInterop]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHousingPortal.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHousingPortal.cs
@@ -1,0 +1,41 @@
+using FFXIVClientStructs.FFXIV.Client.Game;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
+// Client::UI::Agent::AgentHousingPortal
+//   Client::UI::Agent::AgentInterface
+//     Component::GUI::AtkModuleInterface::AtkEventInterface
+[Agent(AgentId.HousingPortal)]
+[GenerateInterop]
+[Inherits<AgentInterface>]
+[StructLayout(LayoutKind.Explicit, Size = 0xA0)]
+public unsafe partial struct AgentHousingPortal {
+    [MemberFunction("40 55 53 41 54 41 55 41 57 48 8D AC 24 ?? ?? ?? ?? B8")]
+    public partial void ReadPacket(HousingPortalPacket* packet);
+}
+
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0x96C)] // at least this big
+public unsafe partial struct HousingPortalPacket {
+    [FieldOffset(0x0)] public HouseId HouseId;
+    [FieldOffset(0x8), FixedSizeArray] internal FixedSizeArray60<HouseInfoEntry> _houseInfoEntries;
+
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 0x28)]
+    public unsafe partial struct HouseInfoEntry {
+        [FieldOffset(0)] public uint HousePrice;
+        [FieldOffset(0x4)] public HouseInfoFlags InfoFlags;
+        /// <remarks>HousingAppeal RowIds</remarks>
+        [FieldOffset(0x5), FixedSizeArray] internal FixedSizeArray3<byte> _houseAppeals;
+        [FieldOffset(0x8), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _ownerName;
+
+        [Flags]
+        public enum HouseInfoFlags : byte {
+            PlotOwned = 1 << 0,
+            VisitorsAllowed = 1 << 1,
+            HasSearchComment = 1 << 2,
+            HouseBuilt = 1 << 3,
+            OwnedByFC = 1 << 4
+        }
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHousingSignboard.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentHousingSignboard.cs
@@ -1,0 +1,45 @@
+using FFXIVClientStructs.FFXIV.Client.Game;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
+
+// Client::UI::Agent::AgentHousingSignboard
+//   Client::UI::Agent::AgentInterface
+//     Component::GUI::AtkModuleInterface::AtkEventInterface
+[Agent(AgentId.HousingSignboard)]
+[GenerateInterop]
+[Inherits<AgentInterface>]
+[StructLayout(LayoutKind.Explicit, Size = 0xB8)]
+public unsafe partial struct AgentHousingSignboard {
+    [MemberFunction("E9 ?? ?? ?? ?? 48 83 7B ?? ?? 74 16")]
+    public partial void ReadPacket(HousingSignboardPacket* packet);
+}
+
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0x118)] // at least this big
+public unsafe partial struct HousingSignboardPacket {
+    [FieldOffset(0x0)] public HouseId HouseId;
+
+    [FieldOffset(0x14)] public bool IsOpen;
+    /// <remarks>
+    /// Small = 0<br/>
+    /// Medium = 1<br/>
+    /// Large = 2<br/>
+    /// Apartment = 5?
+    /// </remarks>
+    [FieldOffset(0x15)] public byte Size;
+    /// <remarks>
+    /// FreeCompany = 0<br/>
+    /// Individual = 2<br/>
+    /// Apartment = 6?
+    /// </remarks>
+    [FieldOffset(0x16)] public byte OwnerType;
+    [FieldOffset(0x17), FixedSizeArray(isString: true)] internal FixedSizeArray21<byte> _name;
+
+    [FieldOffset(0x2E), FixedSizeArray(isString: true)] internal FixedSizeArray193<byte> _greeting;
+    [FieldOffset(0xEF), FixedSizeArray(isString: true)] internal FixedSizeArray31<byte> _ownerName;
+
+    // [FieldOffset(0x10E), FixedSizeArray(isString: true)] internal FixedSizeArrayUNK<byte> _unk;
+
+    /// <remarks>HousingAppeal RowIds</remarks>
+    [FieldOffset(0x115), FixedSizeArray] internal FixedSizeArray3<byte> _houseAppeals;
+}

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2502,6 +2502,7 @@ classes:
         pointer: False
     funcs:
       0x1409A52E0: ctor
+      0x1409A8630: AddHousingMarker
   Client::Game::UI::Map::MapMarkerData:
     funcs:
       0x1409A4FD0: SetData

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -10425,6 +10425,7 @@ classes:
         base: Client::UI::Agent::AgentInterface
     funcs:
       0x1414BA240: ctor
+      0x1414BB570: ReadPacket
   Client::UI::Agent::AgentHousingPortal:
     vtbls:
       - ea: 0x142083468

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1564,6 +1564,13 @@ classes:
       0x140C6E520: GetAirshipVoyageTimeAndDistance # (unsigned __int8 pointA, unsigned __int8 pointB, __int16 speed, _DWORD *voyageTime, int *voyageDistance)
       0x140C6E660: GetAirshipSurveyDuration # (unsigned __int8 point, __int16 speed) -> SurveyDuration (return is time in seconds)
       0x1400B7FE0: GetHouseIcon # static (size, isOpen, isResident, isIndividual, isShared)
+  Client::Game::HouseId:
+    funcs:
+      0x140C53840: GetWardIndex
+      0x140C53860: GetPlotIndex
+      0x140C538B0: GetTerritoryTypeId
+      0x140C538C0: GetWorldId
+      0x140C53B40: IsApartment
   Client::Game::HousingTerritory:
     vtbls:
       - ea: 0x141FB3198

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -10431,6 +10431,7 @@ classes:
         base: Client::UI::Agent::AgentInterface
     funcs:
       0x1414C3F90: ctor
+      0x1414C4980: ReadPacket
   Client::UI::Agent::AgentHousingTravellersNote:
     vtbls:
       - ea: 0x1420834E0


### PR DESCRIPTION
- Adds the `Client::Game::HouseId` struct we've been working on in the Dalamud Discord.
- Adds `Client::Game::UI::Map.AddHousingMarker`
- Adds `Client::UI::Agent::AgentHousingSignboard.ReadPacket`
- Adds `Client::UI::Agent::AgentHousingPortal.ReadPacket`

(I intend to maybe hook those in the future)