### PR TITLE
Update Kernel::Device hWnd and adjacent field offsets

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Device.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Device.cs
@@ -33,10 +33,10 @@ public unsafe partial struct Device {
     [FieldOffset(0x758)] internal RenderCommandBufferGroup* RenderCommandBuffer;
     [FieldOffset(0x760)] public uint RenderCommandBufferCount;
 
-    [FieldOffset(0x820)] public void* hWnd;
-    [FieldOffset(0x830)] public uint NewWidth;
-    [FieldOffset(0x834)] public uint NewHeight;
-    [FieldOffset(0x838)] public int FrameRate;
+    [FieldOffset(0x9D8)] public void* hWnd;
+    [FieldOffset(0x9E8)] public uint NewWidth;
+    [FieldOffset(0x9EC)] public uint NewHeight;
+    [FieldOffset(0x9F0)] public int FrameRate;
 
     [FieldOffset(0x890)] public int D3DFeatureLevel; // D3D_FEATURE_LEVEL enum
     [FieldOffset(0x898)] public void* DXGIFactory; // IDXGIFactory1


### PR DESCRIPTION
Tested in my own CustomResolution plugin using the following kludge:

![image](https://github.com/user-attachments/assets/e08f5d51-389d-4852-b6b3-2d4c4a4a2f28)

I was able to read out `FrameRate` as well, but haven't found the new offsets of all fields following that.