### PR TITLE
Make ID structs equatable and comparable.

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
@@ -66,12 +66,19 @@ public struct EventHandlerObjective {
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x04)]
-public struct EventId {
+public struct EventId : IEquatable<EventId>, IComparable<EventId> {
     [FieldOffset(0x00), CExportIgnore] public uint Id;
     [FieldOffset(0x00)] public ushort EntryId;
     [FieldOffset(0x02)] public EventHandlerContent ContentId;
     public static implicit operator uint(EventId id) => id.Id;
     public static implicit operator EventId(uint id) => new() { Id = id };
+
+    public bool Equals(EventId other) => Id == other.Id;
+    public override bool Equals(object? obj) => obj is EventId other && Equals(other);
+    public override int GetHashCode() => Id.GetHashCode();
+    public static bool operator ==(EventId left, EventId right) => left.Id == right.Id;
+    public static bool operator !=(EventId left, EventId right) => left.Id != right.Id;
+    public int CompareTo(EventId other) => Id.CompareTo(other);
 }
 
 public enum EventHandlerContent : ushort {

--- a/FFXIVClientStructs/FFXIV/Client/Game/HousingManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/HousingManager.cs
@@ -147,7 +147,7 @@ public unsafe partial struct HousingManager {
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x8)]
-public struct HouseId {
+public struct HouseId : IEquatable<HouseId>, IComparable<HouseId> {
     /// <remarks>
     /// Masked data:<br/>
     /// - <c>0b1000_0000</c> (<c>0x80</c>) = Apartment Flag<br/>
@@ -165,6 +165,8 @@ public struct HouseId {
     [FieldOffset(0x4)] public ushort TerritoryTypeId;
     [FieldOffset(0x6)] public ushort WorldId;
 
+    [FieldOffset(0x0), CExportIgnore] public long Id;
+
     public bool IsApartment => (Data0 & 0x80) != 0 && (byte)(Data0 & 0x7F) < 2;
     public byte ApartmentDivision => (byte)(Data0 & 0x7F);
 
@@ -173,8 +175,15 @@ public struct HouseId {
     public short RoomNumber => (short)(Data2 >> 6);
     public bool IsWorkshop => RoomNumber == 0x3FF;
 
-    public static unsafe implicit operator long(HouseId id) => *(long*)&id;
+    public static implicit operator long(HouseId id) => id.Id;
     public static unsafe implicit operator HouseId(long id) => *(HouseId*)&id;
+
+    public bool Equals(HouseId other) => Id == other.Id;
+    public override bool Equals(object? obj) => obj is HouseId other && Equals(other);
+    public override int GetHashCode() => Id.GetHashCode();
+    public static bool operator ==(HouseId left, HouseId right) => left.Id == right.Id;
+    public static bool operator !=(HouseId left, HouseId right) => left.Id != right.Id;
+    public int CompareTo(HouseId other) => Id.CompareTo(other);
 }
 
 public enum EstateType {

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -155,12 +155,20 @@ public unsafe partial struct GameObject {
 //   if (BaseId != 0) ObjectId = BaseId, Type = 1
 // else ObjectId = EntityId, Type = 0
 [StructLayout(LayoutKind.Explicit, Size = 0x8)]
-public struct GameObjectId {
+public struct GameObjectId : IEquatable<GameObjectId>, IComparable<GameObjectId> {
     [FieldOffset(0x0)] public uint ObjectId;
     [FieldOffset(0x4)] public byte Type;
 
-    public static unsafe implicit operator ulong(GameObjectId id) => *(ulong*)&id;
+    [FieldOffset(0x0), CExportIgnore] public ulong Id;
+
+    public static implicit operator ulong(GameObjectId id) => id.Id;
     public static unsafe implicit operator GameObjectId(ulong id) => *(GameObjectId*)&id;
+    public bool Equals(GameObjectId other) => Id == other.Id;
+    public override bool Equals(object? obj) => obj is GameObjectId other && Equals(other);
+    public override int GetHashCode() => Id.GetHashCode();
+    public static bool operator ==(GameObjectId left, GameObjectId right) => left.Id == right.Id;
+    public static bool operator !=(GameObjectId left, GameObjectId right) => left.Id != right.Id;
+    public int CompareTo(GameObjectId other) => Id.CompareTo(other);
 }
 
 public enum ObjectKind : byte {


### PR DESCRIPTION
See title. No clue if this is breaking. No properties are removed in any case, so as long as adding methods and interfaces to structs is fine, this should be no issue.