### PR TITLE
Overhaul normal events in EventHandlerContent

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
@@ -340,65 +340,110 @@ public struct EventId : IEquatable<EventId>, IComparable<EventId> {
 }
 
 public enum EventHandlerContent : ushort {
+    /// <remarks> See Quest sheet. </remarks>
     Quest = 0x0001,
+    /// <remarks> See Warp sheet. </remarks>
     Warp = 0x0002,
     GatheringPoint = 0x0003,
-    Shop = 0x0004,
+    /// <remarks> See GilShop sheet. </remarks>
+    GilShop = 0x0004,
     Aetheryte = 0x0005,
+    /// <remarks> See GuildleveAssignment sheet. </remarks>
     GuildLeveAssignment = 0x0006,
+    /// DefaultTalk sheet.
     DefaultTalk = 0x0009,
     Craft = 0x000A,
+    /// <remarks> See CustomTalk sheet. </remarks>
     CustomTalk = 0x000B,
     CompanyLeveOfficer = 0x000C,
+    /// <remarks> See ArrayEventHandler sheet. </remarks>
     Array = 0x000D,
-    CraftLeveClient = 0x000E,
+    /// <remarks> See CraftLeve sheet. </remarks>
+    CraftLeve = 0x000E,
     GimmickAccessor = 0x000F,
     GimmickBill = 0x0010,
     GimmickRect = 0x0011,
+    /// <remarks> See ChocoboTaxiStand sheet. </remarks>
     ChocoboTaxiStand = 0x0012,
+    /// <remarks> See Opening sheet. </remarks>
     Opening = 0x0013,
     ExitRange = 0x0014,
     Fishing = 0x0015,
+    /// <remarks> See GCShop sheet. </remarks>
     GrandCompanyShop = 0x0016,
+    /// <remarks> See GuildOrderGuide sheet. </remarks>
     GuildOrderGuide = 0x0017,
+    /// <remarks> See GuildOrderOfficer sheet. </remarks>
     GuildOrderOfficer = 0x0018,
+    /// <remarks> see ContentNpc sheet. </remarks>
     ContentNpc = 0x0019,
+    /// <remarks> See Story sheet. </remarks>
     Story = 0x001A,
+    /// <remarks> See SpecialShop sheet. </remarks>
     SpecialShop = 0x001B,
     DeepDungeon = 0x001C,
+    /// <remarks> See InstanceContentGuide sheet. </remarks>
     InstanceContentGuide = 0x001D,
+    /// <remarks> See HousingAethernet sheet. </remarks>
     HousingAethernet = 0x001E,
-    FcTalk = 0x001F,
+    /// <remarks> See SwitchTalk sheet. </remarks>
+    SwitchTalk = 0x001F,
     MobHunt = 0x0020,
+    /// <remarks> See Adventure sheet. </remarks>
     Adventure = 0x0021,
     DailyQuestSupply = 0x0022,
+    /// <remarks> See TripleTriad sheet. </remarks>
     TripleTriad = 0x0023,
+    /// <remarks> See GoldSaucerArcadeMachine sheet. </remarks>
     GoldSaucerArcadeMachine = 0x0024,
-    LotteryDaily = 0x0025, // Mini Cactpot
-    LotteryWeekly = 0x0026, // Jumbo Cactpot
+    /// <remarks> Used in Mini Cactpot. </remarks>
+    LotteryDaily = 0x0025,
+    /// <remarks> Used in Jumbo Cactpot. </remarks>
+    LotteryWeekly = 0x0026,
     RaceChocoboRegistrar = 0x0027,
-
-    GoldSaucerTalk = 0x0029, // Q'nabyano (responding with GoldSaucerTalk#162) and Reymanaud (responding with GoldSaucerTalk#161) use this
+    /// <remarks> Q'nabyano (responding with GoldSaucerTalk#162) and Reymanaud (responding with GoldSaucerTalk#161) use this. </remarks>
+    GoldSaucerTalk = 0x0029,
+    /// <remarks> See FccShop sheet. </remarks>
     FreeCompanyCreditShop = 0x002A,
+    /// <remarks> See AetherCurrent sheet. </remarks>
     AetherCurrent = 0x002B,
+    /// <remarks> See ContentEntry sheet. </remarks>
     ContentEntry = 0x002C,
-    Verminion = 0x002D, // Verminion Tables and Tournament Recordkeeper
+    /// <remarks> Used for Verminion Tables and Tournament Recordkeeper. </remarks>
+    Verminion = 0x002D,
     SkyIslandEntrance = 0x002E,
-    DpsChallengeOfficer = 0x002F, // Stone, Sky, Sea
+    /// <remarks> See DpsChallengeOfficer sheet. </remarks>
+    DpsChallengeOfficer = 0x002F,
     BeginnerTrainingOfficer = 0x0030,
     RetainerBuyback = 0x0031,
+    /// <remarks> See TopicSelect sheet. </remarks>
     TopicSelect = 0x0032,
+    /// <remarks> see LotteryExchangeShop sheet. </remarks>
     LotteryExchangeShop = 0x0034,
+    /// <remarks> See DisposalShop sheet. </remarks>
     DisposalShop = 0x0035,
-    PreHandler = 0x0036, // checks quest completion before handling something, for example opening the Scrip Exchange
-    TripleTriadCompetition = 0x0037,
-    HwdDev = 0x0038, // Ishgardian Restoration (Firmament / Heavensward Development?!)
-    Materialize = 0x0039, // Desynthesis (0x390000), Materia Extraction (0x390001), Aetherial Reduction (0x390002)
+    /// <remarks> Checks quest completion before handling something, for example opening the Scrip Exchange. See PreHandler sheet. </remarks>
+    PreHandler = 0x0036,
+    /// <remarks> See Description sheet. </remarks>
+    Description = 0x0037,
+    /// <remarks> Used for Ishgardian Restoration (Firmament / Heavensward Development?!) </remarks>
+    HwdDev = 0x0038,
+    /// <remarks> Used for Desynthesis (0x390000), Materia Extraction (0x390001), Aetherial Reduction (0x390002) </remarks>
+    Materialize = 0x0039,
+    /// <remarks> See InclusionShop sheet. </remarks>
     InclusionShop = 0x003A,
+    /// <remarks> see CollectablesShop sheet. </remarks>
     CollectablesShop = 0x003B,
-    MJIPasture = 0x003C, // Island Sanctuary Pasture
-    EventPathMove = 0x003D, // Argos in Mare Lamentorum uses this
-    ReactionEvent = 0x003E, // Island Sanctuary Cropland, see ReactionEventObject
+    /// <remarks> Used for Island Sanctuary Pasture. </remarks>
+    MJIPasture = 0x003C,
+    /// <remarks> Used for Argos in Mare Lamentorum. See EventPathMove sheet. </remarks>
+    EventPathMove = 0x003D,
+    /// <remarks> Used for Island Sanctuary Cropland, see ReactionEventObject. </remarks>
+    ReactionEvent = 0x003E,
+    /// <remarks> Used for the teleporters in Solution None. See EventGimmickPathMove sheet. </remarks>
+    EventGimmickPathMove = 0x0040,
+    /// <remarks> See EventMountGimmickPathMove sheet. </remarks>
+    EventMountGimmickPathMove = 0x0041,
 
     BattleLeveDirector = 0x8001,
     GatheringLeveDirector = 0x8002,


### PR DESCRIPTION
Added documentation for most of the normal events, especially useful is the Excel sheets associated with each one. I also fixed/added some of the mislabeled ones like Description and FcTalk.

This is an API break so we'll have to wait until 7.4 though.