### PR TITLE
Add Cosmopouch InventoryTypes

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/InventoryType.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InventoryType.cs
@@ -42,6 +42,9 @@ public enum InventoryType : uint {
     PremiumSaddleBag1 = 4100,
     PremiumSaddleBag2 = 4101,
 
+    Cosmopouch1 = 5000,
+    Cosmopouch2 = 5001,
+
     Invalid = 9999,
 
     RetainerPage1 = 10000,


### PR DESCRIPTION
The content of these types is not part of the InventoryManager though, as `InventoryManager.GetInventoryContainer` resolves them differently. There is a new inventory thing at 142965D90 with specialized containers. The one I looked at (at 1422E89C0) checks TerritoryIntendedUse == 60 (Cosmic Exploration) and communicates with WKSManager.