### PR TITLE
Add back lua_tostring

### DIFF
--- a/FFXIVClientStructs/FFXIV/Common/Lua/LuaState.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Lua/LuaState.cs
@@ -14,16 +14,16 @@ public unsafe partial struct LuaState {
         var top = State->lua_gettop();
         try {
             if (State->luaL_loadbuffer(code, code.Length, name ?? "chunk") != 0)
-                throw new Exception($"{State->lua_tolstring(-1)}");
+                throw new Exception($"{State->lua_tostring(-1)}");
 
             if (State->lua_pcall(0, -1, 0) != 0)
-                throw new Exception($"{State->lua_tolstring(-1)}");
+                throw new Exception($"{State->lua_tostring(-1)}");
 
             var cnt = State->lua_gettop() - top;
             var results = new string?[cnt];
             for (var i = 0; i < cnt; i++) {
                 State->luaB_tostring();
-                results[i] = State->lua_tolstring(-1);
+                results[i] = State->lua_tostring(-1);
                 State->lua_remove(1);
             }
 

--- a/FFXIVClientStructs/FFXIV/Common/Lua/lstate.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Lua/lstate.cs
@@ -40,7 +40,7 @@ public unsafe partial struct lua_State {
     public partial void lua_settop(int idx);
 
     [MemberFunction("E8 ?? ?? ?? ?? 80 38 23")]
-    public partial StringPointer lua_tolstring(int idx, int* len = null);
+    public partial StringPointer lua_tolstring(int idx, int* len);
 
     [MemberFunction("E8 ?? ?? ?? ?? 0F 28 D0 48 8D 15")]
     public partial double lua_tonumber(int idx);
@@ -104,6 +104,10 @@ public unsafe partial struct lua_State {
 
     public void lua_pushcfunction(delegate* unmanaged<lua_State*, int> f) {
         lua_pushcclosure(f, 0);
+    }
+
+    public StringPointer lua_tostring(int idx) {
+        return lua_tolstring(idx, null);
     }
 
     public void lua_pop(int n) {


### PR DESCRIPTION
I accidentally removed this in #1318.
It's actually part of lua: https://www.lua.org/manual/5.3/manual.html#lua_tostring