### PR TITLE
Rename GoldSaucerYell to NpcYell

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/NpcYell.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/NpcYell.cs
@@ -1,5 +1,5 @@
 namespace FFXIVClientStructs.FFXIV.Client.Game.UI;
 
-// Client::Game::UI::GoldSaucerYell
+// Client::Game::UI::NpcYell
 [StructLayout(LayoutKind.Explicit, Size = 0x1750)]
-public struct GoldSaucerYell;
+public struct NpcYell;

--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/UIState.cs
@@ -68,7 +68,7 @@ public unsafe partial struct UIState {
     [FieldOffset(0x16F58)] public CollectablesShop CollectablesShop; // 7.2: size +0x20
     [FieldOffset(0x17250)] public QTE QTE;
     [FieldOffset(0x17278)] public Emj Emj;
-    [FieldOffset(0x172B0)] public GoldSaucerYell GoldSaucerYell;
+    [FieldOffset(0x172B0)] public NpcYell NpcYell;
     [FieldOffset(0x18A00)] public CharaCard CharaCard;
     // 0x18068: ItemAction Unlocks
     [FieldOffset(0x18C40)] public ClientSelectDataConfigFlags ClientSelectDataConfigFlags;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2730,7 +2730,7 @@ classes:
   Client::Game::UI::Emj:
     instances:
       - ea: 0x142949DC8
-  Client::Game::UI::GoldSaucerYell:
+  Client::Game::UI::NpcYell:
     instances:
       - ea: 0x142949E00
     vtbls:


### PR DESCRIPTION
When I added this I only saw it being called from GoldSaucer related code.
As per [comment](https://github.com/aers/FFXIVClientStructs/pull/1412#issuecomment-2838304048) in #1412 and further reverse-engineering, I'm hereby renaming it to NpcYell.