### PR TITLE
Probably fix `Demihuman` offsets for 7.2

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/Demihuman.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/Demihuman.cs
@@ -12,17 +12,17 @@ namespace FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 [Inherits<CharacterBase>]
 [StructLayout(LayoutKind.Explicit, Size = 0xAD0)]
 public unsafe partial struct Demihuman {
-    [FieldOffset(0xA60), FixedSizeArray, CExportIgnore] internal FixedSizeArray5<Pointer<TextureResourceHandle>> _slotDecals;
-    [FieldOffset(0xA60)] public TextureResourceHandle* HeadDecal;
-    [FieldOffset(0xA68)] public TextureResourceHandle* TopDecal;
-    [FieldOffset(0xA70)] public TextureResourceHandle* ArmsDecal;
-    [FieldOffset(0xA78)] public TextureResourceHandle* LegsDecal;
-    [FieldOffset(0xA80)] public TextureResourceHandle* FeetDecal;
+    [FieldOffset(0xA70), FixedSizeArray, CExportIgnore] internal FixedSizeArray5<Pointer<TextureResourceHandle>> _slotDecals;
+    [FieldOffset(0xA70)] public TextureResourceHandle* HeadDecal;
+    [FieldOffset(0xA78)] public TextureResourceHandle* TopDecal;
+    [FieldOffset(0xA80)] public TextureResourceHandle* ArmsDecal;
+    [FieldOffset(0xA88)] public TextureResourceHandle* LegsDecal;
+    [FieldOffset(0xA90)] public TextureResourceHandle* FeetDecal;
 
     public TextureResourceHandle* SlotDecal(int slot) => SlotDecals[slot].Value;
 
-    [FieldOffset(0xA90)] public Texture* FreeCompanyCrest;
-    [FieldOffset(0xA98)] public uint SlotFreeCompanyCrestBitfield; // Only relevant bit is & 0x1
+    [FieldOffset(0xAA0)] public Texture* FreeCompanyCrest;
+    [FieldOffset(0xAA8)] public uint SlotFreeCompanyCrestBitfield; // Only relevant bit is & 0x1
 
     // Expects at least 24 bytes of data.
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 41 0F 10 0F")]


### PR DESCRIPTION
b484eac4abb2368062ef46b1b5d54cf10344978b adjusted `Monster`, `Human` and `Weapon` after `CharacterBase` grew in size, but it seems `Demihuman` was forgotten. This fixes that.