### PR TITLE
Add remarks about how quest IDs are truncated

### DIFF
--- a/FFXIVClientStructs/FFXIV/Application/Network/WorkDefinitions/DailyQuestWork.cs
+++ b/FFXIVClientStructs/FFXIV/Application/Network/WorkDefinitions/DailyQuestWork.cs
@@ -6,6 +6,7 @@ namespace FFXIVClientStructs.FFXIV.Application.Network.WorkDefinitions;
 [Inherits<Base>]
 [StructLayout(LayoutKind.Explicit, Size = 0x10)]
 public partial struct DailyQuestWork {
+    /// <remarks> Not a row ID in the Quest Sheet. This is only the first two bytes (e.g. row 67540 would be stored as 2004.) </remarks>
     [FieldOffset(0x08)] public ushort QuestId;
     [FieldOffset(0x0A)] public byte Flags;
 

--- a/FFXIVClientStructs/FFXIV/Application/Network/WorkDefinitions/QuestWork.cs
+++ b/FFXIVClientStructs/FFXIV/Application/Network/WorkDefinitions/QuestWork.cs
@@ -6,6 +6,7 @@ namespace FFXIVClientStructs.FFXIV.Application.Network.WorkDefinitions;
 [Inherits<Base>]
 [StructLayout(LayoutKind.Explicit, Size = 0x18)]
 public unsafe partial struct QuestWork {
+    /// <remarks> Not a row ID in the Quest Sheet. This is only the first two bytes (e.g. row 67540 would be stored as 2004.) </remarks>
     [FieldOffset(0x08)] public ushort QuestId;
     [FieldOffset(0x0A)] public byte Sequence;
     [FieldOffset(0x0B)] public byte Flags;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/QuestEventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/QuestEventHandler.cs
@@ -10,6 +10,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Event;
 [Inherits<LuaEventHandler>]
 [StructLayout(LayoutKind.Explicit, Size = 0x618)]
 public unsafe partial struct QuestEventHandler {
+    /// <remarks> Not a row ID in the Quest Sheet. This is only the first two bytes (e.g. row 67540 would be stored as 2004.) </remarks>
     [FieldOffset(0x340)] public ushort QuestId;
     [FieldOffset(0x348)] public Utf8String Title;
     [FieldOffset(0x3B0)] public Utf8String ScriptId;


### PR DESCRIPTION
After some exploring, QuestManager truncates uint quest IDs for a reason to transform them into ushorts as seen in these work definitions. I added it as a remark to the ushort quest IDs I found so other people aren't confused why quest IDs don't match up with what you see in the sheet.