### PR TITLE
Update WorldHelper

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/WorldHelper.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/WorldHelper.cs
@@ -12,7 +12,7 @@ public unsafe partial struct WorldHelper {
     [FieldOffset(0x08)] public StdMap<ushort, World> AllWorlds;
     /// <summary> Contains all worlds of the current data center. </summary>
     [FieldOffset(0x18)] public StdMap<ushort, World> DataCenterWorlds;
-    // [FieldOffset(0x28)] public ClassThatLoadsWorlds WorldLoader; // size: 0x10
+    [FieldOffset(0x28)] private ExcelRowCallback ExcelCallback;
     [FieldOffset(0x38)] public bool IsLoaded;
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 85 F6 75 17")]
@@ -26,9 +26,16 @@ public unsafe partial struct WorldHelper {
 
 
     [GenerateInterop]
-    [StructLayout(LayoutKind.Explicit, Size = 0x22)]
+    [StructLayout(LayoutKind.Explicit, Size = 0x24)]
     public partial struct World {
-        [FieldOffset(0x00)] public byte DataCenter;
-        [FieldOffset(0x01), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _name;
+        [FieldOffset(0x00)] public ushort RowId;
+        [FieldOffset(0x02)] public byte DataCenter;
+        [FieldOffset(0x03), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _name;
+    }
+
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 0x10)]
+    public partial struct ExcelRowCallback {
+        [FieldOffset(0x08)] public WorldHelper* WorldHelper;
     }
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -9668,15 +9668,21 @@ classes:
       0x14097FB20: GetDataCenterNameByRowId # unused
   Client::UI::Misc::WorldHelper:
     vtbls:
-      - ea: 0x142064588
+      - ea: 0x1420636D8
     vfuncs:
       0: Dtor
     funcs:
-      0x14097FD40: ctor
-      0x14097FDE0: Finalizer
+      0x14097F1B0: ctor
+      0x14097F250: Finalizer
       0x14097FFB0: GetWorldById
       0x140980030: GetWorldNameById
       0x140980090: GetWorldIdByName
+  Client::UI::Misc::WorldHelper::ExcelRowCallback:
+    vtbls:
+      - ea: 0x1420636C8
+    vfuncs:
+      0: Dtor
+      1: Call
   Client::UI::Misc::ExtraCommandHelper:
     vtbls:
       - ea: 0x142064590


### PR DESCRIPTION
Primarily `Client::UI::Misc::WorldHelper::World` had a missing id field at the start of the type, shifting the other fields around.