### PR TITLE
More MKD

### DIFF
--- a/CExporter/Exporter.cs
+++ b/CExporter/Exporter.cs
@@ -90,6 +90,9 @@ public class Exporter {
                 .ToArray();
             _processType.Clear();
             foreach (var @struct in tmp) {
+                if (@struct.Type.FullName == "FFXIVClientStructs.FFXIV.Component.GUI.AtkComponentBase") {
+                    Console.WriteLine("ATKCB!!");
+                }
                 ProcessType(@struct, quiet);
             }
 
@@ -219,6 +222,9 @@ public class Exporter {
         foreach (var c in def.classes) {
             if (c.Value == null || (c.Value.vfuncs == null || c.Value.vfuncs.Count == 0) && (c.Value.vtbls == null || c.Value.vtbls.Count == 0)) continue;
             var s = _structs.Find(s => s.StructTypeName == c.Key);
+            if (c.Key == "Component::GUI::AtkComponentBase") {
+                Console.WriteLine("Component::GUI::AtkComponentBase");
+            }
             if (s == null) continue;
             s.VirtualFunctions ??= [];
             if (c.Value.vfuncs == null) continue;
@@ -473,6 +479,9 @@ public class Exporter {
             var vtable = type.GetField("VirtualTable", ExporterStatics.BindingFlags)?.FieldType;
             ProcessedVirtualFunction[]? virtualFunctions = null;
             if (vtable != null) {
+                if (vtable.FullName == "FFXIVClientStructs.FFXIV.Component.GUI.AtkComponentButton+AtkComponentButtonVirtualTable*") {
+                    Console.WriteLine($"Checking vtbl {vtable.FullName}");
+                }
                 vtable = vtable.GetElementType()!;
                 var memberFunctions = type.GetMethods(ExporterStatics.BindingFlags).Where(t => t.GetCustomAttribute<VirtualFunctionAttribute>() != null).Select(t => Tuple.Create(t.Name, t.GetParameters(), t.ReturnType)).ToArray();
                 virtualFunctions = vtable.GetFields(ExporterStatics.BindingFlags).Where(t => t.GetCustomAttribute<ObsoleteAttribute>() == null && t.GetCustomAttribute<CExportIgnoreAttribute>() == null).Select(f => {
@@ -928,6 +937,9 @@ public class ProcessedVirtualFunctionConverter : IYamlTypeConverter {
     public object? ReadYaml(IParser parser, Type type) => throw new NotImplementedException();
     public void WriteYaml(IEmitter emitter, object? value, Type type) {
         if (value is not ProcessedVirtualFunction v) return;
+        if (v.VirtualFunctionName == "OnUldUpdate") {
+            Console.WriteLine("OnUldUpdate");
+        }
         emitter.Emit(new MappingStart());
         emitter.Emit(new Scalar("name"));
         emitter.Emit(new Scalar(v.VirtualFunctionName));

--- a/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/PublicContentOccultCrescent.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/PublicContentOccultCrescent.cs
@@ -67,10 +67,14 @@ public struct OccultCrescentState {
     [FieldOffset(0x44), FixedSizeArray] internal FixedSizeArray13<byte> _supportJobLevels;
     [FieldOffset(0x51), FixedSizeArray] internal FixedSizeArray2<byte> _unlockedTeleportBitmask; // for TelepotTown
     [FieldOffset(0x53)] public byte CurrentSupportJob; // MKDSupportJob RowId
+    [Obsolete("Renamed AveragePartyKnowledgeLevel")]
     [FieldOffset(0x54)] public byte KnowledgeLevelSync;
-    [FieldOffset(0x55)] private byte Unk55;
-    [FieldOffset(0x56)] private byte Unk56; // related to Sanguine Cipher item count, cur?
-    [FieldOffset(0x57)] private byte Unk57; // related to Sanguine Cipher item count, max?
-    [FieldOffset(0x58)] private byte Unk58;
-    [FieldOffset(0x59)] private byte Unk59; // flags
+    [FieldOffset(0x54)] public byte AveragePartyKnowledgeLevel;
+    [FieldOffset(0x55)] public byte SyncedKnowledgeLevel; // 0 if unsynced
+    [FieldOffset(0x56)] public byte Cipher;
+    [FieldOffset(0x57)] public byte CiphersOfferedForEntry;
+    [FieldOffset(0x58)] public byte TowerEntryParticipants;
+    // 0x1 = Balanced Party
+    [FieldOffset(0x59)] private byte Flags; // flags
 }
+

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonMKDInfo.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonMKDInfo.cs
@@ -1,0 +1,78 @@
+using FFXIVClientStructs.FFXIV.Client.System.Resource.Handle;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI;
+
+// Client::UI::AddonMKDInfo
+//   Component::GUI::AtkUnitBase
+//     Component::GUI::AtkEventListener
+[Addon("MKDInfo")]
+[GenerateInterop]
+[Inherits<AtkUnitBase>]
+[StructLayout(LayoutKind.Explicit, Size = 0x3F8)]
+public unsafe partial struct AddonMKDInfo {
+    [FieldOffset(0x238)] private uint Unk238; // Seems to be related to the knowledge level ui timelines
+    [FieldOffset(0x23C)] public PartyState PartyStateFlags;
+    [FieldOffset(0x240)] public StdVector<StdPair<uint,Pointer<AtkComponentButton>>> Buttons;
+    [FieldOffset(0x258)] public ButtonOperationGuideManager CriticalEncounterButtonManager; 
+    [FieldOffset(0x290)] public AtkTextNode *KnowledgeExpTextNode;
+    [FieldOffset(0x298)] public AtkTextNode *KnowledgeNeededTextNode;
+    [FieldOffset(0x2A0)] public AtkTextNode *KnowledgeLevelTextNode;
+    [FieldOffset(0x2A8)] public AtkTextNode *AreaKnowledgeLevelTextNode;
+    [FieldOffset(0x2B0)] public AtkResNode *KnowledgeLevelHeaderResNode;
+    [FieldOffset(0x2B8)] public AtkResNode *AreaKnowledgeLevelResNode;
+    [FieldOffset(0x2C0)] public AtkResNode *JobButtonResNode;
+    [FieldOffset(0x2C8)] public AtkResNode *JobButtonCharJumpingResNode;
+    [FieldOffset(0x2D0)] public AtkTextNode *JobNameNode;
+    [FieldOffset(0x2D8)] public AtkTextNode *JobNameSubtitleTextNode;
+    [FieldOffset(0x2E0)] public AtkTextNode *JobLevelTextNode;
+    [FieldOffset(0x2E8)] public AtkTextNode *JobExpTextNode;
+    [FieldOffset(0x2F0)] public AtkComponentBase *JobIconComponent;
+    [FieldOffset(0x2F8)] public AtkResNode *JobMasteryResNode;
+    [FieldOffset(0x300)] public AtkResNode *JobNotificationResNode;
+    [FieldOffset(0x308)] public AtkResNode *LoreNotificationResNode;
+    [FieldOffset(0x310)] public AtkTextNode *SilverPieceCountTextNode;
+    [FieldOffset(0x318)] public uint SilverPieceCount;
+    [FieldOffset(0x320)] public AtkTextNode *GoldPieceCountTextNode;
+    [FieldOffset(0x328)] public uint GoldPieceCount;
+    [FieldOffset(0x330)] public AtkTextNode *CipherCountTextNode;
+    [FieldOffset(0x338)] public uint CipherCount;
+    [FieldOffset(0x340)] public AtkResNode *CipherCountResNode;
+    [FieldOffset(0x348)] public AtkResNode *ChainResNode;
+    [FieldOffset(0x350)] public AtkTextNode *ChainCountTextNode;
+    [FieldOffset(0x358)] public AtkResNode *ChainTimerResNode;
+    [FieldOffset(0x360)] public AtkResNode *ChainTimerTextNode;
+    [FieldOffset(0x368)] public AtkComponentGaugeBar *ChainGaugeComponent;
+    [FieldOffset(0x370)] public float ChainTimer;
+    [FieldOffset(0x374)] public uint TimerMax;
+    [FieldOffset(0x378)] public uint ContentTypeRowId;
+    [FieldOffset(0x37C)] public uint CriticalEngagementStartCountdown;
+    [FieldOffset(0x380)] public CStringPointer oneSlashTwoMacroString;
+    [FieldOffset(0x388)] public CStringPointer paramOneMacroString;
+    [FieldOffset(0x390)] public CStringPointer italicizeParamOneIfParam2PositiveMacroString;
+    [FieldOffset(0x398)] public CStringPointer HyphenString;
+    [FieldOffset(0x3A0)] public CStringPointer SyncPartyLevelsLeaderString;
+    [FieldOffset(0x3A8)] public CStringPointer PartyLevelSyncedLeaderString;
+    [FieldOffset(0x3B0)] public CStringPointer SyncPartyLevelsString;
+    [FieldOffset(0x3B8)] public CStringPointer PartyLevelSyncedString;
+    [FieldOffset(0x3C0)] public CStringPointer MasteredString;
+    [FieldOffset(0x3C8)] public CStringPointer CECountdownMacroString;
+    [FieldOffset(0x3D0)] public CStringPointer CEStartingString;
+    // 3d8
+    [FieldOffset(0x3E0)] public ResourceHandle *InteractSoundResHandle;
+    [FieldOffset(0x3E8)] public ResourceHandle *CursorSoundResHandle;
+    [FieldOffset(0x3F0)] public ResourceHandle *CancelSoundResHandle;
+
+    [Flags]
+    public enum PartyState {
+        PartyLeader = 0x1,
+        InParty = 0x2,
+        InAlliance = 0x4,
+        InCrossrealmParty = 0x8,
+        InOccultCrescent = 0x10,
+        InBalancedParty = 0x20,
+        IsKnowledgeLevelSynced = 0x40,
+        SyncStatusChanging = 0x80
+    }
+}
+

--- a/FFXIVClientStructs/FFXIV/Client/UI/ButtonOperationGuideManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/ButtonOperationGuideManager.cs
@@ -1,0 +1,20 @@
+﻿using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI;
+
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0x34)]
+public unsafe partial struct ButtonOperationGuideManager {
+    [FieldOffset(0x08)] private AtkEventListener AtkEventListener;
+    [FieldOffset(0x10)] public AtkUnitBase *Addon;
+    [FieldOffset(0x18)] public AtkComponentButton *ButtonComponent;
+    [FieldOffset(0x20)] public uint EventParam;
+    [FieldOffset(0x24)] public uint InputId;
+    [FieldOffset(0x28)] public OperationGuide OperationGuide;
+    
+    [VirtualFunction(0)]
+    public partial byte SetShowsPointer();
+    
+    [VirtualFunction(1)]
+    public partial ulong SetEnabledState(byte enabled);
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCommonList.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Info/InfoProxyCommonList.cs
@@ -57,6 +57,7 @@ public unsafe partial struct InfoProxyCommonList {
         //12 bytes
         /// <summary>
         /// Extra flags for status:
+        /// 0x1 = is party leader
         /// 0x10 = ? always set when accepted friend request
         /// 0x20 = WaitingForFriendListApproval
         /// 0x10000->0x70000 = DisplayGroup.Star -> DisplayGroup.Club

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
@@ -80,6 +80,8 @@ public enum AtkEventType : byte {
     LinkMouseClick = 75,
     LinkMouseOver = 76,
     LinkMouseOut = 77,
+    
+    ComponentFocus = 79,
 }
 
 // Component::GUI::AtkEvent

--- a/InteropGenerator/Generator/InteropGenerator.Rendering.Inheritance.cs
+++ b/InteropGenerator/Generator/InteropGenerator.Rendering.Inheritance.cs
@@ -194,7 +194,7 @@ public sealed partial class InteropGenerator {
                     continue;
                 foreach (VirtualFunctionInfo virtualFunctionInfo in inheritedStruct.VirtualFunctions) {
                     var functionPointerType = $"delegate* unmanaged <{structInfo.Name}*, {virtualFunctionInfo.MethodInfo.GetParameterTypeStringWithTrailingType()}{virtualFunctionInfo.MethodInfo.ReturnType}>";
-                    writer.WriteLine($"[global::System.Runtime.InteropServices.FieldOffsetAttribute({virtualFunctionInfo.Index * 8})] public {functionPointerType} {virtualFunctionInfo.MethodInfo.Name};");
+                    writer.WriteLine($"[global::System.Runtime.InteropServices.FieldOffsetAttribute({virtualFunctionInfo.Index * 8})] {ObsoleteAttributeForVirtualFunc(virtualFunctionInfo)} public {functionPointerType} {virtualFunctionInfo.MethodInfo.Name};");
                 }
             }
         }
@@ -226,7 +226,7 @@ public sealed partial class InteropGenerator {
             writer.WriteLine($"""/// <remarks>Method inherited from parent class <see cref="{inheritedStruct.FullyQualifiedMetadataName}">{inheritedStruct.Name}</see>.</remarks>""");
             writer.WriteLine("[global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
             if (methodInfo.ObsoleteInfo is not null) {
-                writer.WriteLine($"""[global::System.ObsoleteAttribute("{methodInfo.ObsoleteInfo.Message}", {methodInfo.ObsoleteInfo.IsError.ToLowercaseString()})]""");
+                writer.WriteLine(ObsoleteAttributeForVirtualFunc(virtualFunctionInfo));
             }
             // function in table - call via table
             if (offset == 0) {

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -17910,6 +17910,17 @@ classes:
         base: Component::GUI::AtkUnitBase
     funcs:
       0x1415D95E0: ctor
+  Client::UI::AddonMKDInfo:
+    vtbls:
+      - ea: 0x14210BDB0
+        base: Component::GUI::AtkUnitBase
+    funcs:
+      0x14140DFF0: ctor
+  Client::UI::ButtonOperationGuideManager:
+    vtbls:
+      - ea: 0x142094AB0
+    funcs:
+      0x141038E40: ctor
   Client::Game::Object::EventObject:
     vtbls:
       - ea: 0x142152258


### PR DESCRIPTION
- Reverses most of AddonMKDInfo
- Reverses the rest of OccultCrescentState
- Adds ButtonOperationGuideManager, also used in MJI
- New AtkEventType - 79: ComponentFocus. Seems to happen when a controller input focuses a Component with focusable set
- CExporter improvement- Copies the Obsolete attribute to the generated fields to help them look more obsolete (which means CExporter actually won't export them)