### PR TITLE
Fix AtkExternalInterface.CallHandler return value

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkExternalInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkExternalInterface.cs
@@ -5,7 +5,7 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 [StructLayout(LayoutKind.Explicit, Size = 0x8)]
 public unsafe partial struct AtkExternalInterface {
     [VirtualFunction(1)]
-    public partial void CallHandler(AtkValue* result, uint handlerIndex, uint valueCount, AtkValue* values);
+    public partial AtkValue* CallHandler(AtkValue* returnValue, uint handlerIndex, uint valueCount, AtkValue* values);
 
     [VirtualFunction(2)]
     public partial void PlaySoundEffect(AtkValue* result, int soundEffectId);

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkModuleEvent.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkModuleEvent.cs
@@ -5,5 +5,5 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 [StructLayout(LayoutKind.Explicit, Size = 8)]
 public unsafe partial struct AtkModuleEvent {
     [VirtualFunction(0)]
-    public partial void CallHandler(AtkValue* result, uint handlerIndex, AtkValue* values, uint valueCount);
+    public partial AtkValue* CallHandler(AtkValue* returnValue, uint handlerIndex, AtkValue* values, uint valueCount);
 }


### PR DESCRIPTION
Without the return value, hooking `AtkExternalInterface.CallHandler` will cause a crash.

I'm not sure if `AtkExternalInterface.PlaySoundEffect` and `AtkModuleEvent.CallHandler` are also missing the return value, so I didn't include them.