### PR TITLE
Update GraphicsConfig.JitterMultiplier to 7.4

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Render/GraphicsConfig.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Render/GraphicsConfig.cs
@@ -61,5 +61,5 @@ public unsafe partial struct GraphicsConfig {
 
     [FieldOffset(0x65)] public bool HousingSSAOEnable;
 
-    [FieldOffset(0x74)] public float JitterMultiplier;
+    [FieldOffset(0x78)] public float JitterMultiplier;
 }


### PR DESCRIPTION
This shifted +4 bytes with 7.4, sadly, I don't know whenever the other fields are still good, sorry.