### PR TITLE
Fully cleanup enums before recreating

### DIFF
--- a/ida/ffxiv_exdgetters.py
+++ b/ida/ffxiv_exdgetters.py
@@ -141,21 +141,26 @@ if api is None:
 
             def create_enum_struct(self, name, values, width = 0):
                 # type: (str, dict[int, str], int) -> None
-                enum_id = self.get_enum_id(name)
                 if len(name.split("::")) > 3:
                     sheet_name = name.split("::")[-2]
                 else:
                     sheet_name = name.split("::")[-1]
+
+                # create or reset if exists
+                enum_id = self.get_enum_id(name)
                 if enum_id == idaapi.BADADDR:
                     enum_id = self.create_enum(name)
-                    self.set_enum_width(enum_id, width)
-                    if width == 1:
-                        if idaapi.IDA_SDK_VERSION < 900:
-                            self.add_enum_member(enum_id, f"{sheet_name}.tmp", self.get_enum_default_mask(enum_id))
-                        self.set_enum_as_bf(enum_id)
+                else:
+                    self.delete_enum_members(enum_id)
+                    idc.set_enum_bf(enum_id, False)
+                    
+                self.set_enum_width(enum_id, width)
+                if width == 1:
+                    if idaapi.IDA_SDK_VERSION < 900:
+                        self.add_enum_member(enum_id, f"{sheet_name}.tmp", self.get_enum_default_mask(enum_id))
+                    self.set_enum_as_bf(enum_id)
                         
                 for key in values:
-                    self.remove_enum_member(enum_id, values[key], sheet_name)
                     self.add_enum_member(enum_id, f"{sheet_name}.{values[key]}", key)
 
                 if width == 1 and idaapi.IDA_SDK_VERSION < 900:

--- a/ida/ffxiv_structimporter.py
+++ b/ida/ffxiv_structimporter.py
@@ -280,12 +280,6 @@ if api is None:
                 # type: (str) -> None
                 self.remove_struct_members(self.get_struct_id(fullname))
 
-            def delete_enum_members(self, enum):
-                # type: (DefinedStructEnum) -> None
-                e = self.get_enum_id(enum.type)
-                for value in enum.values:
-                    self.remove_enum_member(e, value, enum.name)
-
             @property
             def get_file_path(self):
                 return os.path.join(
@@ -298,8 +292,11 @@ if api is None:
             def create_enum_struct(self, enum):
                 # type: (DefinedStructEnum) -> None
                 fullname = enum.type
-                self.create_enum(fullname)
+                
                 e = self.get_enum_id(fullname)
+                if e == idaapi.BADADDR:
+                    self.create_enum(fullname)
+
                 self.set_enum_width(e, self.get_size_from_ida_type(enum.underlying))
                 if self.is_signed(enum.underlying):
                     self.set_enum_flag(e, 0x20000)
@@ -316,7 +313,10 @@ if api is None:
 
             def delete_enum(self, enum):
                 # type: (DefinedStructEnum) -> None
-                self.delete_enum_members(enum)
+                eid = idc.get_enum(enum.type)
+                if eid != idaapi.BADADDR:
+                    self.delete_enum_members(eid)
+                    idc.set_enum_bf(eid, False)
 
             def delete_struct(self, struct):
                 # type: (DefinedStruct) -> None

--- a/ida/ida_wrapper.py
+++ b/ida/ida_wrapper.py
@@ -599,8 +599,8 @@ class IdaInterface(BaseIdaInterface):
                 while mask != idaapi.DEFMASK:
                     masks.append(mask)
                     mask = idc.get_next_bmask(eid, mask)
-            members = []
 
+            members = []
             for mask in masks:
                 mem_val = idc.get_first_enum_member(eid, mask)
                 while mem_val != idaapi.BADNODE:

--- a/ida/ida_wrapper.py
+++ b/ida/ida_wrapper.py
@@ -25,14 +25,6 @@ class BaseIdaInterface(object):
     def get_enum_id(self, name):
         pass
 
-    @abstractmethod
-    def get_struct_size(self, sid):
-        pass
-
-    
-    def enum_exists(self, name: str) -> bool:
-        return self.get_enum_id(name) != idaapi.BADADDR
-
     def get_idc_type_from_ida_type(self, type: str):
         """Retrieve the idc type from the ida type.
 
@@ -102,7 +94,7 @@ class BaseIdaInterface(object):
         else:
             return ida_bytes.byte_flag()
 
-    def get_size_from_idc_type(self, type: int, name: str):
+    def get_size_from_idc_type(self, type: int):
         if type == ida_bytes.byte_flag():
             return 1
         elif type == ida_bytes.word_flag():
@@ -115,10 +107,6 @@ class BaseIdaInterface(object):
             return 4
         elif type == ida_bytes.double_flag():
             return 8
-        elif type == ida_bytes.stru_flag():
-            return self.get_struct_size(self.get_struct_id(name))
-        elif type == ida_bytes.stru_flag():
-            return idc.get_enum_width(self.get_enum_id(name))
         else:
             return 0
 
@@ -135,7 +123,7 @@ class BaseIdaInterface(object):
             return False
 
     def get_size_from_ida_type(self, type: str):
-        return self.get_size_from_idc_type(self.get_idc_type_from_ida_type(type), type)
+        return self.get_size_from_idc_type(self.get_idc_type_from_ida_type(type))
 
     def clean_name(self, name: str):
         """Clean a name

--- a/ida/ida_wrapper.py
+++ b/ida/ida_wrapper.py
@@ -25,6 +25,15 @@ class BaseIdaInterface(object):
     def get_enum_id(self, name):
         pass
 
+    @abstractmethod
+    def delete_enum_members(self, eid: int):
+        """Remove all enum members
+
+        Args:
+            eid (int): The id of the enum
+        """
+        pass
+
     def get_idc_type_from_ida_type(self, type: str):
         """Retrieve the idc type from the ida type.
 

--- a/ida/ida_wrapper.py
+++ b/ida/ida_wrapper.py
@@ -609,16 +609,13 @@ class IdaInterface(BaseIdaInterface):
                     mem_val = idc.get_next_enum_member(eid, mem_val, mask)
 
             for cid in members:
-                ok = ida_enum.del_enum_member(
+                ida_enum.del_enum_member(
                     eid,
                     ida_enum.get_enum_member_value(cid),
                     ida_enum.get_enum_member_serial(cid),
                     ida_enum.get_enum_member_bmask(cid)
                 )
                 
-                if not ok:
-                    raise RuntimeError("Failed to delete enum member {} in enum {}"%(cid, eid))
-
         def create_enum(self, name: str) -> int:
             """Create an enum by its name
 


### PR DESCRIPTION
This change is primarily targeting IDA 9.x+ where duplicate enum member names can result in lingering members during cleanup, but I've also included an implementation for 7.x and 8.x for functional parity.

I've also reverted the back-to-front experiment as it did not improve performance on 9.x (WTF did you do, Hex-Rays?)