### PR TITLE
Add some fields to MapMarkerData

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/Map.cs
@@ -56,9 +56,13 @@ public unsafe partial struct MapMarkerData {
     [FieldOffset(0x30)] public uint MapId;
     [FieldOffset(0x34)] public uint PlaceNameZoneId;
     [FieldOffset(0x38)] public uint PlaceNameId;
+    [FieldOffset(0x3C)] public int EndTimestamp;
 
     [FieldOffset(0x40)] public ushort RecommendedLevel;
     [FieldOffset(0x42)] public ushort TerritoryTypeId;
+    [FieldOffset(0x44)] public ushort DataId;
+    [FieldOffset(0x46)] public byte MarkerType;
+    [FieldOffset(0x47)] public sbyte EventState;
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 53 ?? 8B 86")]
     public partial MapMarkerData* SetData(
@@ -74,5 +78,5 @@ public unsafe partial struct MapMarkerData {
         uint placeNameZoneId,
         uint placeNameId,
         ushort recommendedLevel,
-        sbyte a14 = -1);
+        sbyte eventState = -1);
 }


### PR DESCRIPTION
- `EndTimestamp` seems to hold EndTimestamp from Gold Saucer events.
- `DataId` use depends on `MarkerType` (fate ID for fates, sequential numbers for "escort" arrow quest markers, copy of ObjectiveId for quests, others unknown).
- `MarkerType` indicates the type of marker (0 seems generic, 1 is fates, 3 is quests, 4 is "escort" arrow quest markers, others unknown)
- `EventState` seems used to mark the state of some types (usually -1, but can be 0 for MSQ quests, 2 for completed quests, seems to maybe also indicate something about housing state)