### PR TITLE
Identify ReceiveEvent2

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkModuleInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkModuleInterface.cs
@@ -71,7 +71,11 @@ public unsafe partial struct AtkModuleInterface {
         [VirtualFunction(0)]
         public partial AtkValue* ReceiveEvent(AtkValue* returnValue, AtkValue* values, uint valueCount, ulong eventKind);
 
+        [VirtualFunction(1), Obsolete("Renamed to ReceiveEventWithResult")]
+        public partial AtkValue* ReceiveEvent2(AtkValue* returnValue, AtkValue* values, uint valueCount, ulong eventKind);
+
+        /// <remarks> Using FireCallbackWithResult, the return value is actually forwarded to the caller and might have a different ValueType besides bool. </remarks>
         [VirtualFunction(1)]
-        public partial AtkValue* ReceiveEvent2(AtkValue* returnValue, AtkValue* values, uint valueCount, ulong eventKind); // seems to handle user input validation? but... not always 🤔
+        public partial AtkValue* ReceiveEventWithResult(AtkValue* returnValue, AtkValue* values, uint valueCount, ulong eventKind);
     }
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -228,6 +228,10 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     [MemberFunction("E8 ?? ?? ?? ?? 0F B6 E8 8B 44 24 20")]
     public partial bool FireCallback(uint valueCount, AtkValue* values, bool close = false);
 
+    /// <remarks> Will call <see cref="AtkModuleInterface.AtkEventInterface.ReceiveEventWithResult(AtkValue*, AtkValue*, uint, ulong)"/> of the registered callback handler. </remarks>
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B C8 E8 ?? ?? ?? ?? 48 8D 4C 24 ?? 0F B6 F8")]
+    public partial AtkValue* FireCallbackWithResult(AtkValue* returnValue, uint valueCount, AtkValue* values);
+
     [MemberFunction("E8 ?? ?? ?? ?? 32 C0 88 45 67")]
     public partial void UpdateCollisionNodeList(bool clearFocus);
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -1061,6 +1061,7 @@ classes:
       - ea: 0x14205DCB0
     vfuncs:
       0: ReceiveEvent
+      1: ReceiveEventWithResult
   Component::GUI::AtkTextInput::AtkTextInputEventInterface:
     vtbls:
       - ea: 0x1420A4E00
@@ -8030,7 +8031,7 @@ classes:
       0x140650A70: Destructor
       0x140650F20: FireCallbackAndHideOrClose
       0x140650F30: FireCallbackInt  # this creates an int AtkValue and puts its argument into it before calling Callback
-      0x140651170: FireCallback2 # calls AtkEventInterface.ReceiveEvent2
+      0x140651170: FireCallbackWithResult # calls AtkEventInterface.ReceiveEventWithResult
       0x1406512D0: RegisterEvent
       0x140651310: UnregisterEvent
       0x140651360: SetPosition
@@ -8296,7 +8297,7 @@ classes:
       0x14068A3E0: HandleUnregisterAddonCallback # 1
       0x14068A430: HandleAddonAgentCallback # 2
       0x14068A680: HandleAddonEventCallback # 3 - unsure, used in AddonFadeMiddleBack to send an event to ScheduleManagement
-      0x14068A8B0: HandleAddonEventCallback2 # 4 - unsure, calls AtkEventInterface.ReceiveEvent2
+      0x14068A8B0: HandleAddonEventCallbackWithResult # 4 - calls AtkEventInterface.ReceiveEventWithResult
       0x14068A9A0: HandleSubscribeAtkArrayData # 5
       0x14068AA40: HandleUnsubscribeAtkArrayData # 6
       0x14068B220: HandleCalculateTextLength # 10


### PR DESCRIPTION
`ReceiveEventWithResult` (`ReceiveEvent2`) is allowed to return an AtkValue with a different ValueType besides bool, which is then returned by `FireCallbackWithResult` (`FireCallback2`) - something the `FireCallback` function does not do.