### PR TITLE
Update AtkTooltipArgs

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Enums/DetailKind.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Enums/DetailKind.cs
@@ -1,0 +1,68 @@
+namespace FFXIVClientStructs.FFXIV.Client.Enums;
+
+public enum DetailKind : byte {
+    None = 0,
+
+    // ItemDetail
+    Item = 1, // items in chat (except KeyItems), on the action bar, in some shops...
+    InventoryItem = 2,
+    ItemSearchResult = 3,
+    Loot = 4,
+    ShopBuyback = 5,
+    ShopItem = 6, // most shops use this, exceptions are grand company and sundry splendors
+    Reclaim = 7,
+    KeyItem = 8,
+    GearSet = 9,
+    FreeCompanyChest = 10,
+    ItemId = 11,
+    InventoryContext = 12,
+    ItemInspection = 13,
+    TreasureHighLow = 14,
+    MiragePrismItem = 15, // used by MiragePrismPrismItemDetail with item id
+    MiragePrismBoxItem = 16, // used by MiragePrismPrismItemDetail with index in MirageManager.PrismBoxItemIds
+    MateriaAttach = 17,
+    ReconstructionBuyback = 18,
+    MerchantSetting = 19,
+    MJIItemPouch = 20,
+    MJIKeyItem = 21,
+    MJICraftworksObject = 22,
+    Cabinet = 23,
+    TradeRemote = 24,
+    HandIn = 25,
+    RepairRequest = 26,
+    LetterView = 27,
+
+    // ActionDetail
+    /// Keep in sync with <see cref="UI.Agent.ActionKind"/>
+    Action = 28,
+    CraftingAction = 29,
+    GeneralAction = 30,
+    BuddyOrder = 31,
+    MainCommand = 32,
+    ExtraCommand = 33,
+    Companion = 34,
+    PetOrder = 35,
+    Trait = 36,
+    BuddyAction = 37,
+    CompanyAction = 38,
+    Mount = 39,
+    ChocoboRaceAction = 40,
+    ChocoboRaceItem = 41,
+    DeepDungeonEquipment = 42,
+    DeepDungeonEquipment2 = 43,
+    DeepDungeonItem = 44,
+    QuickChat = 45,
+    ActionComboRoute = 46,
+    PvPSelectTrait = 47,
+    BgcArmyAction = 48,
+    Perform = 49,
+    DeepDungeonMagicStone = 50,
+    DeepDungeonDemiclone = 51,
+    EurekaMagiaAction = 52,
+    MYCTemporaryItem = 53,
+    Ornament = 54,
+    Glasses = 55,
+    Unk56 = 56,
+    MKDTrait = 57,
+    Unk58 = 58,
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentActionDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentActionDetail.cs
@@ -11,10 +11,12 @@ public unsafe partial struct AgentActionDetail {
     [FieldOffset(0x40)] public uint OriginalId; // Example: Summon Topaz
     [FieldOffset(0x44)] public uint AdjustedId; // Example: Summon Titan II
 
+    // flag & 1 = get AdjustedActionId
     [MemberFunction("E8 ?? ?? ?? ?? 4C 8B 7C 24 ?? E9 ?? ?? ?? ?? 83 F8 0F")]
-    public partial void HandleActionHover(ActionKind actionKind, uint actionId, int flag, byte unk);
+    public partial void HandleActionHover(ActionKind actionKind, uint actionId, int flag, byte isLovmActionDetail);
 }
 
+/// Keep in sync with <see cref="Enums.DetailKind"/>
 public enum ActionKind {
     Action = 28,
     CraftingAction = 29,
@@ -44,5 +46,7 @@ public enum ActionKind {
     MYCTemporaryItem = 53,
     Ornament = 54,
     Glasses = 55,
+    Unk56 = 56,
+    MKDTrait = 57,
+    Unk58 = 58,
 }
-

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
@@ -1,7 +1,9 @@
+using FFXIVClientStructs.FFXIV.Client.Enums;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
+// TODO: remove with ItemKind field below
 public enum ItemDetailKind : byte {
     ChatItem = 1,      // all items linked in chat, except event items, also used for some shops
     InventoryItem = 2, // all(?) items outside of chat, including event items
@@ -18,7 +20,8 @@ public enum ItemDetailKind : byte {
 [VirtualTable("48 89 18 48 8D 05 ?? ?? ?? ?? 48 89 07", 6)]
 [StructLayout(LayoutKind.Explicit, Size = 0x220)]
 public unsafe partial struct AgentItemDetail {
-    [FieldOffset(0x118)] public ItemDetailKind ItemKind;
+    [FieldOffset(0x118)] public DetailKind DetailKind;
+    [FieldOffset(0x118), Obsolete($"Use {nameof(DetailKind)}")] public ItemDetailKind ItemKind;
     // Set to the item ID when hovering an item in the chat, otherwise it seems
     // to be different for each inventory. Doesn't appear to have any relation
     // to InventoryType.

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMiragePrismPrismItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMiragePrismPrismItemDetail.cs
@@ -6,7 +6,7 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 [Agent(AgentId.MiragePrismPrismItemDetail)]
 [GenerateInterop]
 [Inherits<AgentInterface>]
-[StructLayout(LayoutKind.Explicit, Size = 0x58)]
+[StructLayout(LayoutKind.Explicit, Size = 0xC8)]
 public unsafe partial struct AgentMiragePrismPrismItemDetail {
     [FieldOffset(0x54)] public uint ItemId;
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTooltipManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTooltipManager.cs
@@ -1,4 +1,7 @@
+using FFXIVClientStructs.FFXIV.Client.Enums;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.System.Memory;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
 
@@ -37,24 +40,135 @@ public unsafe partial struct AtkTooltipManager {
     public partial void ShowTooltip(ushort parentId, AtkResNode* targetNode, CStringPointer tooltipString) {
         var args = stackalloc AtkTooltipArgs[1];
         args->Ctor();
-        args->Text = tooltipString;
+        args->TextArgs.Text = tooltipString;
         ShowTooltip(AtkTooltipType.Text, parentId, targetNode, args);
     }
 
     [MemberFunction("66 3B 91 ?? ?? ?? ?? 75 09")]
     public partial void HideTooltip(ushort parentId, bool unk = false);
 
+    // Values are passed around
+    // from AtkTooltipManager.ShowTooltip/ShowNodeTooltip
+    // to AtkManagedInterface of the addon
+    // to RaptureAtkModule.HandleShowDetailAddon
+    // to the specific agent
     [GenerateInterop]
     [StructLayout(LayoutKind.Explicit, Size = 0x18)]
     public partial struct AtkTooltipArgs : ICreatable {
-        [FieldOffset(0x0)] public CStringPointer Text;
-        [FieldOffset(0x8)] public ulong TypeSpecificId;
-        [FieldOffset(0x10)] public uint Flags;
-        [FieldOffset(0x14)] public short Unk_14;
-        [FieldOffset(0x16)] public byte Unk_16;
+        /// <remarks> Args for <see cref="AtkTooltipType.Text"/> / AddonTooltip. </remarks>
+        [FieldOffset(0), CExporterUnion("Args")] public AtkTooltipTextArgs TextArgs;
+        /// <remarks> Args for <see cref="AtkTooltipType.Item"/> / AddonItemDetail. </remarks>
+        [FieldOffset(0), CExporterUnion("Args")] public AtkTooltipItemArgs ItemArgs;
+        /// <remarks> Args for <see cref="AtkTooltipType.Action"/> / AddonActionDetail. </remarks>
+        [FieldOffset(0), CExporterUnion("Args")] public AtkTooltipActionArgs ActionArgs;
+        /// <remarks> Args for <see cref="AtkTooltipType.LovmAction"/> / AddonLovmActionDetail. </remarks>
+        [FieldOffset(0), CExporterUnion("Args")] public AtkTooltipLovmActionArgs LovmActionArgs;
+        /// <remarks> Args for <see cref="AtkTooltipType.MiragePrismPrismItem"/> / AddonMiragePrismPrismItemDetail. </remarks>
+        [FieldOffset(0), CExporterUnion("Args")] public AtkTooltipMiragePrismPrismItemArgs MiragePrismPrismItemArgs;
+
+        [FieldOffset(0x00), Obsolete("Use TextArgs.Text")] public CStringPointer Text;
+        [FieldOffset(0x08), Obsolete("Use type-specific sub-structs")] public ulong TypeSpecificId;
+        [FieldOffset(0x10), Obsolete("Use type-specific sub-structs")] public uint Flags;
+        [FieldOffset(0x14), Obsolete("Use type-specific sub-structs")] public short Unk_14;
+        [FieldOffset(0x16), Obsolete("Use type-specific sub-structs")] public byte Unk_16;
 
         [MemberFunction("E8 ?? ?? ?? ?? C1 FB 04")]
         public partial void Ctor();
+
+        [StructLayout(LayoutKind.Explicit, Size = 0x18)]
+        public struct AtkTooltipTextArgs {
+            [FieldOffset(0), CExporterUnion("Args")] public CStringPointer Text;
+            // [FieldOffset(0x08)] public int Field8;  // unused
+            /// <remarks>
+            /// Used in AddonTooltip's ManagedInterface vf0.<br/>
+            /// Value:<br/>
+            /// 0 = Nothing<br/>
+            /// 1 = Subscribe to NumberArray Inventory<br/>
+            /// 2 = Subscribe to NumberArray Character
+            /// </remarks>
+            [FieldOffset(0x0C)] public uint AtkArrayType;
+            // [FieldOffset(0x10)] public int Field10; // unused
+            // [FieldOffset(0x14)] public short Field14; // unused
+            // [FieldOffset(0x16)] public byte Field16; // unused
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = 0x18)]
+        public struct AtkTooltipItemArgs {
+            /// <remarks>
+            /// Used when <see cref="Kind"/> is not <see cref="DetailKind.InventoryItem"/>.<br/>
+            /// Set to <see cref="AgentItemDetail.TypeOrId"/>.
+            /// </remarks>
+            [FieldOffset(0x08), CExporterUnion("Id")] public int ItemId;
+            /// <remarks>
+            /// Used when <see cref="Kind"/> is <see cref="DetailKind.InventoryItem"/>.<br/>
+            /// Set to <see cref="AgentItemDetail.TypeOrId"/>.
+            /// </remarks>
+            [FieldOffset(0x08), CExporterUnion("Id")] public InventoryType InventoryType;
+            /// <remarks>
+            /// Set to <see cref="AgentItemDetail.Flag1"/>.
+            /// </remarks>
+            [FieldOffset(0x0C)] public uint Flag1;
+            /// <remarks>
+            /// Set to <see cref="AgentItemDetail.BuyQuantity"/>.
+            /// </remarks>
+            [FieldOffset(0x10)] public int BuyQuantity;
+            /// <remarks>
+            /// Used when <see cref="Kind"/> is <see cref="DetailKind.InventoryItem"/>.<br/>
+            /// Set to <see cref="AgentItemDetail.Index"/>.
+            /// </remarks>
+            [FieldOffset(0x14)] public short Slot;
+            [FieldOffset(0x16)] public DetailKind Kind;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = 0x18)]
+        public struct AtkTooltipActionArgs {
+            /// <remarks>
+            /// Set to <see cref="AgentActionDetail.ActionId"/>/<see cref="AgentActionDetail.OriginalId"/>.
+            /// </remarks>
+            [FieldOffset(0x08)] public int Id;
+            // [FieldOffset(0x0C)] public uint FieldC; // unused
+            // [FieldOffset(0x10)] public int Field10; // unused
+            /// <remarks>
+            /// 1 = Adjust ActionId
+            /// </remarks>
+            [FieldOffset(0x14)] public short Flags;
+            [FieldOffset(0x16)] public DetailKind Kind;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = 0x18)]
+        public struct AtkTooltipLovmActionArgs {
+            [FieldOffset(0x08)] public int Id;
+            // [FieldOffset(0x0C)] public uint FieldC; // unused
+            // [FieldOffset(0x10)] public int Field10; // unused
+            /// <remarks>
+            /// 1 = Adjust ActionId
+            /// </remarks>
+            [FieldOffset(0x14)] public short Flags;
+            [FieldOffset(0x16)] public DetailKind Kind;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = 0x18)]
+        public struct AtkTooltipMiragePrismPrismItemArgs {
+            /// <remarks>
+            /// Used for <see cref="DetailKind.MiragePrismItem"/> as ItemId.<br/>
+            /// When this is a MirageStoreSetItem RowId (ItemId of the Set), then specify <see cref="SetItemSlot"/> for the slot.
+            /// </remarks>
+            [FieldOffset(0x08)] public int Id;
+            // [FieldOffset(0x0C)] public uint FieldC; // unused
+            /// <remarks>
+            /// Used for <see cref="DetailKind.MiragePrismBoxItem"/>.
+            /// </remarks>
+            [FieldOffset(0x10)] public int SetItemSlot;
+            /// <remarks>
+            /// Used for <see cref="DetailKind.MiragePrismItem"/>, but unsure what for.<br/>
+            /// Used for <see cref="DetailKind.MiragePrismBoxItem"/> as Index in <see cref="MirageManager.PrismBoxItemIds"/>/<see cref="MirageManager.PrismBoxStain0Ids"/>/<see cref="MirageManager.PrismBoxStain1Ids"/>.
+            /// </remarks>
+            [FieldOffset(0x14)] public short Index;
+            /// <remarks>
+            /// Either <see cref="DetailKind.MiragePrismItem"/> or <see cref="DetailKind.MiragePrismBoxItem"/>.
+            /// </remarks>
+            [FieldOffset(0x16)] public DetailKind Kind;
+        }
     }
 
     [StructLayout(LayoutKind.Explicit, Size = 0x20)]
@@ -64,10 +178,15 @@ public unsafe partial struct AtkTooltipManager {
         [FieldOffset(0x1A)] public AtkTooltipType Type;
     }
 
+    [Flags]
     public enum AtkTooltipType : byte {
-        Text = 1,
-        Item = 2,
-        TextItem = 3,
-        Action = 4
+        None = 0,
+        Text = 1 << 0,
+        Item = 1 << 1,
+        [Obsolete("Use AtkTooltipType.Text | AtkTooltipType.Item")]
+        TextItem = Text | Item,
+        Action = 1 << 2,
+        LovmAction = 1 << 3,
+        MiragePrismPrismItem = 1 << 4,
     }
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -11789,10 +11789,13 @@ classes:
     funcs:
       0x140C07710: ctor
       0x140C0B560: UpdateItems
-  Client::UI::Agent::AgentMiragePrismItemDetail:
+  Client::UI::Agent::AgentMiragePrismPrismItemDetail:
     vtbls:
       - ea: 0x142071F70
         base: Client::UI::Agent::AgentItemDetailBase
+    funcs:
+      0x140C0D8F0: HandleMiragePrismItemHover
+      0x140C0D970: HandleMiragePrismBoxItemHover
   Client::UI::Agent::AgentMiragePrismPrismSetConvert:
     vtbls:
       - ea: 0x142071FF8
@@ -12696,6 +12699,7 @@ classes:
       0x140E7FDB0: ctor
       0x140E7FEB0: Finalizer
       0x140E82420: OnItemHovered
+      0x140E7FF90: HandleItemHover
   Client::UI::Agent::AgentStatus::StatusCharaView:
     vtbls:
       - ea: 0x1420627D8
@@ -16312,6 +16316,12 @@ classes:
     vtbls:
       - ea: 0x1420C6D58
         base: Component::GUI::AtkUnitBase
+  Client::UI::AddonMiragePrismPrismItemDetail:
+    vtbls:
+      - ea: 0x1420C7B50
+        base: Component::GUI::AtkUnitBase
+      - ea: 0x1420C7DA0
+        base: Component::GUI::AtkManagedInterface
   Client::UI::AddonMiragePrismPlate:
     vtbls:
       - ea: 0x1420C7DD0
@@ -16360,13 +16370,31 @@ classes:
     funcs:
       0x1411ECFD0: ctor
       0x1411ED260: Finalize2
+  Client::UI::AddonActionDetailBase:
+    vtbls:
+      - ea: 0x1420D01E0
+        base: Component::GUI::AtkUnitBase
+      - ea: 0x1420D0430
+        base: Component::GUI::AtkManagedInterface
+    funcs:
+      0x1411FA370: ctor
   Client::UI::AddonActionDetail:
     vtbls:
       - ea: 0x1420D0448
-        base: Component::GUI::AtkUnitBase
+        base: Component::GUI::AddonActionDetailBase
+      - ea: 0x1420D0698
+        base: Component::GUI::AtkManagedInterface
     funcs:
       0x1411FA780: ctor
       0x1411FB130: GenerateTooltip
+  Client::UI::AddonLovmActionDetail:
+    vtbls:
+      - ea: 0x14214D398
+        base: Client::UI::AddonLovmActionDetailBase
+      - ea: 0x14214D5E8
+        base: Component::GUI::AtkManagedInterface
+    funcs:
+      0x1415BC0E0: ctor
   Client::UI::AddonMacro:
     vtbls:
       - ea: 0x1420CFD40
@@ -16375,6 +16403,8 @@ classes:
     vtbls:
       - ea: 0x1420D0930
         base: Component::GUI::AtkUnitBase
+      - ea: 0x1420D0B88
+        base: Component::GUI::AtkManagedInterface
     funcs:
       0x1411FB780: ctor
       0x1411FB9B0: Finalize2


### PR DESCRIPTION
I split up the struct into sub-structs for each `Type`, because using union fields would've made it a bit messy.

---

Some notes for the values that are passed to `Client::UI::RaptureAtkModule_HandleShowDetailAddon`:

- for ItemDetail via `sub_1411FC080`:
```c
[0x16] ItemArgs.Kind                    -> values[0].Value.Int  -> AgentItemDetail.ItemKind
[0x08] ItemArgs.ItemId  / InventoryType -> values[1].Value.Int  -> AgentItemDetail.TypeOrId
[0x14] ItemArgs.Slot                    -> values[2].Value.Int  -> AgentItemDetail.Index
[0x10] ItemArgs.BuyQuantity             -> values[3].Value.Int  -> AgentItemDetail.BuyQuantity
[0x0C] ItemArgs.Flag1                   -> values[4].Value.UInt -> AgentItemDetail.Flag1
```

- for ActionDetail via `sub_1411FAA10`:
```c
[0x16] ActionArgs.Kind  -> values[0].Int  -> actionKind
[0x08] ActionArgs.Id    -> values[1].Int  -> actionId
[0x14] ActionArgs.Flags -> values[2].Int  -> flag
       0                -> values[3].Int  -> isLovmActionDetail
[0x10]                  -> values[4].Int  -> (unused)
[0x0C]                  -> values[5].UInt -> (unused)
```

- for LovmActionDetail via `sub_1411FA500`:
```c
[0x16] LovmActionArgs.Kind  -> values[0].Value.Int  -> actionKind
[0x08] LovmActionArgs.Id    -> values[1].Value.Int  -> actionId
[0x14] LovmActionArgs.Flags -> values[2].Value.Int  -> flag
       1                    -> values[3].Value.Int  -> isLovmActionDetail
[0x10]                      -> values[4].Value.Int  -> (unused)
[0x0C]                      -> values[5].Value.UInt -> (unused)
```

- for MiragePrismPrismItemDetail via `sub_14119D670`:
```c
[0x16] MiragePrismPrismItemArgs.Kind        -> values[0].Value.Int (used to decide which agent function to call, either MiragePrismItem or MiragePrismBoxItem)
[0x08] MiragePrismPrismItemArgs.Id          -> values[1].Value.Int -> AgentMiragePrismPrismItemDetail.ItemId
[0x14] MiragePrismPrismItemArgs.Index       -> values[2].Value.Int -> used as Index for MirageManager.PrismBoxItemIds/PrismBoxStain0Ids/PrismBoxStain1Ids
[0x10] MiragePrismPrismItemArgs.SetItemSlot -> values[3].Value.Int -> Slot index of the Item in the MirageStoreSetItem sheet
```
