### PR TITLE
Move Ghidra scripts from Jython to PyGhidra

### DIFF
--- a/Ghidra/Getting Started.md
+++ b/Ghidra/Getting Started.md
@@ -1,6 +1,8 @@
 # Pre-requisites
-Download and install [Ghidra](https://ghidra-sre.org/)
+Download and install [Ghidra](https://ghidra-sre.org/).  
 They have an installation guide and some additional depdendencies themselves (Java runtime).
+
+Afterwards, ensure that you can **launch PyGhidra.**
 
 # Getting started with a new project
 `File -> New Project` or press `Ctrl+N`<br>
@@ -38,15 +40,16 @@ Note that after each patch, you'll have to re-import, re-analyze, and re-run any
 <p align="center"><img src=".\images\Project Window Multi.png"></p>
 
 # Script dependency installation:
-We use [..\ida\ffxiv_idarename.py](../ida/ffxiv_idarename.py) to apply data.yml.  The same script works for both IDA and Ghidra, howver it's slightly more complicated in Ghidra as it uses an embedded version of jython.
+We use [..\ida\ffxiv_idarename.py](../ida/ffxiv_idarename.py) to apply data.yml.  The same script works for both IDA and Ghidra, howver it's slightly more complicated in Ghidra as we need to add dependencies to the PyGhidra environment manually.
 
-- Install a copy of [Python 2](https://www.python.org/downloads/).<br>
-Note: it has to be major version 2, so something like [Python 2.7.18](https://www.python.org/downloads/release/python-2718/) works.<br>
+- Install a copy of [Python 3](https://www.python.org/downloads/).<br>
+Note: it has to be major version 3, so something like [Python 3.14.3](https://www.python.org/downloads/release/python-3143/) works.<br>
 
-- Execute the following:<br>
-`python.exe -m pip install -t <YourGhidraFolder\>\Ghidra\Features\Jython\lib\Lib\site-packages pyyaml==5.4.1 anytree==2.8.0`<br>
-Note: this must be run from Python 2.  If you have multiple versions installed, you may need to qualify the path like:<br>
-`c:\Python27\python.exe -m pip install -t <YourGhidraFolder\>\Ghidra\Features\Jython\lib\Lib\site-packages pyyaml==5.4.1 anytree==2.8.0`
+- Check your PyGhidra log for "virtual environment" and copy the path. It should be something similar to this:<br>
+`/home/user/.config/ghidra/ghidra_VERSION/venv`
+
+- Execute the following, using the venv path from the log:<br>
+`.../venv/bin/python -m pip install pyyaml==6.0.3 anytree==2.13.0`
 
 - Open the Script Manager <p align="center"><img src=".\images\Open Script Manager.png"></p>
 

--- a/Ghidra/Getting Started.md
+++ b/Ghidra/Getting Started.md
@@ -45,11 +45,13 @@ We use [..\ida\ffxiv_idarename.py](../ida/ffxiv_idarename.py) to apply data.yml.
 - Install a copy of [Python 3](https://www.python.org/downloads/).<br>
 Note: it has to be major version 3, so something like [Python 3.14.3](https://www.python.org/downloads/release/python-3143/) works.<br>
 
-- Check your PyGhidra log for "virtual environment" and copy the path. It should be something similar to this:<br>
-`/home/user/.config/ghidra/ghidra_VERSION/venv`
+- **Check your PyGhidra log for which environment is being used.** For example, if you've using a "virtual environment", it should be something similar to either of the following two paths:<br>
+Windows: `%AppData%\ghidra\ghidra_VERSION\venv`<br>
+Linux: `/home/user/.config/ghidra/ghidra_VERSION/venv`
 
-- Execute the following, using the venv path from the log:<br>
-`.../venv/bin/python -m pip install pyyaml==6.0.3 anytree==2.13.0`
+- Execute the following in your terminal, using Python from the same environment as PyGhidra:<br>
+venv: `.../venv/bin/python -m pip install pyyaml==6.0.3 anytree==2.13.0`<br>
+system: `python -m pip install pyyaml==6.0.3 anytree==2.13.0`
 
 - Open the Script Manager <p align="center"><img src=".\images\Open Script Manager.png"></p>
 

--- a/ida/README.md
+++ b/ida/README.md
@@ -10,10 +10,7 @@ This could be either Python2 or Python3.
 Additionally, you will need to place "idauser.cfg" from this repository in "%AppData%\Hex-Rays\IDA Pro\". IDA doesn't allow you to use certain characters in names and this config changes that.
 
 #### Ghidra dependency installation:
-This is slightly more complicated as Ghidra uses an embedded version of Jython. 
-- Install a copy of Python2 from https://www.python.org/downloads/
-- Execute the following `python.exe -m pip install -t \<YourGhidraFolder\>\Ghidra\Features\Jython\lib\Lib\site-packages pyyaml==5.4.1 anytree==2.8.0`
-- Add `FFXIVClientStructs\ida` as a script directory.
+See [Getting Started](../Ghidra/Getting%20Started.md) for information on how to set up PyGhidra.
 
 ## ffxiv_sigmaker.py
 > [!WARNING]

--- a/ida/ffxiv_idarename.py
+++ b/ida/ffxiv_idarename.py
@@ -1,7 +1,7 @@
 # current exe version: 2020.12.29.0000.0000
 # @category __UserScripts
 # @menupath Tools.Scripts.ffxiv_idarename
-# @runtime Jython
+# @runtime PyGhidra
 
 from __future__ import print_function
 import os
@@ -330,6 +330,10 @@ if api is None:
     except ImportError:
         print("Warning: Unable to load Ghidra")
     else:
+        def toAddr(offset): # noqa
+            # type: (int) -> Address
+            return currentProgram.getAddressFactory().getDefaultAddressSpace().getAddress(offset) # noqa
+
         # noinspection PyUnresolvedReferences
         class GhidraApi(BaseApi):
             @property

--- a/ida/ffxiv_structimporter.py
+++ b/ida/ffxiv_structimporter.py
@@ -1,6 +1,6 @@
 # @category __UserScripts
 # @menupath Tools.Scripts.ffxiv_structimport
-# @runtime Jython
+# @runtime PyGhidra
 
 from yaml import load
 
@@ -707,6 +707,7 @@ if api is None:
         from ghidra.program.model.listing import *
         from ghidra.program.model.symbol import SourceType
         from ghidra.app.util import SymbolPathParser
+        from java.util import ArrayList
 
     except ImportError:
         print("Warning: Unable to load Ghidra")
@@ -816,13 +817,13 @@ if api is None:
                 return funcs.first if not funcs.size() == 0 else None
 
             def create_memberfunc_args(self, member_func):
-                # type: (DefinedStructMemFunc) -> list[ParameterImpl]
-                arg_vars = []
+                # type: (DefinedStructMemFunc) -> ArrayList
+                arg_vars = ArrayList()
                 for param in member_func.parameters:
                     dt = self.get_datatype(param.type)
                     if not dt:
-                        return []
-                    arg_vars.append(ParameterImpl(param.name, dt, currentProgram))
+                        return ArrayList()
+                    arg_vars.add(ParameterImpl(param.name, dt, currentProgram))
                 return arg_vars
 
             @property


### PR DESCRIPTION
Fedora doesn't even ship Python 2 packages anymore, which pushed me to the edge to figure out what's going wrong with PyGhidra, and from my testing:
- jpype picked the wrong overload on toAddr, so I simply wrapped it in a func that always explicitly casts to JLong first.
- FunctionDB.updateFunction was choking because jpype failed to turn Python lists into something that implements the Java List interface. Dunno if it's even meant to do that out of the box. Explicitly using ArrayList solves this.
