### PR TITLE
Identify ManagedVf0

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkManagedInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkManagedInterface.cs
@@ -6,8 +6,8 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 [GenerateInterop(isInherited: true)]
 [StructLayout(LayoutKind.Explicit, Size = 0x08)]
 public unsafe partial struct AtkManagedInterface {
-    // [VirtualFunction(0)]
-    // public partial void ManagedVf0(int command, nint a3, nint a4);
+    [VirtualFunction(0)]
+    public partial bool ManagedInvoke(int command, void* data, AtkResNode* node);
 
     [VirtualFunction(1)]
     public partial void ManagedHide();

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -17101,7 +17101,7 @@ classes:
     vtbls:
       - ea: 0x142103B18
     vfuncs:
-      0: ManagedVf0
+      0: ManagedInvoke
       1: ManagedHide
       2: GetManagedUnitBase
   Client::UI::Atk2DAreaMap:


### PR DESCRIPTION
- 0x140624E60:
	```c
	if ( v39->ManagedInvoke(v39, 0, tooltipArgs, targetNode) )
	```
	Called on the tooltip addons. Only AddonTooltip return true.
	- a3: `AtkTooltipArgs*`
	- a4: `AtkResNode*`

- 0x140656887 and other several places calling it for AddonFilter.
	- a3: `AtkUnitBase*`
	- a4: unused

- 0x140628331:
	```c
	v7 = a1->AttachedToAddon2->GetRootNode(a1->AttachedToAddon2);
	if ( ManagedInvoke(v3, 1, a1->AttachedToAddon2->OperationGuides, v7) )
	```
	- a3: `OperationGuide*`
	- a4: `AtkResNode*`

AddonScreenFrame calls Hide/Show on the addon depending on a2 with a3 and a4 unused.
AddonDialogue has `AtkValue*` in a3 and a4 is unused.