### PR TITLE
Add AtkTextInputEventInterface

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentInputBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentInputBase.cs
@@ -12,6 +12,8 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 public unsafe partial struct AtkComponentInputBase {
     [FieldOffset(0xC8)] public AtkTextNode* AtkTextNode;
     [FieldOffset(0xD0)] public AtkResNode* CursorContainer;
+    [FieldOffset(0xD8)] public AtkEventManager* EventManager;
     [FieldOffset(0xE0)] public Utf8String UnkText1;
     [FieldOffset(0x148)] public Utf8String UnkText2;
+    [FieldOffset(0x1B0)] public AtkUnitBase* ContainingAddon;
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentTextInput.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentTextInput.cs
@@ -14,9 +14,9 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 // type 7
 [GenerateInterop]
 [Inherits<AtkComponentInputBase>]
+[Inherits<AtkTextInput.AtkTextInputEventInterface>]
 [StructLayout(LayoutKind.Explicit, Size = 0x600)]
 public unsafe partial struct AtkComponentTextInput : ICreatable {
-
     [FieldOffset(0x1E8)] public SoftKeyboardDeviceInterface.SoftKeyboardInputInterface SoftKeyboardInputInterface; // implemented by class
 
     [FieldOffset(0x250)] public uint MaxTextLength;
@@ -26,9 +26,25 @@ public unsafe partial struct AtkComponentTextInput : ICreatable {
 
     [FieldOffset(0x280)] public Utf8String UnkText01;
     [FieldOffset(0x2E8)] public Utf8String UnkText02;
-    [FieldOffset(0x350)] public Utf8String UnkText03;
-    [FieldOffset(0x450)] public Utf8String UnkText04;
-    [FieldOffset(0x4B8)] public Utf8String UnkText05;
+
+    [FieldOffset(0x350)] [Obsolete("Renamed to AvailableLines")] public Utf8String UnkText03;
+    [FieldOffset(0x450)] [Obsolete("Renamed to HighlightedAutoTranslateOptionColorPrefix")] public Utf8String UnkText04;
+    [FieldOffset(0x4B8)] [Obsolete("Renamed to HighlightedAutoTranslateOptionColorSuffix")] public Utf8String UnkText05;
+
+    [FieldOffset(0x350)] public Utf8String AvailableLines;
+    // Utf8Strings containing color macros that are wrapped around the highlighted AutoTranslate option
+    [FieldOffset(0x450)] public Utf8String HighlightedAutoTranslateOptionColorPrefix;
+    [FieldOffset(0x4B8)] public Utf8String HighlightedAutoTranslateOptionColorSuffix;
+
+    [FieldOffset(0x3B8)] public AtkTextNode* AvailableLinesTextNode;
+    [FieldOffset(0x3C0)] public AtkTextNode* AvailableCharsTextNode;
+    [FieldOffset(0x3C8)] public AtkUnitBase* ContainingAddon2; // For whatever reason, the text input _also_ has this
+    [FieldOffset(0x3D0)] public AtkResNode* AutoTranslateMenuNode;
+    [FieldOffset(0x3D8)] public int CompletionOffset; // Offset into the total number of completion items- used for drawing the label
+
+    [FieldOffset(0x3E0), FixedSizeArray] internal FixedSizeArray9<Pointer<AtkComponentButton>> _autoTranslateMenuButtons;
+    [FieldOffset(0x428)] public AtkTextNode* AutoTranslateMenuPageInfoTextNode;
+    [FieldOffset(0x430)] public AtkNineGridNode* AutoTranslateMenuBackground;
 
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 45 33 C9 33 D2 B9 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B F0")]
     public partial void Ctor();

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextInput.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextInput.cs
@@ -9,6 +9,7 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0xCC0)]
 public unsafe partial struct AtkTextInput {
+    [FieldOffset(0x8)] public AtkTextInputEventInterface* TargetTextInputEventInterface;
     [FieldOffset(0x10)] public CompletionModule* CompletionModule;
     [FieldOffset(0x18)] public TextService* TextService;
     [FieldOffset(0x20), FixedSizeArray] internal FixedSizeArray19<Pointer<RaptureAtkHistory>> _atkHistory;
@@ -18,4 +19,10 @@ public unsafe partial struct AtkTextInput {
     [FieldOffset(0x298)] public Utf8String CopyBufferRaw;
     [FieldOffset(0x300)] public Utf8String CopyBufferFiltered;
     [FieldOffset(0xBF0)] public uint CompletionDepth;
+
+    // Component::GUI::AtkTextInput::AtkTextInputEventInterface
+    // no explicit constructor, just an event interface 
+    [GenerateInterop(true)]
+    [StructLayout(LayoutKind.Explicit, Size = 0x8)]
+    public unsafe partial struct AtkTextInputEventInterface;
 }


### PR DESCRIPTION
This baseclass is used by AtkTextInput to hold a reference to whatever object is currently receiving text events. Leaving it as a placeholder until I can get the vfuncs worked out

Also fills out a bunch of AtkComponentTextInput fields, as well as a couple of the remaining gaps in AtkComponentInputBase based on my initial digging into those vfuncs