### PR TITLE
Add SetupWorldTravelInfo tp data.yml

### DIFF
--- a/ida/data.yml
+++ b/ida/data.yml
@@ -12178,6 +12178,7 @@ classes:
     funcs:
       0x140BFB290: ctor
       0x140BFB330: Finalizer
+      0x140BFD090: SetupWorldTravelInfo # (agent*, uint currentWorld, uint targetWorld)
   Client::UI::Agent::AgentRideShooting:
     vtbls:
       - ea: 0x14209AFB0


### PR DESCRIPTION
used in setting texts in agent, for addon to display current world name and target world name when the world travel request is ready