### PR TITLE
Add LoadAreaVFXToLocalPlayer to TerritoryInfo

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/UI/TerritoryInfo.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/UI/TerritoryInfo.cs
@@ -16,4 +16,7 @@ public unsafe partial struct TerritoryInfo {
 
     [FieldOffset(0x24)] public uint AreaPlaceNameId;
     [FieldOffset(0x28)] public uint SubAreaPlaceNameId;
+
+    [MemberFunction("E8 ?? ?? ?? ?? C6 05 ?? ?? ?? ?? ?? B2 01")]
+    public partial void LoadAreaVFXToLocalPlayer(uint areaVFX);
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2636,6 +2636,7 @@ classes:
     funcs:
       0x140C89B80: Initialize
       0x140C89BD0: Finalizer
+      0x140C89A60: LoadAreaVFXToLocalPlayer
       0x140C89CF0: Update
   Client::Game::Conditions:
     instances:


### PR DESCRIPTION
a case i see is to set the misdirection status beacon

<img width="165" height="213" alt="image" src="https://github.com/user-attachments/assets/9af416ae-f997-4997-8e76-2d40a778e638" />
