### PR TITLE
Add GameObject.GetNamePlateColorType

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -151,7 +151,7 @@ public unsafe partial struct GameObject {
     /// Gets the id of a saved nameplate color for this game object
     /// </summary>
     [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 35 ?? ?? ?? ?? 48 8B F9")]
-    public partial byte GetNamePlateColor();
+    public partial byte GetNamePlateColorType();
 }
 
 // if (EntityId == 0xE0000000)

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -150,6 +150,39 @@ public unsafe partial struct GameObject {
     /// <summary>
     /// Gets the id of a saved nameplate color for this game object
     /// </summary>
+    /// <remarks>
+    /// The index refers to a hex-color array containing a mix of values from ConfigOptions and hardcoded values:<br/>
+    /// [0] NamePlateEdgeObject, NamePlateColorObject<br/>
+    /// [1] NamePlateEdgeSelf, NamePlateColorSelf<br/>
+    /// [2] NamePlateEdgeParty, NamePlateColorParty<br/>
+    /// [3] NamePlateEdgeOther, NamePlateColorOther<br/>
+    /// [4] NamePlateColorLimEdge, NamePlateColorLim<br/>
+    /// [5] NamePlateColorGriEdge, NamePlateColorGri<br/>
+    /// [6] NamePlateColorUldEdge, NamePlateColorUld<br/>
+    /// [7] NamePlateEdgeUnengagedEnemy, NamePlateColorUnengagedEnemy<br/>
+    /// [8] 0xFF000000, 0xFFBFBFBF (Dead)<br/>
+    /// [9] NamePlateEdgeEngagedEnemy, NamePlateColorEngagedEnemy<br/>
+    /// [10] NamePlateEdgeClaimedEnemy, NamePlateColorClaimedEnemy<br/>
+    /// [11] NamePlateEdgeUnclaimedEnemy, NamePlateColorUnclaimedEnemy<br/>
+    /// [12] NamePlateEdgeNpc, NamePlateColorNpc<br/>
+    /// [13] NamePlateEdgeNpc, NamePlateColorNpc<br/>
+    /// [14] NamePlateEdgeMinion, NamePlateColorMinion<br/>
+    /// [15] NamePlateEdgeSelfBuddy, NamePlateColorSelfBuddy<br/>
+    /// [16] NamePlateEdgeSelfPet, NamePlateColorSelfPet<br/>
+    /// [17] NamePlateEdgeOtherBuddy, NamePlateColorOtherBuddy<br/>
+    /// [18] NamePlateEdgeOtherPet, NamePlateColorOtherPet<br/>
+    /// [19] 0xFF985008, 0xFFFEFFE8<br/>
+    /// [20] NamePlateEdgeAlliance, NamePlateColorAlliance<br/>
+    /// [21] 0xFF000000, 0xFFBFBFBF<br/>
+    /// [23] NamePlateColorHousingFieldEdge, NamePlateColorHousingField<br/>
+    /// [24] NamePlateColorHousingFurnitureEdge, NamePlateColorHousingFurniture<br/>
+    /// [25] 0xFF8C5900, 0xFFFEFFE8<br/>
+    /// [26] 0xFF070F86, 0xFFBFBDFF<br/>
+    /// [27] NamePlateEdgeTank, NamePlateColorTank<br/>
+    /// [28] NamePlateEdgeHealer, NamePlateColorHealer<br/>
+    /// [29] NamePlateEdgeDps, NamePlateColorDps<br/>
+    /// [30] NamePlateEdgeOtherClass, NamePlateColorOtherClass
+    /// <remarks>
     [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 35 ?? ?? ?? ?? 48 8B F9")]
     public partial byte GetNamePlateColorType();
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -182,7 +182,7 @@ public unsafe partial struct GameObject {
     /// [28] NamePlateEdgeHealer, NamePlateColorHealer<br/>
     /// [29] NamePlateEdgeDps, NamePlateColorDps<br/>
     /// [30] NamePlateEdgeOtherClass, NamePlateColorOtherClass
-    /// <remarks>
+    /// </remarks>
     [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 35 ?? ?? ?? ?? 48 8B F9")]
     public partial byte GetNamePlateColorType();
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -150,7 +150,7 @@ public unsafe partial struct GameObject {
     /// <summary>
     /// Gets the id of a saved nameplate color for this game object
     /// </summary>
-    [MemberFunction("E8 ?? ?? ?? ?? 89 85 ?? ?? ?? ?? 0F 57 C0")]
+    [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B 35 ?? ?? ?? ?? 48 8B F9")]
     public partial byte GetNamePlateColor();
 }
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -146,6 +146,12 @@ public unsafe partial struct GameObject {
 
     [MemberFunction("E8 ?? ?? ?? ?? 89 85 ?? ?? ?? ?? 0F 57 C0")]
     public partial uint GetObjStrId();
+
+    /// <summary>
+    /// Gets the id of a saved nameplate color for this game object
+    /// </summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 89 85 ?? ?? ?? ?? 0F 57 C0")]
+    public partial byte GetNamePlateColor();
 }
 
 // if (EntityId == 0xE0000000)

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -9448,7 +9448,7 @@ classes:
       0x14085A220: GetFrameDeltaMultiplier2
       0x14085A9F0: Initialize
       0x14085AC30: ctor
-      0x1400FE420: GetNamePlateColor
+      0x1400FE420: GetNamePlateColorType
       0x140965CB0: GetObjStrId
       0x1418E4070: PlayFootStepSound
   Client::Game::Character::Character:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -28,6 +28,7 @@ globals:
   0x142771790: g_FrameCountAccum # accumulates over a second to calc FPS
   0x142771794: g_FrameTimeAccum # accumulates over a second to calc FPS
   0x1427718A0: g_OSVersion
+  0x142773200: g_NameplateColors
   0x14290D150: g_Client::UI::Agent::CharaSelectCharacterList_CurrentCharaSelectCharacter # Client::Game::Character::Character*
   0x142909300: g_RenderSkeletonLinkedListStart
   0x142909308: g_RenderSkeletonLinkedListEnd
@@ -183,6 +184,7 @@ functions:
   0x1400DF6D0: GetDragDropTypeMask
   0x1400DF6A0: GetDragDropTypeReferenceMask
   0x1400DF760: OpenWebURL
+  0x1400FEAE0: UpdateNameplateColors
   0x14046F400: GetMainCommandAgentId
   0x14046F480: GetMainCommandInputId
   0x14079E6D0: GetHotbarSlotTypeFromDragDropType

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -9448,6 +9448,7 @@ classes:
       0x14085A220: GetFrameDeltaMultiplier2
       0x14085A9F0: Initialize
       0x14085AC30: ctor
+      0x1400FE420: GetNamePlateColor
       0x140965CB0: GetObjStrId
       0x1418E4070: PlayFootStepSound
   Client::Game::Character::Character:


### PR DESCRIPTION
Adds GetNamePlateColor.
This function is often used to check if a gameobject is hostile but essentially gets the color bytes (saved colors in user config) for certain types of mobs.

These are some of the mapped out ones but wasn't sure whether to include it/how to format it for better info: 

            // 4, 5, 6: Enemy players in PvP
            // 7: yellow, can be attacked, not engaged
            // 8: dead
            // 9: red, engaged with your party
            // 10: purple, engaged with other party
            // 11: orange, aggro'd to your party but not attacked yet

Also doublechecked that this is a different function/doesn't overlap with #1539 