### PR TITLE
Restore IDisposable to AtkValue

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkValue.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkValue.cs
@@ -32,7 +32,7 @@ public enum AtkValueType {
 /// </summary>
 [GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x10)]
-public unsafe partial struct AtkValue {
+public unsafe partial struct AtkValue : IDisposable {
     [FieldOffset(0x0)] public AtkValueType Type;
 
     // union field
@@ -55,6 +55,15 @@ public unsafe partial struct AtkValue {
     }
 
     public AtkValue(AtkValue* other) => CtorCopy(other);
+
+    public void Dtor(bool free) => Dispose(free);
+
+    void IDisposable.Dispose() => Dispose(false);
+
+    private void Dispose(bool free) {
+        Dtor();
+        if (free) IMemorySpace.Free((AtkValue*)Unsafe.AsPointer(ref this));
+    }
 
     [MemberFunction("E8 ?? ?? ?? ?? EB ?? 83 CB ?? C7 45")]
     public partial AtkValue* CtorCopy(AtkValue* other);


### PR DESCRIPTION
This reverts commit 3d0b204f35546468cd42b58dd50425df44922c20.

I would appreciate an actual reasoning on why this was removed.

A common usage of AtkValue is as follows:
```cs
    using var returnValue = new AtkValue();
    var command = stackalloc AtkValue[commandValues.Length];

    for (var index = 0; index < commandValues.Length; index++)
    {
        command[index].SetInt(commandValues[index]);
    }

    agent.ReceiveEvent(&returnValue, command, (uint)commandValues.Length, eventKind);
```

I understand that using SetInt on the stackalloc'd AtkValues is probably not a good move given that they are not guaranteed to be zero initialized. That can be fixed easily by using a span, however, the single AtkValue `returnValue` poses no issue.