### PR TITLE
TextFlags Fix

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
@@ -109,8 +109,8 @@ public enum TextFlags : ushort {
     Emboss = 1 << 5,
     WordWrap = 1 << 6,
     MultiLine = 1 << 7,
-    Ellipsis = 1 << 8,
     FixedFontResolution = 1 << 9,
+    Ellipsis = 1 << 10,
 }
 
 public enum FontType : byte {


### PR DESCRIPTION
<img width="1292" height="503" alt="image" src="https://github.com/user-attachments/assets/e5ce4d4e-f7c6-4c12-9ff9-d9bf67fb6259" />

It seems the Elipsis flag has moved, I do not know if FixedFontResolution is still correct or not.

1 << 8, seems to cause the text to ignore Alignment and clips the text to the bounds of the node.