### PR TITLE
Fix AddonChatLog field name

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonChatLog.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonChatLog.cs
@@ -21,7 +21,8 @@ public unsafe partial struct AddonChatLog {
 
     [FieldOffset(0x508)] public AtkTextNode* CurrentChannelTextNode;
     [FieldOffset(0x510)] public AtkComponentNode* SettingsComponentNode;
-    [FieldOffset(0x518)] public AtkComponentNode* CloseComponentNode;
+    [FieldOffset(0x518)] public AtkComponentNode* NoviceNetworkComponentNode;
+    [FieldOffset(0x518), Obsolete("Named incorrectly, use NoviceNetworkComponentNode.")] public AtkComponentNode* CloseComponentNode;
     [FieldOffset(0x520)] public AtkNineGridNode* BackgroundNode;
     [FieldOffset(0x528)] public AtkComponentButton* ResizeButton;
     [FieldOffset(0x530)] public AtkComponentNode* AddTabComponentNode;


### PR DESCRIPTION
My mistake, it was in the same spot as the close button, but was just invisible.

It doesn't seem like the addon holds a reference to the close button.

Picture is of current incorrect name:
<img width="899" height="322" alt="image" src="https://github.com/user-attachments/assets/32bc4897-a81b-42fd-bfbc-1b0fa4ec8dce" />
