### PR TITLE
Add ContentInventoryManager

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/ContentInventoryContainer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/ContentInventoryContainer.cs
@@ -1,0 +1,13 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game;
+
+// Client::Game::ContentInventoryContainer
+//   Client::Game::InventoryContainer
+[GenerateInterop(isInherited: true)]
+[Inherits<InventoryContainer>]
+[StructLayout(LayoutKind.Explicit, Size = 0x28)]
+public partial struct ContentInventoryContainer {
+    [FieldOffset(0x20)] public InventoryType InventoryType;
+
+    [VirtualFunction(6)]
+    public partial InventoryType GetInventoryType();
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/ContentInventoryItem.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/ContentInventoryItem.cs
@@ -1,0 +1,9 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game;
+
+// Client::Game::ContentInventoryItem
+//   Client::Game::InventoryItem
+[GenerateInterop(isInherited: true)]
+[Inherits<InventoryItem>]
+[StructLayout(LayoutKind.Explicit, Size = 0x48)]
+public partial struct ContentInventoryItem;
+

--- a/FFXIVClientStructs/FFXIV/Client/Game/ContentInventoryManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/ContentInventoryManager.cs
@@ -1,0 +1,32 @@
+using FFXIVClientStructs.FFXIV.Client.Game.WKS;
+
+namespace FFXIVClientStructs.FFXIV.Client.Game;
+
+// Client::Game::ContentInventoryManager
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0xC0)]
+public unsafe partial struct ContentInventoryManager {
+    [StaticAddress("48 89 1D ?? ?? ?? ?? ?? ?? ?? 48 8B 5C 24", 3, isPointer: true)]
+    public static partial ContentInventoryManager* Instance();
+
+    [FieldOffset(0x08)] public StdMap<uint, Pointer<ContentInventoryProvider>> InventoryProviders;
+    [FieldOffset(0x18)] public WKSContentInventoryProvider WKSInventoryProvider;
+
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 ?? E8 ?? ?? ?? ?? 48 8B C8 44 0F B7 C6")]
+    public partial bool HasInventoryContainer(InventoryType inventoryType);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 ?? C7 44 24 ?? ?? ?? ?? ?? 40 88 6C 24")]
+    public partial bool HasItemId(uint itemId);
+
+    [MemberFunction("E9 ?? ?? ?? ?? 8B D3 48 8B CE E8 ?? ?? ?? ?? 48 8B C8")]
+    public partial ContentInventoryItem* GetInventorySlot(InventoryType inventoryType, short slotIndex);
+
+    [MemberFunction("E8 ?? ?? ?? ?? EB ?? 49 8B 97")]
+    public partial ContentInventoryContainer* GetInventoryContainer(InventoryType inventoryType);
+
+    /// <summary>
+    /// Returns the <see cref="InventoryType"/> associated with the specified <paramref name="itemId"/>.
+    /// </summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 89 44 24 ?? E8 ?? ?? ?? ?? 48 8D 54 24 ?? 48 8B C8 ?? ?? ?? 41 FF 50 ?? 48 83 C4")]
+    public partial InventoryType GetInventoryTypeByItemId(uint itemId);
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/ContentInventoryProvider.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/ContentInventoryProvider.cs
@@ -1,0 +1,46 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game;
+
+// Client::Game::ContentInventoryProvider
+[GenerateInterop(isInherited: true)]
+[StructLayout(LayoutKind.Explicit, Size = 0x28)]
+public unsafe partial struct ContentInventoryProvider {
+    [FieldOffset(0x10)] public StdMap<uint, InventoryType> ItemIdInventoryItemMapping;
+    [FieldOffset(0x20)] public short SlotCount;
+
+    [VirtualFunction(0)]
+    public partial void Dtor(byte freeFlags);
+
+    [VirtualFunction(1)]
+    public partial bool HasInventoryContainer(InventoryType inventoryType);
+
+    [VirtualFunction(2)]
+    public partial bool IsValidTerritoryType(ushort territoryTypeId);
+
+    [VirtualFunction(3)]
+    public partial void Setup();
+
+    [VirtualFunction(5)]
+    public partial void Update();
+
+    [VirtualFunction(9)]
+    public partial ContentInventoryItem* GetInventorySlot(InventoryType inventoryType, short slotIndex);
+
+    [VirtualFunction(10)]
+    public partial ContentInventoryContainer* GetInventoryContainer(InventoryType inventoryType);
+
+    // not sure
+    // [VirtualFunction(16)]
+    // public partial int GetQuantityWithInventoryItemFallbac(InventoryType inventoryType, InventoryItem* fallback);
+
+    /// <summary>
+    /// Returns whether the specified <paramref name="itemId"/> is a valid item that can be saved in containers provided by this <see cref="ContentInventoryProvider"/>.
+    /// </summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 75 ?? 48 8B 43 ?? 80 78 ?? ?? 74 ?? 48 8B 43 ?? 80 78 ?? ?? 75 ?? 0F 1F 40")]
+    public partial bool HasItemId(uint itemId);
+
+    /// <summary>
+    /// Returns the <see cref="InventoryType"/> associated with the specified <paramref name="itemId"/>.
+    /// </summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 2D ?? ?? ?? ?? 74 ?? 83 F8 ?? 75")]
+    public partial InventoryType GetInventoryTypeByItemId(uint itemId);
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/InventoryContainer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InventoryContainer.cs
@@ -1,13 +1,13 @@
 namespace FFXIVClientStructs.FFXIV.Client.Game;
 
 // Client::Game::InventoryContainer
-[GenerateInterop]
+[GenerateInterop(isInherited: true)]
 [VirtualTable("48 8D 0D ?? ?? ?? ?? 48 89 6C 24 ?? BD ?? ?? ?? ?? 48 89 28", 3)]
 [StructLayout(LayoutKind.Explicit, Size = 0x20)]
 public unsafe partial struct InventoryContainer {
     [FieldOffset(0x08)] public InventoryItem* Items;
     [FieldOffset(0x10)] public InventoryType Type;
-    [FieldOffset(0x14)] public uint Size;
+    [FieldOffset(0x14)] public int Size;
     [FieldOffset(0x18)] public bool IsLoaded;
 
     [VirtualFunction(0)]
@@ -23,7 +23,7 @@ public unsafe partial struct InventoryContainer {
     // public partial void Noop();
 
     [VirtualFunction(4)]
-    public partial uint GetSize();
+    public partial int GetSize();
 
     [VirtualFunction(5)]
     public partial InventoryItem* GetInventorySlot(int index);

--- a/FFXIVClientStructs/FFXIV/Client/Game/InventoryItem.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InventoryItem.cs
@@ -45,7 +45,7 @@ public unsafe partial struct InventoryItem : ICreatable {
     public partial void Ctor();
 
     [VirtualFunction(0)]
-    public partial void Dtor();
+    public partial void Dtor(byte freeFlags);
 
     /// <summary>Copies the values from the other InventoryItem and, if it's symbolic, resolves its linked item.</summary>
     [VirtualFunction(1)]

--- a/FFXIVClientStructs/FFXIV/Client/Game/InventoryType.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InventoryType.cs
@@ -43,8 +43,8 @@ public enum InventoryType : uint {
     PremiumSaddleBag1 = 4100,
     PremiumSaddleBag2 = 4101,
 
-    Cosmopouch1 = 5000,
-    Cosmopouch2 = 5001,
+    Cosmopouch1 = 5000, // Cosmic Exploration: Mission Inventory (including Fishing Bait)
+    Cosmopouch2 = 5001, // Cosmic Exploration: Mech Ops Inventory
 
     Invalid = 9999,
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSContentInventoryContainer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSContentInventoryContainer.cs
@@ -1,0 +1,20 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game.WKS;
+
+// Client::Game::WKS::WKSContentInventoryContainer
+//  Client::Game::ContentInventoryContainer
+//    Client::Game::InventoryContainer
+[GenerateInterop]
+[Inherits<ContentInventoryContainer>]
+[StructLayout(LayoutKind.Explicit, Size = 0x40)]
+public partial struct WKSContentInventoryContainer {
+    [FieldOffset(0x28)] public StdVector<WKSContentInventoryItem> WKSItems;
+
+    [VirtualFunction(7)]
+    public partial void ClearItems();
+
+    [VirtualFunction(8)]
+    public partial void SetItem(InventoryType inventoryType, short slot, uint itemId, ushort quantity);
+
+    [VirtualFunction(9)]
+    public partial void SetItemEx(InventoryType inventoryType, short slot, uint itemId, ushort quantity, InventoryItem.ItemFlags flags, ushort collectability);
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSContentInventoryItem.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSContentInventoryItem.cs
@@ -1,0 +1,18 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game.WKS;
+
+// Client::Game::WKS::WKSContentInventoryItem
+//  Client::Game::ContentInventoryItem
+//    Client::Game::InventoryItem
+[GenerateInterop]
+[Inherits<ContentInventoryItem>]
+[StructLayout(LayoutKind.Explicit, Size = 0x60)]
+public partial struct WKSContentInventoryItem {
+    [FieldOffset(0x48)] public InventoryType WKSInventoryType;
+    [FieldOffset(0x4C)] public short WKSItemSlot; // -1 = undefined
+    // 2 bytes padding
+    [FieldOffset(0x50)] public uint WKSItemId;
+    [FieldOffset(0x54)] public short WKSItemQuantity;
+    [FieldOffset(0x56)] public InventoryItem.ItemFlags WKSItemFlags;
+    [FieldOffset(0x58)] public short WKSItemCollectability;
+    // 6 bytes padding
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSContentInventoryProvider.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSContentInventoryProvider.cs
@@ -1,0 +1,11 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game.WKS;
+
+// Client::Game::WKS::WKSContentInventoryProvider
+//   Client::Game::ContentInventoryProvider
+[GenerateInterop]
+[Inherits<ContentInventoryProvider>]
+[StructLayout(LayoutKind.Explicit, Size = 0xA8)]
+public unsafe partial struct WKSContentInventoryProvider {
+    [FieldOffset(0x28)] public WKSContentInventoryContainer Cosmopouch1;
+    [FieldOffset(0x68)] public WKSContentInventoryContainer Cosmopouch2;
+}

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -132,6 +132,7 @@ functions:
 #fail   0x1403297E0: GetGlobalTextParameter
   0x1406A4CE0: std::vector<Component::GUI::AtkValue>_SetSize
   0x140D5C0D0: GetGameObjectByIndex
+  0x140D11AA0: IsTerritoryTypeCosmicExploration
   0x140914A20: GetRandomInteger
   0x140914A80: GetRandomFloat
   0x1404D8310: UpdateAnimFactor
@@ -1476,6 +1477,7 @@ classes:
       0x1408273A0: GetPermittedGearsetCount
       0x140831020: GetLimitedTomestoneCount
       0x140821EF0: GetEmptySlotsInBag
+      0x140822130: GetFirstEmptyInventorySlot
       0x14082B7D0: SendTradeRequest
       0x14082DCA0: GetRetainerGil
       0x14082EDC0: GetRetainerMarketPrice
@@ -1566,6 +1568,80 @@ classes:
       0x14081A680: IsCrystals
       0x14081A6B0: IsArmory
       0x140823D00: IsEquippedItems
+  Client::Game::ContentInventoryManager:
+    vtbls:
+      - ea: 0x1421C3F10
+    instances:
+      - ea: 0x142951D90
+    vfuncs:
+      0: Dtor
+      6: vf6
+    funcs:
+      0x14186D2E0: CreateInstance
+      0x14186D390: DestroyInstance
+      0x14186D3F0: HasInstance
+      0x14186D410: GetInstance
+      0x14186D4E0: ctor # inlined
+      0x14186D6B0: Update
+      0x14186D750: Load
+      0x14186D9C0: ProcessPacket
+      0x14186E0E0: HasItemIdByPtr
+      0x14186E1A0: IsInCosmicExploration1 # used by GatheringPointEventHandler
+      0x14186E1C0: IsInCosmicExploration2 # used by SpearFishingEventHandler
+      0x14186E1E0: HasInventoryContainer
+      0x14186E290: HasItemId
+      0x14186E350: GetInventorySlot
+      0x14186E420: GetInventoryContainer
+      0x14186E4E0: GetInventoryTypeByItemId
+  Client::Game::ContentInventoryItem:
+    vtbls:
+      - ea: 0x1422F6348
+        base: Client::Game::InventoryItem
+  Client::Game::ContentInventoryContainer:
+    vtbls:
+      - ea: 0x14231CF88
+        base: Client::Game::InventoryContainer
+    vfuncs:
+      6: GetInventoryType
+    funcs:
+      0x141BBD020: ctor
+  Client::Game::ContentInventoryProvider:
+    vtbls:
+      - ea: 0x1422D58F8
+    vfuncs:
+      0: Dtor
+      1: HasInventoryContainer
+      2: IsValidTerritoryType
+      3: Setup
+      9: GetInventorySlot
+      10: GetInventoryContainer
+      16: vf16
+    funcs:
+      0x141B14140: ctor
+      0x141B14490: HasItemId
+      0x141B141D0: GetInventoryTypeByItemId
+  Client::Game::WKS::WKSContentInventoryItem:
+    vtbls:
+      - ea: 0x1422F6410
+        base: Client::Game::ContentInventoryItem
+    funcs:
+      0x141BBD310: ctor
+  Client::Game::WKS::WKSContentInventoryContainer:
+    vtbls:
+      - ea: 0x1422F64D8
+        base: Client::Game::ContentInventoryContainer
+    vfuncs:
+      7: ClearItems
+      8: SetItem # (this, Client::Game::InventoryType inventoryType, short slot, uint itemId, ushort quantity)
+      9: SetItemEx # (this, Client::Game::InventoryType inventoryType, short slot, uint itemId, ushort quantity, Client::Game::InventoryItem::ItemFlags flags, ushort collectability)
+    funcs:
+      0x141B5F540: ctor
+  Client::Game::WKS::WKSContentInventoryProvider:
+    vtbls:
+      - ea: 0x1422D5AF0
+        base: Client::Game::ContentInventoryProvider
+    funcs:
+      0x141B14880: ctor
   Client::Game::MonsterNoteManager:
     instances:
       - ea: 0x14291E6B0


### PR DESCRIPTION
I assume it's meant for "content" since it has functions to check the TerritoryTypeId, but currently the `ContentInventoryManager` only has a single inventory provider (`WKSInventoryProvider`) and nothing more.

There are still a couple unnamed vfuncs. I didn't care that much.

Breaking Changes:
- `InventoryContainer.Size`/`GetSize` were changed from `uint` to `int`, because `Client::Game::ContentInventoryContainer.GetSize` returns `-1`.
- `InventoryItem.Dtor` was missing the `freeFlags` parameter.