### PR TITLE
Additions

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkInputManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkInputManager.cs
@@ -13,6 +13,8 @@ public unsafe partial struct AtkInputManager {
 
     [FieldOffset(0x80), FixedSizeArray] internal FixedSizeArray256<FocusEntry> _focusList;
 
+    [FieldOffset(0x1880)] public AtkCollisionNode* FocusedCollisionNode;
+
     [MemberFunction("E8 ?? ?? ?? ?? 33 C0 48 89 86 ?? ?? ?? ?? 88 86 ?? ?? ?? ?? 38 86")]
     public partial void HandleInput(AtkUnitManager* unitManager, AtkCollisionManager* collisionManager);
 

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextureResourceManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextureResourceManager.cs
@@ -1,3 +1,4 @@
+using FFXIVClientStructs.FFXIV.Client.System.Resource.Handle;
 using FFXIVClientStructs.FFXIV.Component.Exd;
 
 namespace FFXIVClientStructs.FFXIV.Component.GUI;
@@ -13,6 +14,14 @@ public unsafe partial struct AtkTextureResourceManager {
     // Icon ranges are inclusive: id ∈ [a,b]
     [FieldOffset(0x30), FixedSizeArray] internal FixedSizeArray4<StdPair<uint, uint>> _localizedIconRange;
     [FieldOffset(0x50)] public uint LocalizedIconRangeCount;
+
+    /// <summary>
+    /// Unloads the texture if the reference count is 1, otherwise decrements the textures reference count.
+    /// </summary>
+    /// <param name="textureHandle">Pointer to a texture resource</param>
+    /// <returns>-1 if the textureHandle is null, 0 otherwise</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? 32 C0 45 84 FF")]
+    public partial long UnloadTexture(TextureResourceHandle* textureHandle);
 }
 
 public enum IconSubFolder {

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextureResourceManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextureResourceManager.cs
@@ -22,6 +22,12 @@ public unsafe partial struct AtkTextureResourceManager {
     /// <returns>-1 if the textureHandle is null, 0 otherwise</returns>
     [MemberFunction("E8 ?? ?? ?? ?? 32 C0 45 84 FF")]
     public partial long UnloadTexture(TextureResourceHandle* textureHandle);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B F0 48 85 C0 74 35 48 8B 48 08")]
+    public partial AtkTextureResource* LoadIconTexture(int iconId, IconSubFolder folder);
+    
+    [MemberFunction("E8 ?? ?? ?? ?? 4C 8B E8 48 85 C0 74 52")]
+    public partial AtkTextureResource* LoadTexture(CStringPointer path, IconSubFolder folder);
 }
 
 public enum IconSubFolder {

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -7053,6 +7053,7 @@ classes:
     funcs:
       0x14060E360: LoadTexture
       0x14060E5F0: LoadIconTexture
+      0x14060E950: UnloadTexture
   Component::GUI::AtkTooltipManager:
     vtbls:
       - ea: 0x142040790


### PR DESCRIPTION
I'm 95% sure the return of LoadTexture is AtkTextureResource*, IDA shows a weird type for the return, but the actual object returned is AtkTextureResource*.

UnloadTexture returns 0xFFFFFFFF if given a null texture, but returns 0 in all other cases.
Not sure if long is the best return type for this, though it's the most accurate.