### PR TITLE
Revert "Function to StaticAddress"

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/CameraManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/CameraManager.cs
@@ -4,8 +4,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Control;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x180)]
 public unsafe partial struct CameraManager {
-    [StaticAddress("48 89 05 ?? ?? ?? ?? E8 ?? ?? ?? ?? 33 D2 45 33 C0 8D 4A 20", 3, isPointer: true)]
-    public static partial CameraManager* Instance();
+    public static CameraManager* Instance() => (CameraManager*)Control.Instance();
 
     [FieldOffset(0x00)] public Camera* Camera;
     [FieldOffset(0x08)] public LowCutCamera* LowCutCamera;


### PR DESCRIPTION
This reverts commit 24dfca0256ba5973fe8cccbc839e81dd8066f482.
`Client::Game::Control::CameraManager` != `Client::Graphics::Scene::CameraManager`