### PR TITLE
Add known virtual function used to load in ResourceEventListener

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/Resource/ResourceEventListener.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Resource/ResourceEventListener.cs
@@ -9,9 +9,8 @@ public unsafe partial struct ResourceEventListener {
 
     // vfuncs 1-4 are virtuals that are specific to the classes that inherits this
 
-    // unsure of what the function does but its specific to this class from what I find in the vtable references
-    // [VirtualFunction(3)]
-    // public partial void vf3(ResourceHandle* handle);
+    [VirtualFunction(3)]
+    public partial void Load(Handle.ResourceHandle* handle);
 
     // looks similar to vf3 but seems to be a different function
     // [VirtualFunction(4)]

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4896,6 +4896,7 @@ classes:
       - ea: 0x142013188
     vfuncs:
       0: Dtor
+      3: Load
     funcs:
       0x1402ED630: ctor
   Client::System::Resource::Handle::GrassGridDataResourceHandle:


### PR DESCRIPTION
For example, this is used by LuaScriptLoader to load Lua scripts
from the resource system.