### PR TITLE
Fix RedBlackTree memory alignment

### DIFF
--- a/FFXIVClientStructs/STD/Helper/RedBlackTree.cs
+++ b/FFXIVClientStructs/STD/Helper/RedBlackTree.cs
@@ -454,8 +454,6 @@ public unsafe struct RedBlackTree<T, TKey, TKeyExtractor>
         public Node* _Right;
         public RedBlackTreeNodeColor _Color;
         public bool _Isnil;
-        public byte _18;
-        public byte _19;
         public T _Myval;
 
         public static Node* BuyHeadNode<TMemorySpace>()


### PR DESCRIPTION
Current version doesn't work for `StdSet<byte>` because the value should be at 0x1A (where the field `_18` is).