### PR TITLE
Add AddonConfig.ApplyHudLayout

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/AddonConfig.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/AddonConfig.cs
@@ -25,6 +25,12 @@ public unsafe partial struct AddonConfig {
     /// <returns></returns>
     [MemberFunction("E8 ?? ?? ?? ?? 33 C0 EB 12")]
     public partial void ChangeHudLayout(uint layoutIndex, bool unk1 = false, bool unk2 = true);
+
+    /// <summary>
+    /// Applies the current HUD Layout
+    /// </summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 4C 8B 7C 24 ?? 41 C6 46 ?? ??")]
+    public partial void ApplyHudLayout();
 }
 
 [GenerateInterop]

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -9096,6 +9096,7 @@ classes:
     funcs:
       0x1407A34A0: ctor
       0x1407A4610: ChangeHudLayout
+      0x1407A60F0: ApplyHudLayout
   Client::UI::Misc::PronounModule:
     vtbls:
       - ea: 0x142063818


### PR DESCRIPTION
This function applies the settings from the current HUD layout directly.
Sig found by nebel.

Someone should probably sanitycheck because I'm not 100% sure what MemberFunction does but if I understand correctly you don't need to pass AddonConfig.Instance() to it when you do.
Context: https://canary.discord.com/channels/581875019861328007/653504487352303619/1405847242606383175