### PR TITLE
DrawObject outline offset

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/DrawObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/DrawObject.cs
@@ -1,3 +1,5 @@
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
+
 namespace FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 
 // Client::Graphics::Scene::DrawObject
@@ -10,14 +12,14 @@ public unsafe partial struct DrawObject {
     [BitField<bool>(nameof(IsCoveredFromRain), 4)]
     [FieldOffset(0x88)] public byte Flags;
 
-    /// <summary>
-    /// used in vanilla with Highlight Potential Targets, Housing object outlines. can be set by GameObject.Highlight
-    /// </summary>
-    /// <remarks>
-    /// (&amp; 0xF0) >> 4 == ObjectHighlightColor
-    /// &amp; 0x0F == other state (3 = Default)
-    /// </remarks>
+    [BitField<ObjectHighlightColor>(nameof(OutlineColor), 4, 4)]
     [FieldOffset(0x89)] public byte OutlineFlags;
+
+    /// <summary>
+    /// Used to highlight potential targets and housing object outlines.<br/>
+    /// To set the color it is recommended to use <see cref="GameObject.Highlight" />, as it makes sure that it also highlights a characters weapon(s), mount and ornament, if available.
+    /// </summary>
+    public partial ObjectHighlightColor OutlineColor { get; set; }
 
     public bool IsVisible {
         get => (Flags & 0x09) == 0x09; // Unsure why two bits and what exactly they mean.


### PR DESCRIPTION
have seen yellow outlines used in vanilla with the Highlight Potential Targets setting and during housing editing, but not sure of any uses of the other colors. lmk of any changes needed