### PR TITLE
Add RetainerItemsPrices to InventoryManager

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/InventoryManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InventoryManager.cs
@@ -24,7 +24,7 @@ public unsafe partial struct InventoryManager {
     [FieldOffset(0x21A9)] public bool TradeWarnIfMovedTooFar;
     [FieldOffset(0x21AB)] public bool TradeIsSyncPending;
 
-    [FieldOffset(0x21B8), FixedSizeArray] internal FixedSizeArray20<ulong> _retainerItemsPrices;
+    [FieldOffset(0x21B8), FixedSizeArray] internal FixedSizeArray20<ulong> _retainerMarketPrices;
 
     // Data here for Gearset Item check
     [FieldOffset(0x2400)] internal BannerData GearsetPortraitData;

--- a/FFXIVClientStructs/FFXIV/Client/Game/InventoryManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InventoryManager.cs
@@ -24,6 +24,8 @@ public unsafe partial struct InventoryManager {
     [FieldOffset(0x21A9)] public bool TradeWarnIfMovedTooFar;
     [FieldOffset(0x21AB)] public bool TradeIsSyncPending;
 
+    [FieldOffset(0x21B8), FixedSizeArray] internal FixedSizeArray20<ulong> _retainerItemsPrices;
+
     // Data here for Gearset Item check
     [FieldOffset(0x2400)] internal BannerData GearsetPortraitData;
     // Related to Addon#4385 "<head(<ennoun(Item,2,lnum1,1,1)>)> registered to this gear set could not be found in your Armoury Chest. Replace it with <ennoun(Item,1,lnum2,1,1)>?"


### PR DESCRIPTION
the array that contains all market selling items prices in current retainer.
used in my plugin for a long time and i think it's better to move it to FFCS

Example code:
```
private static ulong GetRetainerMarketPrice(ushort slot)
        {
            if (slot >= 20) return 0;

            var manager = InventoryManager.Instance();
            if (manager == null) return 0;

            var container = manager->GetInventoryContainer(InventoryType.RetainerMarket);
            if (container == null || !container->IsLoaded) return 0;

            var slotData = container->GetInventorySlot(slot);
            if (slotData == null) return 0;

            var marketPrices = (ulong*)((byte*)manager + 8632);
            return marketPrices[slot];
        }
```