### PR TITLE
Fix Character.IsWeaponDrawn

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/TimelineContainer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/TimelineContainer.cs
@@ -43,7 +43,7 @@ public unsafe partial struct TimelineContainer {
     [FieldOffset(0x349)] public byte Flags2; // bit 2 makes it load the requested banner animation
 
     // 0x40 = WeaponDrawn
-    [FieldOffset(0x34C)] public byte Flags3;
+    [FieldOffset(0x34E)] public byte Flags3;
 
     /// <summary> Computes height difference between the player the action timeline belongs to and target to height adjust emotes. </summary>
     /// <param name="target"> The object id of the target of the emote. </param>


### PR DESCRIPTION
Some other stuff was also updated by @Haselnussbomber but not sure about those. I confirmed for Flags3 though (used by `Character.IsWeaponDrawn`).