### PR TITLE
Instance getters cleanup

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/BGMSystem.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/BGMSystem.cs
@@ -4,7 +4,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x100)]
 public unsafe partial struct BGMSystem {
-    [StaticAddress("4C 8B 15 ?? ?? ?? ?? 4D 85 D2 74 77 41 83 7A", 3, true)]
+    [StaticAddress("4C 8B 15 ?? ?? ?? ?? 4D 85 D2 74 77 41 83 7A", 3, isPointer: true)]
     public static partial BGMSystem* Instance();
 
     [FieldOffset(0x8)] public uint NumScenes; // equals the amount of rows in the BGMScene sheet

--- a/FFXIVClientStructs/FFXIV/Client/Game/CSBonusManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/CSBonusManager.cs
@@ -5,7 +5,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x178)]
 public unsafe partial struct CSBonusManager {
-    [StaticAddress("48 8B 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 63 D0", 3, true)]
+    [StaticAddress("48 8B 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 63 D0", 3, isPointer: true)]
     public static partial CSBonusManager* Instance();
 
     [FieldOffset(0x08)] public CSBonusEventInfo EventInfo;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/CharacterManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/CharacterManager.cs
@@ -5,15 +5,15 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Character;
 [StructLayout(LayoutKind.Explicit, Size = 0x390)]
 [Inherits<CharacterManagerInterface>]
 public unsafe partial struct CharacterManager {
+    [StaticAddress("8B D0 48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 85 C0 0F 84 ?? ?? ?? ?? 48 8B D0", 5)]
+    public static partial CharacterManager* Instance();
+
     [FieldOffset(0x50), FixedSizeArray] internal FixedSizeArray100<Pointer<BattleChara>> _battleCharas;
     [FieldOffset(0x370)] public BattleChara* BattleCharaMemory;
     [FieldOffset(0x378)] public Companion* CompanionMemory;
     //used to calculate the minion address in CompanionMemory when adding a BattleChara
     [FieldOffset(0x380)] public int CompanionClassSize;
     [FieldOffset(0x384)] public int UpdateIndex;
-
-    [StaticAddress("8B D0 48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 85 C0 0F 84 ?? ?? ?? ?? 48 8B D0", 5)]
-    public static partial CharacterManager* Instance();
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 89 84 3D ?? ?? ?? ??")]
     public partial BattleChara* LookupBattleCharaByEntityId(uint entityId);

--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/CameraManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/CameraManager.cs
@@ -4,7 +4,8 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Control;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x180)]
 public unsafe partial struct CameraManager {
-    public static CameraManager* Instance() => (CameraManager*)Control.Instance();
+    [StaticAddress("48 89 05 ?? ?? ?? ?? E8 ?? ?? ?? ?? 33 D2 45 33 C0 8D 4A 20", 3, isPointer: true)]
+    public static partial CameraManager* Instance();
 
     [FieldOffset(0x00)] public Camera* Camera;
     [FieldOffset(0x08)] public LowCutCamera* LowCutCamera;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
@@ -20,7 +20,7 @@ public unsafe partial struct Control {
     [StaticAddress("4C 8D 35 ?? ?? ?? ?? 48 8B 09", 3)]
     public static partial Control* Instance();
 
-    [StaticAddress("48 8B 2D ?? ?? ?? ?? 75", 3, true)]
+    [StaticAddress("48 8B 2D ?? ?? ?? ?? 75", 3, isPointer: true)]
     public static partial BattleChara* GetLocalPlayer(); // g_Client::Game::Control::Control_LocalPlayer
 
     /// <summary>

--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
@@ -7,6 +7,9 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Control;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x76E0)]
 public unsafe partial struct Control {
+    [StaticAddress("4C 8D 35 ?? ?? ?? ?? 48 8B 09", 3)]
+    public static partial Control* Instance();
+
     [FieldOffset(0x00)] public CameraManager CameraManager;
     [FieldOffset(0x180)] public TargetSystem TargetSystem;
 
@@ -16,9 +19,6 @@ public unsafe partial struct Control {
     [FieldOffset(0x76A0)] public Matrix4x4 ViewProjectionMatrix;
 
     public static bool CanFly => GetFlightAllowedStatus() == FlightAllowedStatus.CanFly;
-
-    [StaticAddress("4C 8D 35 ?? ?? ?? ?? 48 8B 09", 3)]
-    public static partial Control* Instance();
 
     [StaticAddress("48 8B 2D ?? ?? ?? ?? 75", 3, isPointer: true)]
     public static partial BattleChara* GetLocalPlayer(); // g_Client::Game::Control::Control_LocalPlayer

--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/TargetSystem.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/TargetSystem.cs
@@ -6,6 +6,9 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Control;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x6EF0)]
 public unsafe partial struct TargetSystem {
+    [StaticAddress("48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 3B C6 0F 95 C0", 3)]
+    public static partial TargetSystem* Instance();
+
     [FieldOffset(0x80)] public GameObject* Target;
     [FieldOffset(0x88)] public GameObject* SoftTarget;
     [FieldOffset(0x98)] public GameObject* GPoseTarget;
@@ -24,9 +27,6 @@ public unsafe partial struct TargetSystem {
     // For example, when interacting with the aethernet menu, these values change presumable to limit your ability to select an object other than the aetheryte.
     [FieldOffset(0x6E60), FixedSizeArray] internal FixedSizeArray8<uint> _targetModes;
     [FieldOffset(0x6E80)] public uint TargetModeIndex;
-
-    [StaticAddress("48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 3B C6 0F 95 C0", 3)]
-    public static partial TargetSystem* Instance();
 
     /// <summary>
     /// Method to get the player's current target's ObjectId. Will resolve the hard and soft targets, in

--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventFramework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventFramework.cs
@@ -9,6 +9,9 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Event;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x44A0)]
 public unsafe partial struct EventFramework {
+    [StaticAddress("4C 39 2D ?? ?? ?? ?? 74 14", 3, isPointer: true)]
+    public static partial EventFramework* Instance();
+
     [FieldOffset(0x00)] public EventHandlerModule EventHandlerModule;
     [FieldOffset(0xC0)] public DirectorModule DirectorModule;
     [FieldOffset(0x160)] public LuaActorModule LuaActorModule;
@@ -23,9 +26,6 @@ public unsafe partial struct EventFramework {
     [FieldOffset(0x3CB0)] public EventState EventState2;
 
     [FieldOffset(0x42A8)] public DailyQuestMap DailyQuests;
-
-    [StaticAddress("4C 39 2D ?? ?? ?? ?? 74 14", 3, isPointer: true)]
-    public static partial EventFramework* Instance();
 
     [MemberFunction("E8 ?? ?? ?? ?? EB E0 41 81 E9")]
     public partial ContentDirector* GetContentDirector();

--- a/FFXIVClientStructs/FFXIV/Client/Game/Fate/FateManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Fate/FateManager.cs
@@ -7,6 +7,9 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Fate;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0xD0)]
 public unsafe partial struct FateManager {
+    [StaticAddress("48 89 01 48 8B 3D ?? ?? ?? ?? 48 8B 87", 6, isPointer: true)]
+    public static partial FateManager* Instance();
+
     [FieldOffset(0x00)] public StdVector<GameObjectId> Unk_Vector;
     [FieldOffset(0x18)] public Utf8String Unk_String;
     [FieldOffset(0x80)] public FateDirector* FateDirector;
@@ -14,9 +17,6 @@ public unsafe partial struct FateManager {
     [FieldOffset(0x90)] public StdVector<Pointer<FateContext>> Fates;
     [FieldOffset(0xA8)] public ushort SyncedFateId;
     [FieldOffset(0xAC)] public byte FateJoined;
-
-    [StaticAddress("48 89 01 48 8B 3D ?? ?? ?? ?? 48 8B 87", 6, isPointer: true)]
-    public static partial FateManager* Instance();
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 85 C0 48 8D 4C 24 ?? 0F 95 C2")]
     public partial FateContext* GetFateById(ushort fateId);

--- a/FFXIVClientStructs/FFXIV/Client/Game/Group/GroupManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Group/GroupManager.cs
@@ -8,11 +8,11 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Group;
 [StructLayout(LayoutKind.Explicit, Size = 0x10000)]
 [Inherits<CharacterManagerInterface>]
 public unsafe partial struct GroupManager {
-    [FieldOffset(0x0020)] public Group MainGroup;
-    [FieldOffset(0x8010)] public Group ReplayGroup;
-
     [StaticAddress("33 D2 48 8D 0D ?? ?? ?? ?? 33 DB", 5)]
     public static partial GroupManager* Instance();
+
+    [FieldOffset(0x0020)] public Group MainGroup;
+    [FieldOffset(0x8010)] public Group ReplayGroup;
 
     [MemberFunction("E8 ?? ?? ?? ?? 0F B6 55 80")]
     public partial Group* GetGroup(bool replayGroup = false);

--- a/FFXIVClientStructs/FFXIV/Client/Game/HousingManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/HousingManager.cs
@@ -5,7 +5,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0xE8)]
 public unsafe partial struct HousingManager {
-    [MemberFunction("E8 ?? ?? ?? ?? 4C 8D 60 60")]
+    [StaticAddress("48 89 1D ?? ?? ?? ?? EB 07", 3, isPointer: true)]
     public static partial HousingManager* Instance();
 
     [FieldOffset(0x00)] public HousingTerritory* CurrentTerritory;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObjectManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObjectManager.cs
@@ -4,12 +4,12 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Object;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x4CE8)]
 public unsafe partial struct GameObjectManager {
+    [StaticAddress("48 8D 35 ?? ?? ?? ?? 81 FA", 3)]
+    public static partial GameObjectManager* Instance();
+
     [FieldOffset(0x00)] public uint NextUpdateIndex; // rate limiting for updates per frame
     [FieldOffset(0x04)] public byte Active;
     [FieldOffset(0x18)] public ObjectArrays Objects;
-
-    [StaticAddress("48 8D 35 ?? ?? ?? ?? 81 FA", 3)]
-    public static partial GameObjectManager* Instance();
 
     [GenerateInterop]
     [StructLayout(LayoutKind.Explicit, Size = 0x4CD0)]

--- a/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/QuestManager.cs
@@ -7,7 +7,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x1042)]
 public unsafe partial struct QuestManager {
-    [MemberFunction("E8 ?? ?? ?? ?? 66 BA 10 0C")]
+    [StaticAddress("48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? C6 84 24", 3)]
     public static partial QuestManager* Instance();
 
     [FieldOffset(0x00)] private ushort Unk0;

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Render/OffscreenRenderingManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Render/OffscreenRenderingManager.cs
@@ -8,6 +8,9 @@ namespace FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x190)]
 public unsafe partial struct OffscreenRenderingManager {
+    [StaticAddress("48 89 98 ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? E8 ?? ?? ?? ??", 3, isPointer: true)]
+    public static partial OffscreenRenderingManager* Instance();
+
     [FieldOffset(0xC8), FixedSizeArray] internal FixedSizeArray4<Pointer<Camera>> _cameras;
 
     [FieldOffset(0x148)] public ShaderPackageResourceHandle* PrimitiveVSHandle;

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/CharacterUtility.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/CharacterUtility.cs
@@ -9,7 +9,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x590)]
 public unsafe partial struct CharacterUtility {
-    [StaticAddress("48 8B 05 ?? ?? ?? ?? 83 B9", 3, true)]
+    [StaticAddress("48 8B 05 ?? ?? ?? ?? 83 B9", 3, isPointer: true)]
     public static partial CharacterUtility* Instance();
 
     [FieldOffset(0x8), FixedSizeArray] internal FixedSizeArray114<Pointer<ResourceHandle>> _resourceHandles;

--- a/FFXIVClientStructs/FFXIV/Client/Sound/SoundManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Sound/SoundManager.cs
@@ -14,6 +14,9 @@ namespace FFXIVClientStructs.FFXIV.Client.Sound;
 [Inherits<ResourceEventListener>]
 [StructLayout(LayoutKind.Explicit, Size = 0x1D08)]
 public unsafe partial struct SoundManager {
+    [StaticAddress("48 89 35 ?? ?? ?? ?? 48 83 C4 20", 3, isPointer: true)]
+    public static partial SoundManager* Instance();
+
     [FieldOffset(0x0008)] public Thread Thread; // TODO: make Thread properly inheritable
     [FieldOffset(0x0031)] public bool Disabled;
     [FieldOffset(0x0034)] public float MasterVolume;

--- a/FFXIVClientStructs/FFXIV/Client/System/File/FileManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/File/FileManager.cs
@@ -2,7 +2,11 @@ namespace FFXIVClientStructs.FFXIV.Client.System.File;
 
 // Client::System::File::FileManager
 //   Client::System::Framework::Task
+[GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x141a8)]
-public unsafe struct FileManager {
+public unsafe partial struct FileManager {
+    [StaticAddress("48 8B 3D ?? ?? ?? ?? 48 85 C0", 3, isPointer: true)]
+    public static partial FileManager* Instance();
+
     [FieldOffset(0x38)] public FileThread* FileThread;
 }

--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
@@ -21,7 +21,7 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Framework;
 [VirtualTable("48 8D 05 ?? ?? ?? ?? 66 C7 41 ?? ?? ?? 48 89 01 48 8B F1", 3)]
 [StructLayout(LayoutKind.Explicit, Size = 0x35F0)]
 public unsafe partial struct Framework {
-    [StaticAddress("49 8B DC 48 89 1D ?? ?? ?? ??", 6, true)]
+    [StaticAddress("49 8B DC 48 89 1D ?? ?? ?? ??", 6, isPointer: true)]
     public static partial Framework* Instance();
 
     [FieldOffset(0x0010)] public SystemConfig SystemConfig;

--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/GameWindow.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/GameWindow.cs
@@ -4,6 +4,9 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Framework;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x68)]
 public unsafe partial struct GameWindow {
+    [StaticAddress("89 15 ?? ?? ?? ?? 48 F7 E1", 2)]
+    public static partial GameWindow* Instance();
+
     [FieldOffset(0x00)] public ulong ArgumentCount; // TODO: (u)int
     [FieldOffset(0x08)] public byte** Arguments; // Points to an array that points to CStr // TODO: use CStringPointer, add Span
     [FieldOffset(0x10)] public float FrameDeltaTime;

--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/TaskManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/TaskManager.cs
@@ -9,6 +9,9 @@ public struct TaskManagerOsData {
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x70)]
 public unsafe partial struct TaskManager {
+    [StaticAddress("4D 89 66 68 4C 89 35 ?? ?? ?? ??", 7, isPointer: true)]
+    public static partial TaskManager* Instance();
+
     [FieldOffset(0x08)] public TaskManagerOsData OsData;
     [FieldOffset(0x58)] public RootTask* TaskList;
     [FieldOffset(0x60)] public uint TaskCount;

--- a/FFXIVClientStructs/FFXIV/Client/System/Input/Cursor.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Input/Cursor.cs
@@ -7,6 +7,9 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Input;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x378)]
 public unsafe partial struct Cursor {
+    [StaticAddress("75 36 48 8B 15 ?? ?? ?? ??", 5, isPointer: true)]
+    public static partial Cursor* Instance();
+
     [FieldOffset(0x009)] public bool UseSoftwareCursor;
     [FieldOffset(0x00A)] public byte SoftwareCursorScale;
     [FieldOffset(0x00B)] public bool IsCursorVisible;

--- a/FFXIVClientStructs/FFXIV/Client/System/Scheduler/ActionTimelineManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Scheduler/ActionTimelineManager.cs
@@ -4,7 +4,7 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Scheduler;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0xB8)]
 public unsafe partial struct ActionTimelineManager {
-    [StaticAddress("4C 8B 43 48 48 8B 0D ?? ?? ?? ??", 7)]
+    [StaticAddress("4C 8B 43 48 48 8B 0D ?? ?? ?? ??", 7, isPointer: true)]
     public static partial ActionTimelineManager* Instance();
 
     [MemberFunction("48 83 EC 38 48 8B 02 C7 44 24")]

--- a/FFXIVClientStructs/FFXIV/Client/System/Scheduler/Resource/SchedulerResourceManagement.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Scheduler/Resource/SchedulerResourceManagement.cs
@@ -1,8 +1,12 @@
 namespace FFXIVClientStructs.FFXIV.Client.System.Scheduler.Resource;
 
 // Client::System::Scheduler::Resource::SchedulerResourceManagement
+[GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x58)]
-public unsafe struct SchedulerResourceManagement {
+public unsafe partial struct SchedulerResourceManagement {
+    [StaticAddress("48 8B 0D ?? ?? ?? ?? 0F 28 CE E8 ?? ?? ?? ?? 48 83 7E ?? ??", 3, isPointer: true)]
+    public static partial SchedulerResourceManagement* Instance();
+
     [FieldOffset(0x08)] public SchedulerResource* Begin;
     [FieldOffset(0x10)] public StdMap<int, SchedulerResource> Resources;
 }

--- a/FFXIVClientStructs/FFXIV/Client/System/Threading/ThreadManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Threading/ThreadManager.cs
@@ -5,6 +5,9 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Threading;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x1048)]
 public unsafe partial struct ThreadManager {
+    [StaticAddress("48 89 B3 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 8B", 3, isPointer: true)]
+    public static partial ThreadManager* Instance();
+
     [FieldOffset(0x0008)] public nint FrameworkThread;
     [FieldOffset(0x0010)] public void* CriticalSection;
     [FieldOffset(0x0038), FixedSizeArray] internal FixedSizeArray512<Pointer<Thread>> _threads;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/CharaSelectCharacterList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/CharaSelectCharacterList.cs
@@ -8,7 +8,7 @@ public unsafe partial struct CharaSelectCharacterList {
     [StaticAddress("48 8D 05 ?? ?? ?? ?? 48 89 7C 24 ?? 4C 8D 05 ?? ?? ?? ?? 33 FF 8B CF 66 0F 1F 44 00 ??", 3)]
     public static partial CharaSelectCharacterList* Instance();
 
-    [StaticAddress("75 39 48 8B 0D ?? ?? ?? ?? 48 85 C9", 5, true)]
+    [StaticAddress("75 39 48 8B 0D ?? ?? ?? ?? 48 85 C9", 5, isPointer: true)]
     public static partial Character* GetCurrentCharacter();
 
     [MemberFunction("E8 ?? ?? ?? ?? 4D 0F BF 8E ?? ?? ?? ??")]

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkStage.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkStage.cs
@@ -10,6 +10,9 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 [Inherits<AtkEventTarget>]
 [StructLayout(LayoutKind.Explicit, Size = 0x75E00)]
 public unsafe partial struct AtkStage {
+    [StaticAddress("48 8B 05 ?? ?? ?? ?? 4C 8B 40 18 45 8B 40 18", 3, isPointer: true)]
+    public static partial AtkStage* Instance();
+
     [FieldOffset(0x10)] public AtkFontManager* AtkFontManager;
     [FieldOffset(0x18)] public AtkTextureResourceManager* AtkTextureResourceManager;
     [FieldOffset(0x20)] public RaptureAtkUnitManager* RaptureAtkUnitManager;
@@ -35,9 +38,6 @@ public unsafe partial struct AtkStage {
     [FieldOffset(0x858)] public uint NextEventDispatcherIndex;
     //[FieldOffset(0x85C)] public bool DispatchEvents;
     [FieldOffset(0x878), FixedSizeArray] internal FixedSizeArray10000<AtkEvent> _registeredEvents;
-
-    [MemberFunction("E8 ?? ?? ?? ?? 45 33 C0 48 8B C8 4C 8B CB 41 8D 50 03")]
-    public static partial AtkStage* Instance();
 
     [MemberFunction("48 8B 51 ?? 48 0F BF 82")]
     public partial AtkResNode* GetFocus();

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -15672,6 +15672,7 @@ classes:
         base: Component::GUI::AtkUnitBase
     funcs:
       0x1411E7F10: ctor
+      0x1411EDA50: IsZoomed
   Client::UI::AddonChatLog:
     vtbls:
       - ea: 0x1420CAF68


### PR DESCRIPTION
I updated several Instance getters to make sure the scripts set the types for global addresses correctly.

- Changed some MemberFunction Instance getters to StaticAddress
- Updated CameraManagers function Instance getter to StaticAddress
- Fixed ActionTimelineManager Instance getter, which was missing `isPointer: true`
- Added missing `isPointer: ` for readability
- Moved Instance getters above fields for readability
- Added missing Instance getters

The only issue remains is `MacroDecoder.GetMacroTime()`, which is incorrectly detected as Instance getter for `Component::Text::MacroDecoder` (currently at 0x1428EE518).