### PR TITLE
Fix EXDSchema check + enum creation on IDA9+

### DIFF
--- a/ida/ffxiv_structimporter.py
+++ b/ida/ffxiv_structimporter.py
@@ -287,7 +287,7 @@ if api is None:
                 )
             
             def can_run(self):
-                idc.get_enum("Component::Exd::SheetsEnum") != idaapi.BADADDR
+                return idc.get_enum("Component::Exd::SheetsEnum") != idaapi.BADADDR
 
             def create_enum_struct(self, enum):
                 # type: (DefinedStructEnum) -> None

--- a/ida/ffxiv_structimporter.py
+++ b/ida/ffxiv_structimporter.py
@@ -287,7 +287,7 @@ if api is None:
                 )
             
             def can_run(self):
-                return self.enum_exists("Component::Exd::SheetsEnum")
+                idc.get_enum("Component::Exd::SheetsEnum") != idaapi.BADADDR
 
             def create_enum_struct(self, enum):
                 # type: (DefinedStructEnum) -> None

--- a/ida/ffxiv_structimporter.py
+++ b/ida/ffxiv_structimporter.py
@@ -295,7 +295,7 @@ if api is None:
                 
                 e = self.get_enum_id(fullname)
                 if e == idaapi.BADADDR:
-                    self.create_enum(fullname)
+                    e = self.create_enum(fullname)
 
                 self.set_enum_width(e, self.get_size_from_ida_type(enum.underlying))
                 if self.is_signed(enum.underlying):


### PR DESCRIPTION
`IdaApi.enum_exists` did not exist, replaced with a check using `idc.get_enum` instead.