### PR TITLE
Revert "Add IMemorySpace.Calloc/Realloc/Recalloc"

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/Memory/IMemorySpace.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Memory/IMemorySpace.cs
@@ -9,8 +9,9 @@ public interface ICreatable {
 [StructLayout(LayoutKind.Explicit, Size = 8)]
 public unsafe partial struct IMemorySpace {
     public T* Create<T>() where T : unmanaged, ICreatable {
-        var memory = Calloc<T>(1);
+        var memory = (T*)Malloc<T>();
         if (memory is null) return null;
+        Memset(memory, 0, (ulong)sizeof(T));
         memory->Ctor();
         return memory;
     }
@@ -36,27 +37,14 @@ public unsafe partial struct IMemorySpace {
     [MemberFunction("4C 8B D9 0F B6 D2")]
     public static partial void Memset(void* ptr, int value, ulong size);
 
-    [MemberFunction("E8 ?? ?? ?? ?? 48 8B F0 48 85 C0 74 16 48 3B FB")]
-    public static partial void* Realloc(void* ptr, ulong size);
-
-    [MemberFunction("E8 ?? ?? ?? ?? 33 C9 4C 8B E8")]
-    public static partial void* Calloc(ulong count, ulong size);
-
-    [MemberFunction("E8 ?? ?? ?? ?? 33 C9 48 8B D8 E8 ?? ?? ?? ?? 48 85 DB 74 20")]
-    public static partial void* Recalloc(void* ptr, ulong count, ulong size);
-
     [VirtualFunction(3)]
     public partial void* Malloc(ulong size, ulong alignment);
 
-    public void* Malloc<T>(ulong alignment = 8) where T : unmanaged // TODO: return T*
-        => Malloc((ulong)sizeof(T), alignment);
+    public void* Malloc<T>(ulong alignment = 8) where T : unmanaged {
+        return Malloc((ulong)sizeof(T), alignment);
+    }
 
-    public static T* Calloc<T>(ulong count) where T : unmanaged
-        => (T*)Calloc(count, (ulong)sizeof(T));
-
-    public static T* Recalloc<T>(T* ptr, ulong count) where T : unmanaged
-        => (T*)Recalloc(ptr, count, (ulong)sizeof(T));
-
-    public static void Free<T>(T* ptr) where T : unmanaged
-        => Free(ptr, (ulong)sizeof(T));
+    public static void Free<T>(T* ptr) where T : unmanaged {
+        Free(ptr, (ulong)sizeof(T));
+    }
 }


### PR DESCRIPTION
Reverts aers/FFXIVClientStructs#1460

Reason: Memory allocated with Calloc cannot be free'd with the Free function. This crashes the game.