### PR TITLE
Add support for IDA Pro 9.0 - 9.2

### DIFF
--- a/ida/ffxiv_exdgetters.py
+++ b/ida/ffxiv_exdgetters.py
@@ -153,8 +153,7 @@ if api is None:
                     self.add_enum_member(enum_id, f"{sheet_name}_{values[key]}", key)
 
             def create_struct(self, name, fields):
-                if idaapi.IDA_SDK_VERSION < 900:
-                    idaapi.begin_type_updating(idaapi.UTP_STRUCT)
+                idaapi.begin_type_updating(idaapi.UTP_STRUCT)
                 struct_id = self.get_struct_id(name)
                 if struct_id == idaapi.BADADDR:
                     struct_id = self.create_struct_type(name)
@@ -202,8 +201,7 @@ if api is None:
                     self.set_struct_member_info(
                         struct_type, meminfo, 0, self.get_tinfo_from_type(type), 0
                     )
-                if idaapi.IDA_SDK_VERSION < 900:
-                    idaapi.end_type_updating(idaapi.UTP_STRUCT)
+                idaapi.end_type_updating(idaapi.UTP_STRUCT)
 
             def set_func_name(self, ea, name, cmt):
                 ida_name.set_name(ea, name)

--- a/ida/ffxiv_structimporter.py
+++ b/ida/ffxiv_structimporter.py
@@ -432,12 +432,17 @@ if api is None:
                             None,
                             self.get_size_from_ida_type(field_type),
                         )
+
                     meminfo = self.get_struct_member_by_name(s, field_name)
+                    if meminfo is None:
+                        raise RuntimeError(f"Failed to find member {field_name} in struct {fullname}")
+                    
                     if field_is_base:
                         if idaapi.IDA_SDK_VERSION >= 900:
                             meminfo.set_baseclass()
                         else:
                             meminfo.props |= self.get_base_class_flag()
+                            
                     array_size = field.size if hasattr(field, "size") else 0
                     self.set_struct_member_info(
                         s,
@@ -1276,6 +1281,8 @@ def run():
     print("{0} Deleting old enums and creating new ones".format(get_time()))
     for enum in yaml.enums:
         api.delete_enum(enum)
+    
+    for enum in yaml.enums:
         api.create_enum_struct(enum)
 
     print("{0} Creating new structs".format(get_time()))

--- a/ida/ffxiv_structimporter.py
+++ b/ida/ffxiv_structimporter.py
@@ -479,6 +479,9 @@ if api is None:
                         continue
 
                     meminfo = self.get_struct_member_by_name(s, field_name)
+                    if meminfo is None:
+                        raise RuntimeError(f"Failed to find member {field_name} in struct {fullname}")
+
                     field_type = self.clean_name(virt_func.return_type)
                     field_type = field_type + "(__fastcall* " + field_name + ")("
                     for param in virt_func.parameters:


### PR DESCRIPTION
**The version of `ffxiv_structs.yml` in HEAD contains duplicate and overlapping fields. In order to test this PR, you must use the version attached to this PR: [ffxiv_structs.yml](https://github.com/user-attachments/files/21939195/ffxiv_structs.yml)**

These changes have been tested and are stable on IDA Pro 9.2b. I am unable to test on older versions of IDA and request that others with access to those versions ensure that the scripts run and produce the expected output still.

The IDA Pro 9.0b version which was leaked earlier this year will not be supported as the `ida_typeinf` changes were half-baked and are missing a lot of required functions and constructors. As such, officially, we should only support full release versions for 7.x, 8.x, and 9.x through 9.2.

For bitfield enums in IDA 9+, 0-mask + 0-value fields are disallowed. To work around this, we are creating a default mask group which covers the full width of the enum's base type and are adding all values to that group. Because this is equal to `DEFMASK64`, for 64-bit enums, we drop the highest-order bit for 64-bit types. In practice, this shouldn't be an issue, but there may be a more elegant solution.

IDA 9+ also requires that all enum members have unique names across the entire DB. Previously, there were a few collisions - `ExcelLanguage.X` for example. To work around this, we attempt to avoid naming collisions by appending up to 3 underscores to the end of any enum member name which collides with one that already exists. I've also changed structimporter to tear down all enums before recreating them to help avoid potential collisions where two colliding members originate from structimporter. In the future, we should look to place enums created by exdimporter and structimporter in the same namespaces so that structimporter can tear down and rebuild those, assuming that they're always kept in sync.

The following versions of IDA still require testing. I will update this as results are reported.
## Needs Testing
- IDA Pro 7.x
- IDA Pro 8.x
- IDA Pro 9.0 (non-beta)
- IDA Pro 9.1