### PR TITLE
Add Scene/VfxObject structs

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/VfxObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/VfxObject.cs
@@ -3,6 +3,11 @@ using FFXIVClientStructs.FFXIV.Client.Graphics.Vfx;
 namespace FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 
 // Client::Graphics::Scene::VfxObject
+//   Client::Graphics::Scene::DrawObject
+//     Client::Graphics::Scene::Object
+//   Apricot::ApricotInstanceListenner
+//     Apricot::IInstanceListenner
+//   Client::Graphics::Vfx::VfxResourceInstanceListenner
 [GenerateInterop]
 [Inherits<DrawObject>]
 [StructLayout(LayoutKind.Explicit, Size = 0x380)]

--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Vfx/VfxResourceInstance.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Vfx/VfxResourceInstance.cs
@@ -5,10 +5,10 @@ namespace FFXIVClientStructs.FFXIV.Client.Graphics.Vfx;
 // best guess at namespace, VfxResourceInstanceListenner is related and belongs in ::Graphics::Vfx
 [StructLayout(LayoutKind.Explicit, Size = 0xD0)]
 public unsafe struct VfxResourceInstance {
-    [FieldOffset(0x08)] public VfxResourceUnk* VfxResourceUnk; // ?? no clue what this passthrough struct is
+    [FieldOffset(0x08)] internal VfxResourceUnk* VfxResourceUnk;
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x20)]
-public unsafe struct VfxResourceUnk {
+internal unsafe struct VfxResourceUnk {
     [FieldOffset(0x18)] public ApricotResourceHandle* ApricotResourceHandle;
 }

--- a/FFXIVClientStructs/FFXIV/Client/System/Resource/Handle/ApricotResourceHandle.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Resource/Handle/ApricotResourceHandle.cs
@@ -5,6 +5,6 @@ namespace FFXIVClientStructs.FFXIV.Client.System.Resource.Handle;
 //     Client::System::Resource::Handle::ResourceHandle
 //       Client::System::Common::NonCopyable
 [GenerateInterop]
-[Inherits<ResourceHandle>]
+[Inherits<DefaultResourceHandle>]
 [StructLayout(LayoutKind.Explicit, Size = 0xC8)]
 public unsafe partial struct ApricotResourceHandle { }


### PR DESCRIPTION
these are structs I've used on [Pathfinder](https://github.com/ktisis-tools/ffxiv-pathfinder/blob/main/Pathfinder/Interop/Structs.cs) for parsing filepaths of static/environmental VFX. I haven't determined if these or similar Apricot resources are used for dynamic VFX, such as those from abilities or attached to equipment, but they've been reliable so far for processing scene objects at least

please let me know if any changes or further details are needed here ^^