### PR TITLE
AtkUnitBase.RegisterEvent

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -265,6 +265,9 @@ public unsafe partial struct AtkUnitBase : ICreatable {
     [MemberFunction("E8 ?? ?? ?? ?? 4D 8B CF C6 44 24 ?? ?? 4C 8B C7"), GenerateStringOverloads]
     public partial void SaveAddonConfig(CStringPointer name, bool a2, bool a3);
 
+    [MemberFunction("E8 ?? ?? ?? ?? 8D 56 0C 48 8B CF")]
+    public partial void RegisterEvent(AtkEventType eventType, uint param, AtkEventListener* listener, AtkResNode* node);
+
     [VirtualFunction(3)]
     public partial bool Open(uint depthLayer);
 


### PR DESCRIPTION
IDA seems to think there's a return value, but I have not found it be used anywhere.

Address was already mapped in data.yml

```c
Component::GUI::AtkResNode *__fastcall Component::GUI::AtkUnitBase_RegisterEvent(
        Component::GUI::AtkUnitBase *a1,
        Component::GUI::AtkEventType a2,
        unsigned int a3,
        Component::GUI::AtkEventListener *listener,
        Component::GUI::AtkResNode *nodeParam)
{
  Component::GUI::AtkResNode *result; // rax

  result = a1->RootNode;
  if ( result )
    return Component::GUI::AtkEventManager_RegisterEvent(
             &result->AtkEventManager,
             a2,
             a3,
             nodeParam,
             result,
             listener,
             0);
  return result;
}
```