### PR TITLE
Cascade CExporter attributes to inheritance structs.

### DIFF
--- a/InteropGenerator/Generator/InteropGenerator.Rendering.Inheritance.cs
+++ b/InteropGenerator/Generator/InteropGenerator.Rendering.Inheritance.cs
@@ -176,6 +176,9 @@ public sealed partial class InteropGenerator {
             if (methodInfo.ObsoleteInfo is not null) {
                 writer.WriteLine($"""[global::System.ObsoleteAttribute("{methodInfo.ObsoleteInfo.Message}", {methodInfo.ObsoleteInfo.IsError.ToLowercaseString()})]""");
             }
+            if (methodInfo.CExporterExcelInfo is not null) {
+                writer.WriteLine(methodInfo.CExporterExcelInfo.GetAttribute());
+            }
             // public int SomeInheritedMethod(int param, int param2) => Path.To.Parent.SomeInheritedMethod(param, param2);
             writer.WriteLine($"{methodInfo.GetDeclarationStringWithoutPartial()} => {path}.{methodInfo.Name}({methodInfo.GetParameterNamesString()});");
         }
@@ -227,6 +230,9 @@ public sealed partial class InteropGenerator {
             writer.WriteLine("[global::System.Runtime.CompilerServices.MethodImplAttribute(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
             if (methodInfo.ObsoleteInfo is not null) {
                 writer.WriteLine($"""[global::System.ObsoleteAttribute("{methodInfo.ObsoleteInfo.Message}", {methodInfo.ObsoleteInfo.IsError.ToLowercaseString()})]""");
+            }
+            if (methodInfo.CExporterExcelInfo is not null) {
+                writer.WriteLine(methodInfo.CExporterExcelInfo.GetAttribute());
             }
             // function in table - call via table
             if (offset == 0) {

--- a/InteropGenerator/Generator/InteropGenerator.Rendering.cs
+++ b/InteropGenerator/Generator/InteropGenerator.Rendering.cs
@@ -165,11 +165,11 @@ public sealed partial class InteropGenerator {
         }
         string paramTypesAndNames;
         if (methodInfo.IsStatic) {
-            paramTypesAndNames = methodInfo.GetParameterTypesAndNamesString();
+            paramTypesAndNames = methodInfo.GetParameterTypesAndNamesStringWithAttributes();
         } else {
             paramTypesAndNames = $"{structType}* thisPtr";
             if (!methodInfo.Parameters.IsEmpty)
-                paramTypesAndNames += $", {methodInfo.GetParameterTypesAndNamesString()}";
+                paramTypesAndNames += $", {methodInfo.GetParameterTypesAndNamesStringWithAttributes()}";
         }
         string methodModifiers = methodInfo.Modifiers.Replace(" partial", string.Empty).Replace(" static", string.Empty);
         writer.WriteLine($"{methodModifiers} delegate {methodInfo.ReturnType} {methodInfo.Name}({paramTypesAndNames});");

--- a/InteropGenerator/Models/CExporterExcelInfo.cs
+++ b/InteropGenerator/Models/CExporterExcelInfo.cs
@@ -1,0 +1,5 @@
+namespace InteropGenerator.Models;
+
+internal sealed record CExporterExcelInfo(string SheetName) {
+    public string GetAttribute() => $"[global::FFXIVClientStructs.Attributes.CExporterExcelAttribute(\"{SheetName}\")]";
+};

--- a/InteropGenerator/Models/CExporterTypeForceInfo.cs
+++ b/InteropGenerator/Models/CExporterTypeForceInfo.cs
@@ -1,0 +1,5 @@
+namespace InteropGenerator.Models;
+
+internal sealed record CExporterTypeForceInfo(string TypeName) {
+    public string GetAttribute() => $"[global::FFXIVClientStructs.Attributes.CExporterTypeForceAttribute(\"{TypeName}\")]";
+};

--- a/InteropGenerator/Models/MethodInfo.cs
+++ b/InteropGenerator/Models/MethodInfo.cs
@@ -11,11 +11,14 @@ internal sealed record MethodInfo(
     string GenericConstraints,
     bool IsStatic,
     EquatableArray<ParameterInfo> Parameters,
-    ObsoleteInfo? ObsoleteInfo) {
+    ObsoleteInfo? ObsoleteInfo,
+    CExporterExcelInfo? CExporterExcelInfo) {
 
     public string GetDeclarationString() => $"{Modifiers} {ReturnType} {Name}({GetParameterTypesAndNamesString()}){GenericConstraints}";
 
-    public string GetDeclarationStringWithoutPartial() => $"{Modifiers.Replace(" partial", string.Empty)} {ReturnType} {Name}({GetParameterTypesAndNamesStringWithDefaults()}){GenericConstraints}";
+    public string GetDeclarationStringWithAttributes() => $"{Modifiers} {ReturnType} {Name}({GetParameterTypesAndNamesStringWithAttributes()}){GenericConstraints}";
+
+    public string GetDeclarationStringWithoutPartial() => $"{Modifiers.Replace(" partial", string.Empty)} {ReturnType} {Name}({GetParameterTypesAndNamesStringWithAttributesAndDefaults()}){GenericConstraints}";
 
     public string GetDeclarationStringForDelegateType(string structType) {
         var paramTypesAndNames = $"{structType}* thisPtr";
@@ -46,6 +49,9 @@ internal sealed record MethodInfo(
 
     private string GetParameterTypesAndNamesStringWithDefaults() => string.Join(", ", Parameters.Select(p => $"{p.RefKind.GetStringPrefix()}{p.Type} {p.Name}{p.GetDefaultValue()}"));
 
+    public string GetParameterTypesAndNamesStringWithAttributes() => string.Join(", ", Parameters.Select(p => $"{p.GetAttributes()}{p.RefKind.GetStringPrefix()}{p.Type} {p.Name}"));
 
+    public string GetParameterTypesAndNamesStringWithAttributesAndDefaults() => string.Join(", ", Parameters.Select(p => $"{p.GetAttributes()}{p.RefKind.GetStringPrefix()}{p.Type} {p.Name}{p.GetDefaultValue()}"));
+    
     public string GetReturnString() => ReturnType == "void" ? "" : "return ";
 }

--- a/InteropGenerator/Models/ParameterInfo.cs
+++ b/InteropGenerator/Models/ParameterInfo.cs
@@ -6,6 +6,10 @@ internal sealed record ParameterInfo(
     string Name,
     string Type,
     string? DefaultValue,
-    RefKind RefKind) {
+    RefKind RefKind,
+    CExporterExcelInfo? CExporterExcelInfo,
+    CExporterTypeForceInfo? CExporterTypeForceInfo) {
     public string GetDefaultValue() => DefaultValue is null ? string.Empty : $" = {DefaultValue}";
+    public string GetAttributes() => (CExporterExcelInfo is null ? string.Empty : CExporterExcelInfo.GetAttribute()) + 
+                                     (CExporterTypeForceInfo is null ? string.Empty : CExporterTypeForceInfo.GetAttribute());
 };


### PR DESCRIPTION
This is necessary for CExporter to get the right types on inheritances, as this information is lost otherwise.

Without this change:
![image](https://github.com/user-attachments/assets/1e703280-fe7f-4ac6-8c9b-f6f0ee075836)


With this change:
![image](https://github.com/user-attachments/assets/e2d0f8c8-a996-4517-863b-f0ab0eab1b30)
