### PR TITLE
Add Getter/Setter for Soft/Hard targets

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/TargetSystem.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/TargetSystem.cs
@@ -48,6 +48,18 @@ public unsafe partial struct TargetSystem {
     [Obsolete($"Renamed to {nameof(GetTargetObject)}", true)]
     public GameObject* GetCurrentTarget() => GetTargetObject();
 
+    [MemberFunction("E8 ?? ?? ?? ?? 48 3B C7 75 ?? 32 C0")]
+    public partial GameObject* GetHardTarget();
+    
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 5C 24 ?? 48 83 C4 30 5F C3 8B 83")]
+    public partial bool SetHardTarget(GameObject* hardTargetObject, bool ignoreTargetModes = false, bool a4 = false, int a5 = 0);
+    
+    [MemberFunction("E8 ?? ?? ?? ?? 48 3B C3 74 ?? B0 01")]
+    public partial GameObject* GetSoftTarget();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 81 C4 E0 19 00 00 41 5F 41 5D")]
+    public partial bool SetSoftTarget(GameObject* softTargetObject);
+
     [MemberFunction("48 85 D2 74 2C 4C 63 89")]
     public partial bool IsObjectInViewRange(GameObject* obj);
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -6361,9 +6361,11 @@ classes:
       0x1405D2680: GetHardTargetObjectId
       0x1405D26A0: GetHardTargetId
       0x1405D26C0: GetHardTarget
+      0x1405C9AF0: SetHardTarget
       0x1405D26E0: GetSoftTargetObjectId
       0x1405D2700: GetSoftTargetId
       0x1405D2720: GetSoftTarget
+      0x1405C9810: SetSoftTarget
       0x1405D2740: GetMouseOverTargetPlayerId
       0x1405D2780: GetMouseOverTarget
       0x1405D2790: SetMouseOverEventObj
@@ -6381,6 +6383,7 @@ classes:
       0x1405D5100: HandleLeftClick # inlined @ 0x140602A35
       0x1405D5500: RemoveObjectFromTargets
       0x1405D0CC0: IsObjectOnScreen
+      0x1405D01B0: GetTargetModeByActiveIndex
   Client::Game::Control::Control:
     instances:
       - ea: 0x1427C5F40


### PR DESCRIPTION
Allows setting soft or hard targets in a way that keeps track of the game's state (hopefully).

Probably needs validating, since `1405C9AF0` especially is kind of a mess.