### PR TITLE
AgentItemComp and AddonItemDetailCompare

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/InventoryItem.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InventoryItem.cs
@@ -1,5 +1,7 @@
+using System.Runtime.CompilerServices;
 using FFXIVClientStructs.FFXIV.Client.Game.Event;
 using FFXIVClientStructs.FFXIV.Client.System.Memory;
+using FFXIVClientStructs.FFXIV.Component.Exd;
 
 namespace FFXIVClientStructs.FFXIV.Client.Game;
 
@@ -164,4 +166,11 @@ public unsafe partial struct InventoryItem : ICreatable {
     /// <summary>Gets the materia count from the original InventoryItem or itself if not symbolic.</summary>
     [MemberFunction("E8 ?? ?? ?? ?? 45 0F B6 7D")]
     public partial byte GetMateriaCount();
+
+    [MemberFunction("E8 ?? ?? ?? ?? 80 7F 5E 01")]
+    // a5 and a6 control behavior around IsPvP gear, but the PvP gear never has stats anymore, so they're meaningless
+    public static partial uint GetParameterValue(uint baseParamRowId, InventoryItem* inventoryItem, bool includeMateria, bool checkHQ, bool a5, bool a6);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 66 89 46 12")]
+    public static partial uint GetParameterMaxValue(uint baseParamRowId, void* itemRowData);
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/InventoryItem.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InventoryItem.cs
@@ -168,9 +168,8 @@ public unsafe partial struct InventoryItem : ICreatable {
     public partial byte GetMateriaCount();
 
     [MemberFunction("E8 ?? ?? ?? ?? 80 7F 5E 01")]
-    // a5 and a6 control behavior around IsPvP gear, but the PvP gear never has stats anymore, so they're meaningless
-    public static partial uint GetParameterValue(uint baseParamRowId, InventoryItem* inventoryItem, bool includeMateria, bool checkHQ, bool a5, bool a6);
+    public static partial uint GetParameterValue(uint baseParamRowId, InventoryItem* inventoryItem, bool includeMateria, bool checkHQ, bool checkPvPCharacterFlag, bool checkPvPItemFlag);
 
     [MemberFunction("E8 ?? ?? ?? ?? 66 89 46 12")]
-    public static partial uint GetParameterMaxValue(uint baseParamRowId, void* itemRowData);
+    public static partial uint GetParameterMaxValue(uint baseParamRowId, [CExporterExcel("Item")] void* itemRowData);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonItemDetailCompare.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonItemDetailCompare.cs
@@ -1,0 +1,90 @@
+﻿using FFXIVClientStructs.FFXIV.Client.System.String;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI;
+
+// Client::UI::AddonItemDetailCompare
+//   Component::GUI::AtkUnitBase
+//     Component::GUI::AtkEventListener
+[Addon("ItemDetailCompare")]
+[GenerateInterop]
+[Inherits<AtkUnitBase>]
+[StructLayout(LayoutKind.Explicit, Size = 0x3F0)]
+public partial struct AddonItemDetailCompare {
+    [FieldOffset(0x238)] public Glamour SelectedItem;
+    [FieldOffset(0x310)] public Glamour EquippedItem;
+    [FieldOffset(0x3E8)] public short ArrowYOffset;
+
+    [StructLayout(LayoutKind.Explicit, Size = 0xD8)]
+    public struct Glamour {
+        [FieldOffset(0x0)] public Utf8String ItemName;
+        [FieldOffset(0x68)] public Utf8String GlamourName;
+        [FieldOffset(0xD0)] public bool ShowGlamour;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x15D0)]
+    public struct AtkValuesArray {
+        [FieldOffset(0x0000)] public Item SelectedItem;
+        [FieldOffset(0x0560)] public Item SelectedItemOtherQuality;
+        [FieldOffset(0x0AC0)] public Item EquippedItem;
+        [FieldOffset(0x1020)] public Item LeftRing;
+        [FieldOffset(0x1580)] public AtkValue SlotName;
+        [FieldOffset(0x1590)] public AtkValue QualityToggleHelpText;
+        [FieldOffset(0x15A0)] public AtkValue ShowRingSlotToggle;
+        [FieldOffset(0x15B0)] public AtkValue RingSlotState;
+        [FieldOffset(0x15C0)] public AtkValue CtrlHeld;
+
+        [StructLayout(LayoutKind.Explicit, Size = 0x560)]
+        public struct Item {
+            [FieldOffset(0x000)] public AtkValue IconId;
+            [FieldOffset(0x010)] public AtkValue DyeColor1;
+            [FieldOffset(0x020)] public AtkValue DyeColor2;
+            [FieldOffset(0x030)] public AtkValue EquippableStateTimelineId;
+            [FieldOffset(0x040)] public AtkValue RequiredLevelColor;
+            [FieldOffset(0x050), FixedSizeArray] internal FixedSizeArray3<AtkValue> _mainStatDeltaColorTimelineId;
+            [FieldOffset(0x080)] public AtkValue BonusStatCount;
+            [FieldOffset(0x090)] public AtkValue GreenBonusItemCount;
+            [FieldOffset(0x0A0)] public AtkValue BlueMateriaSlotCount;
+            [FieldOffset(0x0B0), FixedSizeArray] internal FixedSizeArray5<AtkValue> _materiaGrades;
+            [FieldOffset(0x100)] public AtkValue OvercappingMateriaIndexes; // bitfield
+            [FieldOffset(0x110)] public AtkValue RepairJobIconId;
+            [FieldOffset(0x120)] private AtkValue Unk18;
+            [FieldOffset(0x130)] public AtkValue ConditionPercentage;
+            [FieldOffset(0x140)] public AtkValue SpiritbondPercentage;
+            [FieldOffset(0x150)] public AtkValue Flags;
+            [FieldOffset(0x160)] public AtkValue ItemName;
+            [FieldOffset(0x170)] public AtkValue GlamName;
+            [FieldOffset(0x180)] public AtkValue EquipSlot;
+            [FieldOffset(0x190)] public AtkValue InventoryCount;
+            [FieldOffset(0x1A0)] public AtkValue ItemLevel;
+            [FieldOffset(0x1B0)] public AtkValue EquippableBy;
+            [FieldOffset(0x1C0)] public AtkValue EquipLevel;
+            [FieldOffset(0x1D0)] public AtkValue ItemSeries;
+            [FieldOffset(0x1E0), FixedSizeArray] internal FixedSizeArray3<AtkValue> _primaryStatNames;
+            [FieldOffset(0x210), FixedSizeArray] internal FixedSizeArray3<AtkValue> _primaryStatValues;
+            [FieldOffset(0x240), FixedSizeArray] internal FixedSizeArray3<AtkValue> _primaryStatDeltas;
+            [FieldOffset(0x270)] public AtkValue BonusesLabel;
+            [FieldOffset(0x280), FixedSizeArray] internal FixedSizeArray8<AtkValue> _bonusStats;
+            [FieldOffset(0x300), FixedSizeArray] internal FixedSizeArray8<AtkValue> _greenBonusItems;
+            [FieldOffset(0x380)] private AtkValue Unk56;
+            [FieldOffset(0x390), FixedSizeArray] internal FixedSizeArray5<AtkValue> _materiaNames;
+            [FieldOffset(0x3E0), FixedSizeArray] internal FixedSizeArray5<AtkValue> _materiaValues;
+            [FieldOffset(0x430)] public AtkValue RequirementsHeader;
+            [FieldOffset(0x440), FixedSizeArray] internal FixedSizeArray4<AtkValue> _requirementValues;
+            [FieldOffset(0x480)] public AtkValue ConditionPercentageString;
+            [FieldOffset(0x490)] public AtkValue SpiritbondOrCollectabilityHeader;
+            [FieldOffset(0x4A0)] public AtkValue SpiritbondOrCollectabilityValueString;
+            [FieldOffset(0x4B0)] private AtkValue Unk75;
+            [FieldOffset(0x4C0)] private AtkValue Unk76;
+            [FieldOffset(0x4D0)] private AtkValue Unk77;
+            [FieldOffset(0x4E0)] private AtkValue Unk78;
+            [FieldOffset(0x4F0)] public AtkValue ExtractProjectDesynthString;
+            [FieldOffset(0x500)] public AtkValue DyeColors;
+            [FieldOffset(0x510)] public AtkValue Marketability;
+            [FieldOffset(0x520)] public AtkValue CrafterName;
+            [FieldOffset(0x530)] public AtkValue SellPrice;
+            [FieldOffset(0x540)] public AtkValue RequiredJobLabel;
+            [FieldOffset(0x550)] public AtkValue RequiredJob;
+        }
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonItemDetailCompare.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonItemDetailCompare.cs
@@ -23,68 +23,72 @@ public partial struct AddonItemDetailCompare {
     }
 
     [StructLayout(LayoutKind.Explicit, Size = 0x15D0)]
-    public struct AtkValuesArray {
-        [FieldOffset(0x0000)] public Item SelectedItem;
-        [FieldOffset(0x0560)] public Item SelectedItemOtherQuality;
-        [FieldOffset(0x0AC0)] public Item EquippedItem;
-        [FieldOffset(0x1020)] public Item LeftRing;
-        [FieldOffset(0x1580)] public AtkValue SlotName;
-        [FieldOffset(0x1590)] public AtkValue QualityToggleHelpText;
-        [FieldOffset(0x15A0)] public AtkValue ShowRingSlotToggle;
-        [FieldOffset(0x15B0)] public AtkValue RingSlotState;
-        [FieldOffset(0x15C0)] public AtkValue CtrlHeld;
+    public partial struct AtkValuesArray {
+        [FieldOffset(ComparedItem.StructSize * 0)] public ComparedItem SelectedItem;
+        [FieldOffset(ComparedItem.StructSize * 1)] public ComparedItem SelectedItemOtherQuality;
+        [FieldOffset(ComparedItem.StructSize * 2)] public ComparedItem EquippedItem;
+        [FieldOffset(ComparedItem.StructSize * 3)] public ComparedItem LeftRing;
+        [FieldOffset(ComparedItem.StructSize * 4 +AtkValue.StructSize * 0)] public AtkValue SlotName;
+        [FieldOffset(ComparedItem.StructSize * 4 +AtkValue.StructSize * 1)] public AtkValue QualityToggleHelpText;
+        [FieldOffset(ComparedItem.StructSize * 4 +AtkValue.StructSize * 2)] public AtkValue ShowRingSlotToggle;
+        [FieldOffset(ComparedItem.StructSize * 4 +AtkValue.StructSize * 3)] public AtkValue RingSlotState;
+        [FieldOffset(ComparedItem.StructSize * 4 +AtkValue.StructSize * 4)] public AtkValue CtrlHeld;
 
+        [GenerateInterop]
         [StructLayout(LayoutKind.Explicit, Size = 0x560)]
-        public struct Item {
-            [FieldOffset(0x000)] public AtkValue IconId;
-            [FieldOffset(0x010)] public AtkValue DyeColor1;
-            [FieldOffset(0x020)] public AtkValue DyeColor2;
-            [FieldOffset(0x030)] public AtkValue EquippableStateTimelineId;
-            [FieldOffset(0x040)] public AtkValue RequiredLevelColor;
-            [FieldOffset(0x050), FixedSizeArray] internal FixedSizeArray3<AtkValue> _mainStatDeltaColorTimelineId;
-            [FieldOffset(0x080)] public AtkValue BonusStatCount;
-            [FieldOffset(0x090)] public AtkValue GreenBonusItemCount;
-            [FieldOffset(0x0A0)] public AtkValue BlueMateriaSlotCount;
-            [FieldOffset(0x0B0), FixedSizeArray] internal FixedSizeArray5<AtkValue> _materiaGrades;
-            [FieldOffset(0x100)] public AtkValue OvercappingMateriaIndexes; // bitfield
-            [FieldOffset(0x110)] public AtkValue RepairJobIconId;
-            [FieldOffset(0x120)] private AtkValue Unk18;
-            [FieldOffset(0x130)] public AtkValue ConditionPercentage;
-            [FieldOffset(0x140)] public AtkValue SpiritbondPercentage;
-            [FieldOffset(0x150)] public AtkValue Flags;
-            [FieldOffset(0x160)] public AtkValue ItemName;
-            [FieldOffset(0x170)] public AtkValue GlamName;
-            [FieldOffset(0x180)] public AtkValue EquipSlot;
-            [FieldOffset(0x190)] public AtkValue InventoryCount;
-            [FieldOffset(0x1A0)] public AtkValue ItemLevel;
-            [FieldOffset(0x1B0)] public AtkValue EquippableBy;
-            [FieldOffset(0x1C0)] public AtkValue EquipLevel;
-            [FieldOffset(0x1D0)] public AtkValue ItemSeries;
-            [FieldOffset(0x1E0), FixedSizeArray] internal FixedSizeArray3<AtkValue> _primaryStatNames;
-            [FieldOffset(0x210), FixedSizeArray] internal FixedSizeArray3<AtkValue> _primaryStatValues;
-            [FieldOffset(0x240), FixedSizeArray] internal FixedSizeArray3<AtkValue> _primaryStatDeltas;
-            [FieldOffset(0x270)] public AtkValue BonusesLabel;
-            [FieldOffset(0x280), FixedSizeArray] internal FixedSizeArray8<AtkValue> _bonusStats;
-            [FieldOffset(0x300), FixedSizeArray] internal FixedSizeArray8<AtkValue> _greenBonusItems;
-            [FieldOffset(0x380)] private AtkValue Unk56;
-            [FieldOffset(0x390), FixedSizeArray] internal FixedSizeArray5<AtkValue> _materiaNames;
-            [FieldOffset(0x3E0), FixedSizeArray] internal FixedSizeArray5<AtkValue> _materiaValues;
-            [FieldOffset(0x430)] public AtkValue RequirementsHeader;
-            [FieldOffset(0x440), FixedSizeArray] internal FixedSizeArray4<AtkValue> _requirementValues;
-            [FieldOffset(0x480)] public AtkValue ConditionPercentageString;
-            [FieldOffset(0x490)] public AtkValue SpiritbondOrCollectabilityHeader;
-            [FieldOffset(0x4A0)] public AtkValue SpiritbondOrCollectabilityValueString;
-            [FieldOffset(0x4B0)] private AtkValue Unk75;
-            [FieldOffset(0x4C0)] private AtkValue Unk76;
-            [FieldOffset(0x4D0)] private AtkValue Unk77;
-            [FieldOffset(0x4E0)] private AtkValue Unk78;
-            [FieldOffset(0x4F0)] public AtkValue ExtractProjectDesynthString;
-            [FieldOffset(0x500)] public AtkValue DyeColors;
-            [FieldOffset(0x510)] public AtkValue Marketability;
-            [FieldOffset(0x520)] public AtkValue CrafterName;
-            [FieldOffset(0x530)] public AtkValue SellPrice;
-            [FieldOffset(0x540)] public AtkValue RequiredJobLabel;
-            [FieldOffset(0x550)] public AtkValue RequiredJob;
+        public partial struct ComparedItem {
+            [FieldOffset(AtkValue.StructSize * 0)] public AtkValue IconId;
+            [FieldOffset(AtkValue.StructSize * 1)] public AtkValue DyeColor1;
+            [FieldOffset(AtkValue.StructSize * 2)] public AtkValue DyeColor2;
+            [FieldOffset(AtkValue.StructSize * 3)] public AtkValue EquippableStateTimelineId;
+            [FieldOffset(AtkValue.StructSize * 4)] public AtkValue RequiredLevelColor;
+            [FieldOffset(AtkValue.StructSize * 5), FixedSizeArray] internal FixedSizeArray3<AtkValue> _mainStatDeltaColorTimelineId;
+            [FieldOffset(AtkValue.StructSize * 8)] public AtkValue BonusStatCount;
+            [FieldOffset(AtkValue.StructSize * 9)] public AtkValue GreenBonusItemCount;
+            [FieldOffset(AtkValue.StructSize * 10)] public AtkValue BlueMateriaSlotCount;
+            [FieldOffset(AtkValue.StructSize * 11), FixedSizeArray] internal FixedSizeArray5<AtkValue> _materiaGrades;
+            /// <remark>
+            ///  Bitfield of booleans, where bit index maps to materia slot index
+            /// </remark>
+            [FieldOffset(AtkValue.StructSize * 16)] public AtkValue OvercappingMateriaIndexes;
+            [FieldOffset(AtkValue.StructSize * 17)] public AtkValue RepairJobIconId;
+            [FieldOffset(AtkValue.StructSize * 18)] private AtkValue Unk18;
+            [FieldOffset(AtkValue.StructSize * 19)] public AtkValue ConditionPercentage;
+            [FieldOffset(AtkValue.StructSize * 20)] public AtkValue SpiritbondPercentage;
+            [FieldOffset(AtkValue.StructSize * 21)] public AtkValue Flags;
+            [FieldOffset(AtkValue.StructSize * 22)] public AtkValue ItemName;
+            [FieldOffset(AtkValue.StructSize * 23)] public AtkValue GlamName;
+            [FieldOffset(AtkValue.StructSize * 24)] public AtkValue EquipSlot;
+            [FieldOffset(AtkValue.StructSize * 25)] public AtkValue InventoryCount;
+            [FieldOffset(AtkValue.StructSize * 26)] public AtkValue ItemLevel;
+            [FieldOffset(AtkValue.StructSize * 27)] public AtkValue EquippableBy;
+            [FieldOffset(AtkValue.StructSize * 28)] public AtkValue EquipLevel;
+            [FieldOffset(AtkValue.StructSize * 29)] public AtkValue ItemSeries;
+            [FieldOffset(AtkValue.StructSize * 30), FixedSizeArray] internal FixedSizeArray3<AtkValue> _primaryStatNames;
+            [FieldOffset(AtkValue.StructSize * 33), FixedSizeArray] internal FixedSizeArray3<AtkValue> _primaryStatValues;
+            [FieldOffset(AtkValue.StructSize * 36), FixedSizeArray] internal FixedSizeArray3<AtkValue> _primaryStatDeltas;
+            [FieldOffset(AtkValue.StructSize * 39)] public AtkValue BonusesLabel;
+            [FieldOffset(AtkValue.StructSize * 40), FixedSizeArray] internal FixedSizeArray8<AtkValue> _bonusStats;
+            [FieldOffset(AtkValue.StructSize * 48), FixedSizeArray] internal FixedSizeArray8<AtkValue> _greenBonusItems;
+            [FieldOffset(AtkValue.StructSize * 56)] private AtkValue Unk56;
+            [FieldOffset(AtkValue.StructSize * 57), FixedSizeArray] internal FixedSizeArray5<AtkValue> _materiaNames;
+            [FieldOffset(AtkValue.StructSize * 62), FixedSizeArray] internal FixedSizeArray5<AtkValue> _materiaValues;
+            [FieldOffset(AtkValue.StructSize * 67)] public AtkValue RequirementsHeader;
+            [FieldOffset(AtkValue.StructSize * 68), FixedSizeArray] internal FixedSizeArray4<AtkValue> _requirementValues;
+            [FieldOffset(AtkValue.StructSize * 72)] public AtkValue ConditionPercentageString;
+            [FieldOffset(AtkValue.StructSize * 73)] public AtkValue SpiritbondOrCollectabilityHeader;
+            [FieldOffset(AtkValue.StructSize * 74)] public AtkValue SpiritbondOrCollectabilityValueString;
+            [FieldOffset(AtkValue.StructSize * 75)] private AtkValue Unk75;
+            [FieldOffset(AtkValue.StructSize * 76)] private AtkValue Unk76;
+            [FieldOffset(AtkValue.StructSize * 77)] private AtkValue Unk77;
+            [FieldOffset(AtkValue.StructSize * 78)] private AtkValue Unk78;
+            [FieldOffset(AtkValue.StructSize * 79)] public AtkValue ExtractProjectDesynthString;
+            [FieldOffset(AtkValue.StructSize * 80)] public AtkValue DyeColors;
+            [FieldOffset(AtkValue.StructSize * 81)] public AtkValue Marketability;
+            [FieldOffset(AtkValue.StructSize * 82)] public AtkValue CrafterName;
+            [FieldOffset(AtkValue.StructSize * 83)] public AtkValue SellPrice;
+            [FieldOffset(AtkValue.StructSize * 84)] public AtkValue RequiredJobLabel;
+            [FieldOffset(AtkValue.StructSize * 85)] public AtkValue RequiredJob;
         }
     }
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemComp.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemComp.cs
@@ -19,27 +19,30 @@ public unsafe partial struct AgentItemComp {
 
     [StructLayout(LayoutKind.Explicit, Size = 0x1650)]
     public partial struct ComparedItemData {
-        [FieldOffset(0), CExporterIgnore] public ComparedInventoryItem SelectedItem;
-        [FieldOffset(0x50), CExporterIgnore] public ComparedInventoryItem SelectedItemAlternateQuality;
-        [FieldOffset(0xA0), CExporterIgnore] public ComparedInventoryItem EquippedItem;
-        // If SelectedItem is a Ring, this will contain the left ring and EquippedItem will contain the right
-        [FieldOffset(0xF0), CExporterIgnore] public ComparedInventoryItem LeftRingItem;
-        // The game accesses these as an array
+        /// <remarks>
+        /// These items are, in order: the selected item, the alternate quality (HQ/NQ) of the selected item, the currently equipped item, and the left ring slot (if the SelectedItem is a ring)
+        /// Any item that doesn't exist is retained as an empty item in the array
+        /// </remarks>
         [FieldOffset(0), FixedSizeArray] internal FixedSizeArray4<ComparedInventoryItem> _items;
 
-        [FieldOffset(0x140), CExporterIgnore] public ComparedInventoryItemData SelectedItemData;
-        [FieldOffset(0x680), CExporterIgnore] public ComparedInventoryItemData SelectedItemAlternateQualityData;
-        [FieldOffset(0xBC0), CExporterIgnore] public ComparedInventoryItemData EquippedItemData;
-        [FieldOffset(0x1100), CExporterIgnore] public ComparedInventoryItemData LeftRingItemData;
-        // The game accesses these as an array
+        /// <remarks>
+        /// This array has the same layout as the one for Items
+        /// </remarks>
         [FieldOffset(0x140), FixedSizeArray] internal FixedSizeArray4<ComparedInventoryItemData> _itemData;
 
-        // 0 = No update needed
-        // 1 = Open
-        // 2 = Refresh
+        /// <summary>
+        /// This is set on any frame that the Agent will be updating the addon's UI
+        /// </summary>
+        /// <remarks>
+        /// 0 = No update needed
+        /// 1 = Open
+        /// 2 = Refresh
+        /// </remarks>
         [FieldOffset(0x1640)] public int UpdateState;
 
-        // Counts up across frames as the agent loads the necessary data
+        /// <remark>
+        /// Counts up across frames as the agent loads the necessary data
+        /// </remark>
         [FieldOffset(0x1644)] public int LoadState;
         [FieldOffset(0x1648)] public int ParentAddonId;
         [FieldOffset(0x164C)] public bool ShowAlternateQuality;
@@ -68,13 +71,14 @@ public unsafe partial struct AgentItemComp {
             [FieldOffset(0x51C), CExporterUnion("Delta")] public ShieldDataDelta Shield;
             [FieldOffset(0x51C), CExporterUnion("Delta")] public GearDataDelta Gear;
             [FieldOffset(0x53C)] public ushort ItemLevelRowId;
-            /*
-                0- Error
-                1- OK
-                2- Different Job can equip, but generally only for weapons?
-                3- Level Restricted
-                4- Class/Race/Gender/GC Restricted
-             */
+
+            /// <remark>
+            /// 0- Error
+            /// 1- OK
+            /// 2- Different Job can equip, but generally only for weapons?
+            /// 3- Level Restricted
+            /// 4- Class/Race/Gender/GC Restricted
+            /// </remark>
             [FieldOffset(0x53E)] public byte EquippableState;
             [FieldOffset(0x53F)] public byte DyeCount;
         }
@@ -100,11 +104,16 @@ public unsafe partial struct AgentItemComp {
             public int MagicDefense;
             public int PhysicalDefenseDelta;
             public int MagicDefenseDelta;
-            // Second values used when comparing against Left Ring
-            public int PhysicalDefense2;
-            public int MagicDefense2;
-            public int PhysicalDefenseDelta2;
-            public int MagicDefenseDelta2;
+            /// <remark>
+            /// This is always the same as PhysicalDefense, but the game sets it separately
+            /// </remark>
+            public int LeftRingSlotPhysicalDefense;
+            /// <remark>
+            /// This is always the same as MagicDefense, but the game sets it separately
+            /// </remark>
+            public int LeftRingSlotMagicDefense;
+            public int LeftRingSlotPhysicalDefenseDelta;
+            public int LeftRingSlotMagicDefenseDelta;
         }
     }
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemComp.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemComp.cs
@@ -1,3 +1,6 @@
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Client.System.String;
+
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 // Client::UI::Agent::AgentItemComp
@@ -7,7 +10,101 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 [GenerateInterop]
 [Inherits<AgentInterface>]
 [StructLayout(LayoutKind.Explicit, Size = 0x60)]
-public partial struct AgentItemComp {
+public unsafe partial struct AgentItemComp {
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 48 8B 53 ?? 0F B7 4B")]
     public partial void CompareItem(ushort parentAddonId, uint itemId, byte stain0Id, byte stain1Id);
+
+    [FieldOffset(0x50)] public ComparedItemData* ItemData;
+    [FieldOffset(0x58)] public bool ShowLeftRing;
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x1650)]
+    public partial struct ComparedItemData {
+        [FieldOffset(0), CExporterIgnore] public ComparedInventoryItem SelectedItem;
+        [FieldOffset(0x50), CExporterIgnore] public ComparedInventoryItem SelectedItemAlternateQuality;
+        [FieldOffset(0xA0), CExporterIgnore] public ComparedInventoryItem EquippedItem;
+        // If SelectedItem is a Ring, this will contain the left ring and EquippedItem will contain the right
+        [FieldOffset(0xF0), CExporterIgnore] public ComparedInventoryItem LeftRingItem;
+        // The game accesses these as an array
+        [FieldOffset(0), FixedSizeArray] internal FixedSizeArray4<ComparedInventoryItem> _items;
+
+        [FieldOffset(0x140), CExporterIgnore] public ComparedInventoryItemData SelectedItemData;
+        [FieldOffset(0x680), CExporterIgnore] public ComparedInventoryItemData SelectedItemAlternateQualityData;
+        [FieldOffset(0xBC0), CExporterIgnore] public ComparedInventoryItemData EquippedItemData;
+        [FieldOffset(0x1100), CExporterIgnore] public ComparedInventoryItemData LeftRingItemData;
+        // The game accesses these as an array
+        [FieldOffset(0x140), FixedSizeArray] internal FixedSizeArray4<ComparedInventoryItemData> _itemData;
+
+        // 0 = No update needed
+        // 1 = Open
+        // 2 = Refresh
+        [FieldOffset(0x1640)] public int UpdateState;
+
+        // Counts up across frames as the agent loads the necessary data
+        [FieldOffset(0x1644)] public int LoadState;
+        [FieldOffset(0x1648)] public int ParentAddonId;
+        [FieldOffset(0x164C)] public bool ShowAlternateQuality;
+
+        [StructLayout(LayoutKind.Explicit, Size = 0x50)]
+        public struct ComparedInventoryItem {
+            [FieldOffset(0)] public InventoryItem Item;
+            [FieldOffset(0x48)] public byte CurrentSyncedJobLevel;
+            [FieldOffset(0x49)] public byte CurrentJobLevel;
+            [FieldOffset(0x4A)] public byte CurrentClassJobId;
+        }
+
+        [GenerateInterop]
+        [StructLayout(LayoutKind.Explicit, Size = 0x540)]
+        public partial struct ComparedInventoryItemData {
+            [FieldOffset(0)] public Utf8String GlamouredItemName;
+            [FieldOffset(0x68)] public Utf8String CrafterName;
+            [FieldOffset(0xD0)] public Utf8String DyeNames;
+            [FieldOffset(0x138), FixedSizeArray] internal FixedSizeArray5<Utf8String> _materiaNames;
+            [FieldOffset(0x340)] public Utf8String RepairItemName;
+            [FieldOffset(0x3A8)] public Utf8String Marketability;
+            [FieldOffset(0x410)] private Utf8String Unk410;
+            // [0x478 ~ 0x518) - Exd::Sheet::Item
+            // [0x518 ~ 0x51C) - Exd::Sheet::GilShopInfo
+            [FieldOffset(0x51C), CExporterUnion("Delta")] public WeaponDataDelta Weapon;
+            [FieldOffset(0x51C), CExporterUnion("Delta")] public ShieldDataDelta Shield;
+            [FieldOffset(0x51C), CExporterUnion("Delta")] public GearDataDelta Gear;
+            [FieldOffset(0x53C)] public ushort ItemLevelRowId;
+            /*
+                0- Error
+                1- OK
+                2- Different Job can equip, but generally only for weapons?
+                3- Level Restricted
+                4- Class/Race/Gender/GC Restricted
+             */
+            [FieldOffset(0x53E)] public byte EquippableState;
+            [FieldOffset(0x53F)] public byte DyeCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Size = 0x14)]
+        public struct WeaponDataDelta {
+            public int PhysicalDamage;
+            public int MagicDamage;
+            public int Delay;
+            public int PhysicalDamageDelta;
+            public int MagicDamageDelta;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Size = 0x8)]
+        public struct ShieldDataDelta {
+            public int Block;
+            public int BlockDelta;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Size = 0x20)]
+        public struct GearDataDelta {
+            public int PhysicalDefense;
+            public int MagicDefense;
+            public int PhysicalDefenseDelta;
+            public int MagicDefenseDelta;
+            // Second values used when comparing against Left Ring
+            public int PhysicalDefense2;
+            public int MagicDefense2;
+            public int PhysicalDefenseDelta2;
+            public int MagicDefenseDelta2;
+        }
+    }
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkEvent.cs
@@ -82,6 +82,9 @@ public enum AtkEventType : byte {
     WindowRollOut = 71,
     WindowChangeScale = 72,
 
+    // AtkTimeline
+    TimelineActiveLabelChanged = 74,
+
     // AtkTextNode
     LinkMouseClick = 75,
     LinkMouseOver = 76,

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkEventData.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkEventData.cs
@@ -12,6 +12,7 @@ public unsafe partial struct AtkEventData {
     [FieldOffset(0x00)] public LinkData* LinkData;
     [FieldOffset(0x00)] public AtkAddonControlData AddonControlData;
     [FieldOffset(0x00)] public GUI.AtkInputData* RawInputData;
+    [FieldOffset(0x00)] public AtkTimelineData TimelineData;
 }
 
 public partial struct AtkEventData {
@@ -92,4 +93,11 @@ public partial struct AtkEventData {
     public unsafe struct AtkAddonControlData {
         [FieldOffset(0x00)] public AtkUnitBase* UnitBase;
     }
+    
+    [StructLayout(LayoutKind.Explicit, Size = 0x28)]
+    public struct AtkTimelineData {
+        [FieldOffset(0x00)] public ushort LabelId;
+        [FieldOffset(0x02)] public AtkTimelineJumpBehavior JumpBehavior;
+    }
+
 }


### PR DESCRIPTION
Reverses AddonItemDetailCompare and AgentItemComp
Also adds a new AtkEvent found while reversing the addon, as well as two parameter-fetching functions used in AgentItemComp to more easily get equipment stats/params