### PR TITLE
Add LoadTextureWithDefaultVersion

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTexture.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTexture.cs
@@ -37,6 +37,11 @@ public unsafe partial struct AtkTexture : ICreatable {
 
     [VirtualFunction(0)]
     public partial void Destroy(bool free);
+    
+    // Based on call from AtkImageNode_LoadTextureWithDefaultVersion
+    [GenerateStringOverloads]
+    public int LoadTextureWithDefaultVersion(CStringPointer path)
+        => LoadTexture(path, AtkStage.Instance()->AtkTextureResourceManager->DefaultTextureVersion);
 }
 
 public enum TextureType : byte {


### PR DESCRIPTION
This may help people avoid the pitfall that is the default argument on LoadTexture poisoning the games texture cache when used before the game loads the texture itself.

## Context
When LoadTexture is called with a hardcoded value of 1, the game will attempt to load the texture in low-resolution mode.
Specifically what this means is the game will not add "_hr1" to the texture path, and will just load whatever texture it is told to load. 

The catch here is, if a plugin tries to load a texture and does specify a "_hr1" texture, when the LoadTexture call is invoked before the game has loaded that texture on its own, it ends up corrupting the internal size of the parts created with that texture, with the size and position data from the higher resolution texture file.

The LoadTexture function internally will append "_hr1" to the texture if the mode is **not** 1.
Normal-Resolution mode is 1, High-Resolution mode is 2.

Correct usage of LoadTexture involves passing the correct DefaultTextureVersion from AtkStage->AtkTextureResourceManager.
Even with High-Resolution set, when on the title screen for example, the game will be in Low-Resolution mode, but when actually logged into the game the game will switch to High-Resolution mode.

### Conclusion
We should technically remove the default value from LoadTexture, or should pass it the DefaultTextureVersion value on each call.

However, anyone that is passing in a texture with "_hr1" already in it, will get a null texture loaded when in High-Resolution mode.

This could be mitigated in CS by stripping "_hr1" and letting the game re-add it, if it's in the correct mode.
```cs
    public void LoadTexture(string path) {
        var texturePath = path.Replace("_hr1", string.Empty);
        var textureVersion = AtkStage.Instance()->AtkTextureResourceManager->DefaultTextureVersion;
        LoadTexture(texturePath, textureVersion );
    }
```