### PR TITLE
Upstream DeviceCallbacks

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Device.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Kernel/Device.cs
@@ -7,25 +7,6 @@ namespace FFXIVClientStructs.FFXIV.Client.Graphics.Kernel;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0xE0AC8)]
 public unsafe partial struct Device {
-    // Client::Graphics::Kernel::Device::CallbackManager
-    [GenerateInterop]
-    [StructLayout(LayoutKind.Explicit, Size = 0x40)]
-    public unsafe partial struct CallbackManager {
-        // Unsure about the names of things inside CallbackManager though
-        [GenerateInterop]
-        [StructLayout(LayoutKind.Explicit, Size = 0x10)]
-        public unsafe partial struct Entry {
-            [FieldOffset(0x0)] public void* Function;
-            [FieldOffset(0x8)] public void* Context;
-        }
-
-        [FieldOffset(0x8)] public void* Lock; // CRITICAL_SECTION*
-
-        [FieldOffset(0x30)] public Entry* Entries;
-        [FieldOffset(0x38)] public uint Capacity;
-        [FieldOffset(0x3c)] public uint Count;
-    }
-
     [StaticAddress("48 8B 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 80 7B 08 00", 3, isPointer: true)]
     public static partial Device* Instance();
 
@@ -82,6 +63,23 @@ public unsafe partial struct Device {
     // /// A collection of the render command buffer array.
     // /// </summary>
     // public Span<RenderCommandBufferGroup> RenderCommandBufferGroups => new(RenderCommandBuffer, (int)RenderCommandBufferCount);
+
+    // Client::Graphics::Kernel::Device::CallbackManager
+    [StructLayout(LayoutKind.Explicit, Size = 0x40)]
+    public unsafe partial struct CallbackManager {
+        [FieldOffset(0x8)] public void* Lock; // CRITICAL_SECTION
+
+        [FieldOffset(0x30)] public Entry* Entries;
+        [FieldOffset(0x38)] public uint Capacity;
+        [FieldOffset(0x3C)] public uint Count;
+        
+        // Unsure about the names of things inside CallbackManager though
+        [StructLayout(LayoutKind.Explicit, Size = 0x10)]
+        public unsafe partial struct Entry {
+            [FieldOffset(0x0)] public void* Function;
+            [FieldOffset(0x8)] public void* Context;
+        }
+    }
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x10)]


### PR DESCRIPTION
This PR upstreams some DX device callback findings I've stumbled upon.

- `DeviceCallbacks` acts as a simple list of `DeviceCallback`, `DeviceDX11::Initialize` only ever creates ones with 4 slots.
- All `DeviceCallbacks` share the same vtbl with a single dtor freeing 0x40 bytes.
- Callback registration seems to be all over the place, might be the same listener add code inlined weirdly? Haven't looked too deep into this.
- I didn't find a good match in `data.yml` at a glance, thus I just named it `DeviceCallbacks` as it's graphics device specific callbacks.
- I haven't looked too deep into what each callback is used for, beyond the ones I needed myself. Sorry not sorry 😅
  - Framework listens to 0x28
  - RenderTargetManager listens to 0x30, 0x38, 0x40, 0x48
  - AgentMap, RaptureAtkModule, AgentConfigBase listen to 0xA10