### PR TITLE
Add UIModulePacketType for InitZone

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/UIModuleInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/UIModuleInterface.cs
@@ -185,6 +185,7 @@ public enum UIModulePacketType {
     LevelChange = 3,
     ShowLogMessage = 4,
     Login = 6,
+    InitZone = 5,
     Logout = 7,
     CloseLogoutDialog = 8,
     StartLogoutCountdown = 9,


### PR DESCRIPTION
This is called during InitZone where it passes the packet over to the UIModule for doing more flag checks. Since it seems to depend on the InitZone packet structure, I named it as such.