### PR TITLE
Replace ReconstructionBoxManager with DomanEnclaveManager

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/DomanEnclaveManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/DomanEnclaveManager.cs
@@ -1,0 +1,30 @@
+using FFXIVClientStructs.FFXIV.Common.Component.Excel;
+
+namespace FFXIVClientStructs.FFXIV.Client.Game;
+
+// Client::Game::DomanEnclaveManager
+// Manager for Doman Enclave Reconstruction
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0xA8)]
+public unsafe partial struct DomanEnclaveManager {
+    [StaticAddress("48 8B 15 ?? ?? ?? ?? 48 8B C8 48 83 C4 28", 3, isPointer: true)]
+    public static partial DomanEnclaveManager* Instance();
+
+    [FieldOffset(0x08)] public bool IsLoaded;
+    [FieldOffset(0x10)] public ExcelSheetWaiter* DomaStoryProgressSheetWaiter; // size: 0x50
+    [FieldOffset(0x18)] public ExcelSheet* DomaStoryProgressSheet;
+    /// <remarks> RowIds of DomaStoryProgress sheet. </remarks>
+    [FieldOffset(0x20), FixedSizeArray] internal FixedSizeArray128<byte> _milestones;
+    [FieldOffset(0xA0)] public DomanEnclaveState State;
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x08)]
+    public struct DomanEnclaveState {
+        [FieldOffset(0x00)] public ushort Donated;
+        /// <remarks> Index in the <see cref="Milestones" /> array. </remarks>
+        [FieldOffset(0x02)] public byte CurrentMilestone;
+        [FieldOffset(0x03)] public bool IsAcceptingDonations;
+        /// <remarks> Add 100 to get the correct value. </remarks>
+        [FieldOffset(0x04)] public byte Factor;
+        [FieldOffset(0x06)] public ushort Allowance;
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/ReconstructionBoxManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/ReconstructionBoxManager.cs
@@ -3,6 +3,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game;
 // Client::Game::ReconstructionBoxManager
 // Doman Enclave Reconstruction Box
 [GenerateInterop]
+[Obsolete("Use DomanEnclaveManager instead.")]
 [StructLayout(LayoutKind.Explicit, Size = 0xA8)]
 public unsafe partial struct ReconstructionBoxManager {
     [StaticAddress("48 8B 15 ?? ?? ?? ?? 48 8B C8 48 83 C4 28", 3, isPointer: true)]

--- a/FFXIVClientStructs/FFXIV/Common/Component/Excel/ExcelSheetWaiter.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Component/Excel/ExcelSheetWaiter.cs
@@ -1,0 +1,6 @@
+namespace FFXIVClientStructs.FFXIV.Common.Component.Excel;
+
+// Common::Component::Excel::ExcelSheetWaiter
+[GenerateInterop(isInherited: true)]
+[StructLayout(LayoutKind.Explicit, Size = 0x30)]
+public unsafe partial struct ExcelSheetWaiter;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -8621,7 +8621,8 @@ classes:
       0x140788CF0: GrandCompanyUpdateTask            # (this) -> void
       0x140788F70: PvPStateUpdateTask                # (this) -> void
       0x140789080: ToggleWXHBRightFocusFlag
-      0x1407F4B30: ToggleWXHBLeftFocusFlag
+      0x1407890E0: ToggleWXHBLeftFocusFlag
+      0x140789140: ToggleWXHBFocusFlags
       0x14078C440: SetStandardHotbarShareState
       0x14078C4B0: SetCrossHotbarShareState
       0x14078E420: DeleteAllHotbars                 # (this, performReset) -> void?

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -14025,7 +14025,7 @@ classes:
         base: Client::Game::Event::Director
     funcs:
       0x140CAD360: ctor
-  Client::Game::ReconstructionBoxManager:
+  Client::Game::DomanEnclaveManager:
     instances:
       - ea: 0x142932230
         pointer: true
@@ -14038,6 +14038,14 @@ classes:
       0x1409744F0: Destroy
       0x140974550: HasInstance
       0x140974570: GetInstance
+      0x140974680: GetProgress
+      0x140974730: ReadPacket
+      0x140974A20: ctor
+  Client::Game::DomanEnclaveManager::DomanEnclaveState:
+    funcs:
+      0x1409743C0: ctor
+      0x1409743F0: ReadPacket
+      0x140974420: GetAllowance
   Client::Game::Event::EventFramework:
     instances:
       - ea: 0x14294F4F0


### PR DESCRIPTION
Besides the state being in its own struct (and heavily inlined), the manager is also used to decide which SharedGroup layout instance to display.
So it made sense to rename and replace it with a whole new struct, imo.