### PR TITLE
Fix WKSResearch naming

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSResearch.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSResearch.cs
@@ -8,17 +8,20 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.WKS;
 [StructLayout(LayoutKind.Explicit, Size = 0x80)]
 public unsafe partial struct WKSResearch {
     [FieldOffset(0x08), FixedSizeArray] internal FixedSizeArray11<ushort> _analysis;
-    [FieldOffset(0x60), FixedSizeArray] internal FixedSizeArray11<byte> _currentRanks;
-    [FieldOffset(0x6B), FixedSizeArray] internal FixedSizeArray11<byte> _unlockedRanks;
+    [FieldOffset(0x60), FixedSizeArray] internal FixedSizeArray11<byte> _currentStages;
+    [FieldOffset(0x6B), FixedSizeArray] internal FixedSizeArray11<byte> _unlockedStages;
     [FieldOffset(0x76)] public ushort RatePercentage;
     [FieldOffset(0x78)] public bool IsLoaded;
 
     [MemberFunction("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 41 0F B6 D8 0F B6 FA 48 8B F1 E8 ?? ?? ?? ?? 80 78 1D 00 74 36")]
-    public partial ushort GetCurrentAnalysis(byte toolClass, byte rank);
+    public partial ushort GetCurrentAnalysis(byte toolClass, byte type);
 
     [MemberFunction("48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 83 EC 20 41 0F B6 D8")]
-    public partial ushort GetNeededAnalysis(byte toolClass, byte rank);
+    public partial ushort GetNeededAnalysis(byte toolClass, byte type);
 
     [MemberFunction("E8 ?? ?? ?? ?? 49 C1 E6 04 48 8D BD ?? ?? ?? ??")]
-    public partial ushort GetMaxAnalysis(byte toolClass, byte rank);
+    public partial ushort GetMaxAnalysis(byte toolClass, byte type);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 0F 84 ?? ?? ?? ?? 0F B6 4E FD")]
+    public partial bool IsTypeAvailable(byte toolClass, byte type);
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1920,11 +1920,12 @@ classes:
       0x14199C140: GetCurrentAnalysis
       0x14199C1C0: GetMaxAnalysis
       0x14199C270: GetNeededAnalysis
-      0x14199C450: GetCurrentRank
-      0x14199C4A0: IsMaxRank
-      0x14199C520: IsNextRankAvailable
+      0x14199C450: GetCurrentStage
+      0x14199C4A0: IsMaxStage
+      0x14199C520: IsNextStageAvailable
+      0x14199C330: IsTypeAvailable
       0x14199C5A0: GetRatePercentage
-      0x14199C850: GetUnlockedRank
+      0x14199C850: GetUnlockedStage
       0x14199CD20: GetClassJobLevel
   Client::System::String::Utf8String:
     funcs:


### PR DESCRIPTION
Based on https://ffxiv.consolegameswiki.com/wiki/Cosmic_Tools: each tool has 9 stages (not ranks) with up to 4 types each.
This PR fixes the way things are named.