### PR TITLE
InteropGenerator: support multiple inheritance pointer arithmetic

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentTextInput.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentTextInput.cs
@@ -14,9 +14,9 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 // type 7
 [GenerateInterop]
 [Inherits<AtkComponentInputBase>]
+[Inherits<AtkTextInput.AtkTextInputEventInterface>("48 89 01 48 8D 05 ?? ?? ?? ?? 48 89 81 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ?? 48 89 81 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ?? 48 8B 48 68", 6)]
 [StructLayout(LayoutKind.Explicit, Size = 0x600)]
 public unsafe partial struct AtkComponentTextInput : ICreatable {
-
     [FieldOffset(0x1E8)] public SoftKeyboardDeviceInterface.SoftKeyboardInputInterface SoftKeyboardInputInterface; // implemented by class
 
     [FieldOffset(0x250)] public uint MaxTextLength;

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextInput.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextInput.cs
@@ -9,6 +9,7 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0xCC0)]
 public unsafe partial struct AtkTextInput {
+    [FieldOffset(0x8)] public AtkTextInputEventInterface* TargetTextInputEventInterface;
     [FieldOffset(0x10)] public CompletionModule* CompletionModule;
     [FieldOffset(0x18)] public TextService* TextService;
     [FieldOffset(0x20), FixedSizeArray] internal FixedSizeArray19<Pointer<RaptureAtkHistory>> _atkHistory;
@@ -18,4 +19,10 @@ public unsafe partial struct AtkTextInput {
     [FieldOffset(0x298)] public Utf8String CopyBufferRaw;
     [FieldOffset(0x300)] public Utf8String CopyBufferFiltered;
     [FieldOffset(0xBF0)] public uint CompletionDepth;
+
+    [GenerateInterop(true)]
+    [StructLayout(LayoutKind.Explicit, Size = 0x8)]
+    public unsafe partial struct AtkTextInputEventInterface {
+        // vfuncs
+    }
 }

--- a/InteropGenerator.Runtime/Attributes/InheritsAttribute.cs
+++ b/InteropGenerator.Runtime/Attributes/InheritsAttribute.cs
@@ -6,6 +6,12 @@ namespace InteropGenerator.Runtime.Attributes;
 /// <param name="parentOffset">Explicit parent offset, overriding size-based offsetting with multiple inheritance.</param>
 /// <typeparam name="T"></typeparam>
 [AttributeUsage(AttributeTargets.Struct, AllowMultiple = true)]
-public sealed class InheritsAttribute<T>(int parentOffset = 0) : Attribute where T : unmanaged {
+public sealed class InheritsAttribute<T>(int parentOffset, string vtableSignature, ushort[] relativeFollowOffsets) : Attribute where T : unmanaged {
     public int ParentOffset { get; } = parentOffset;
+    public string VtableSignature { get; } = vtableSignature;
+    public ushort[] RelativeFollowOffsets { get; } = relativeFollowOffsets;
+    
+    public InheritsAttribute(int parentOffset = 0) : this(parentOffset, string.Empty, []) { }
+    public InheritsAttribute(string vtableSignature, ushort[] relativeFollowOffsets) : this(0, vtableSignature, relativeFollowOffsets) { }
+    public InheritsAttribute(string vtableSignature, ushort relativeFollowOffset) : this(0, vtableSignature, [relativeFollowOffset]) { }
 }

--- a/InteropGenerator.Runtime/Resolver.cs
+++ b/InteropGenerator.Runtime/Resolver.cs
@@ -31,7 +31,13 @@ public sealed class Resolver {
     }
 
     public static Resolver GetInstance => Instance.Value;
-
+    
+    public static unsafe T* FromBasePointer<T, TB>(TB *bp, nint baseVtblAddr, nint baseOffset) where T : unmanaged where TB : unmanaged  {
+        if (bp == null) return null;
+        if (*(nint*)bp != baseVtblAddr) return null;
+        return (T*)((nint)bp - baseOffset);
+    }
+    
     public void Setup(nint moduleCopyPointer = 0, string version = "", FileInfo? cacheFile = null) {
         if (_isSetup) return;
         var module = Process.GetCurrentProcess().MainModule;

--- a/InteropGenerator/Generator/InteropGenerator.Rendering.cs
+++ b/InteropGenerator/Generator/InteropGenerator.Rendering.cs
@@ -97,6 +97,9 @@ public sealed partial class InteropGenerator {
             if (structInfo.StaticVirtualTableSignature is not null) {
                 writer.WriteLine(GetAddressString(structInfo, "StaticVirtualTable", structInfo.StaticVirtualTableSignature));
             }
+            foreach (var ii in structInfo.ExtraBases()) {
+                writer.WriteLine(GetAddressString(structInfo, $"Static{ii.InheritedTypeName}VirtualTable", ii.StaticVirtualTableSignature!));
+            }
         }
     }
 
@@ -363,6 +366,10 @@ public sealed partial class InteropGenerator {
                     if (sInfo.StaticVirtualTableSignature is not null) {
                         writer.WriteLine(GetAddToResolverString(sInfo, "StaticVirtualTable"));
                     }
+                    // Additional baseclass static virtual tables
+                    foreach (InheritanceInfo ii in sInfo.ExtraBases()) {
+                        writer.WriteLine(GetAddToResolverString(sInfo, $"Static{ii.InheritedTypeName}VirtualTable"));
+                    }
                 }
             }
             writer.WriteLine("public static void Unregister()");
@@ -379,6 +386,10 @@ public sealed partial class InteropGenerator {
                     // static virtual table
                     if (sInfo.StaticVirtualTableSignature is not null) {
                         writer.WriteLine(GetRemoveFromResolverString(sInfo, "StaticVirtualTable"));
+                    }
+                    // Additional baseclass static virtual tables
+                    foreach (InheritanceInfo ii in sInfo.ExtraBases()) {
+                        writer.WriteLine(GetRemoveFromResolverString(sInfo, $"Static{ii.InheritedTypeName}VirtualTable"));
                     }
                 }
             }

--- a/InteropGenerator/Generator/InteropGenerator.cs
+++ b/InteropGenerator/Generator/InteropGenerator.cs
@@ -46,7 +46,7 @@ public sealed partial class InteropGenerator : IIncrementalGenerator {
                 using ImmutableArrayBuilder<StructInfo> inheritedStructsBuilder = new();
 
                 foreach (InheritanceInfo inheritedStruct in targetStruct.InheritedStructs) {
-                    CollectInheritedStructs(inheritedStruct.InheritedTypeName, structsInherited, tempInheritanceMap, inheritedStructsBuilder);
+                    CollectInheritedStructs(inheritedStruct.FullInheritedTypeName, structsInherited, tempInheritanceMap, inheritedStructsBuilder);
                 }
 
                 structInheritanceGroupedBuilder.Add((targetStruct, inheritedStructsBuilder.ToImmutable()));
@@ -104,7 +104,7 @@ public sealed partial class InteropGenerator : IIncrementalGenerator {
         // recursively add child types
         if (targetInheritedStruct.InheritedStructs.Length != 0) {
             foreach (InheritanceInfo inheritanceInfo in targetInheritedStruct.InheritedStructs) {
-                CollectInheritedStructs(inheritanceInfo.InheritedTypeName, validInheritedTypes, processedInheritanceMap, inheritanceHierarchyBuilder);
+                CollectInheritedStructs(inheritanceInfo.FullInheritedTypeName, validInheritedTypes, processedInheritanceMap, inheritanceHierarchyBuilder);
             }
         }
 

--- a/InteropGenerator/Models/InheritanceInfo.cs
+++ b/InteropGenerator/Models/InheritanceInfo.cs
@@ -1,5 +1,7 @@
 namespace InteropGenerator.Models;
 
 internal sealed record InheritanceInfo(
+    string FullInheritedTypeName,
     string InheritedTypeName,
-    int ParentOffset);
+    int ParentOffset,
+    SignatureInfo? StaticVirtualTableSignature);

--- a/InteropGenerator/Models/StructInfo.cs
+++ b/InteropGenerator/Models/StructInfo.cs
@@ -16,8 +16,10 @@ internal sealed record StructInfo(
     int? Size,
     ExtraInheritedStructInfo? ExtraInheritedStructInfo) {
     public string Name => Hierarchy[0];
-    public bool HasSignatures() => !MemberFunctions.IsEmpty || !StaticAddresses.IsEmpty || StaticVirtualTableSignature is not null;
+    public bool HasSignatures() => !MemberFunctions.IsEmpty || !StaticAddresses.IsEmpty || StaticVirtualTableSignature is not null || ExtraBases().Any();
     public bool HasVirtualTable() => !VirtualFunctions.IsEmpty || StaticVirtualTableSignature is not null;
 
     public bool NeedsRender() => MemberFunctions.Any() || VirtualFunctions.Any() || StaticAddresses.Any() || StringOverloads.Any() || StaticVirtualTableSignature is not null || FixedSizeArrays.Any();
+    
+    public IEnumerable<InheritanceInfo> ExtraBases() => InheritedStructs.Skip(1).Where(i => i.StaticVirtualTableSignature is not null);
 }


### PR DESCRIPTION
Adds a static `T* FromBasePointer(TB* basePtr)` that uses a known static vtbl pointer to validate that basePtr is pointing to a TB baseclass inside of a T.

The use on AtkComponentTextInput is meant to be the first usage of it, but right now the interface type doesn't have any of its vfuncs reversed- I can work on adding some if needed, but for now, this is sufficient to enable the autocomplete functionality in dalamud