### PR TITLE
AtkComponentListItemPopulator Fix Incorrect Types

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentListItemPopulator.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentListItemPopulator.cs
@@ -3,22 +3,22 @@ namespace FFXIVClientStructs.FFXIV.Component.GUI;
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x18)]
 public unsafe partial struct AtkComponentListItemPopulator {
-    public delegate void PopulateWithRendererDelegate(AtkUnitBase* unitBase, int listItemIndex, AtkResNode** nodeList, AtkComponentListItemRenderer* listItemRenderer);
-    public delegate void PopulateDelegate(AtkUnitBase* unitBase, ListItemInfo* listItemInfo, AtkResNode** nodeList);
+    public delegate void PopulateWithRendererDelegate(AtkEventListener* eventListener, int listItemIndex, AtkResNode** nodeList, AtkComponentListItemRenderer* listItemRenderer);
+    public delegate void PopulateDelegate(AtkEventListener* eventListener, ListItemInfo* listItemInfo, AtkResNode** nodeList);
 
-    [FieldOffset(0x00)] public AtkUnitBase* UnitBase;
-    [FieldOffset(0x08)] public delegate* unmanaged<AtkUnitBase*, int, AtkResNode**, AtkComponentListItemRenderer*, void> PopulateWithRenderer;
-    [FieldOffset(0x10)] public delegate* unmanaged<AtkUnitBase*, ListItemInfo*, AtkResNode**, void> Populate;
+    [FieldOffset(0x00)] public AtkEventListener* UnitBase;
+    [FieldOffset(0x08)] public delegate* unmanaged<AtkEventListener*, int, AtkResNode**, AtkComponentListItemRenderer*, void> PopulateWithRenderer;
+    [FieldOffset(0x10)] public delegate* unmanaged<AtkEventListener*, ListItemInfo*, AtkResNode**, void> Populate;
 
     [MemberFunction("E8 ?? ?? ?? ?? 45 0F B6 CE 89 74 24")]
-    public partial AtkComponentListItemPopulator* CtorWithRenderer(AtkUnitBase* unitBase, delegate* unmanaged<AtkUnitBase*, int, AtkResNode**, AtkComponentListItemRenderer*, void> populateWithRenderer);
+    public partial AtkComponentListItemPopulator* CtorWithRenderer(AtkEventListener* eventListener, delegate* unmanaged<AtkEventListener*, int, AtkResNode**, AtkComponentListItemRenderer*, void> populateWithRenderer);
 
     [MemberFunction("E8 ?? ?? ?? ?? 45 0F B6 CD")]
-    public partial AtkComponentListItemPopulator* Ctor(AtkUnitBase* unitBase, delegate* unmanaged<AtkUnitBase*, ListItemInfo*, AtkResNode**, void> populate);
+    public partial AtkComponentListItemPopulator* Ctor(AtkEventListener* eventListener, delegate* unmanaged<AtkEventListener*, ListItemInfo*, AtkResNode**, void> populate);
 
     [StructLayout(LayoutKind.Explicit, Size = 0x10)]
     public struct ListItemInfo {
-        [FieldOffset(0)] public int ListItemIndex;
+        [FieldOffset(0x0)] public int ListItemIndex;
         [FieldOffset(0x8)] public AtkComponentTreeListItem* ListItem;
     }
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentListItemPopulator.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentListItemPopulator.cs
@@ -6,7 +6,7 @@ public unsafe partial struct AtkComponentListItemPopulator {
     public delegate void PopulateWithRendererDelegate(AtkEventListener* eventListener, int listItemIndex, AtkResNode** nodeList, AtkComponentListItemRenderer* listItemRenderer);
     public delegate void PopulateDelegate(AtkEventListener* eventListener, ListItemInfo* listItemInfo, AtkResNode** nodeList);
 
-    [FieldOffset(0x00)] public AtkEventListener* UnitBase;
+    [FieldOffset(0x00)] public AtkEventListener* EventListener;
     [FieldOffset(0x08)] public delegate* unmanaged<AtkEventListener*, int, AtkResNode**, AtkComponentListItemRenderer*, void> PopulateWithRenderer;
     [FieldOffset(0x10)] public delegate* unmanaged<AtkEventListener*, ListItemInfo*, AtkResNode**, void> Populate;
 


### PR DESCRIPTION
Through testing with AddonSelectString, it passes a PopupMenuDerive as the event listener, not an AtkUnitBase.