### PR TITLE
Add RentedAtkValues helper

### DIFF
--- a/FFXIVClientStructs/Interop/RentedAtkValues.cs
+++ b/FFXIVClientStructs/Interop/RentedAtkValues.cs
@@ -1,0 +1,30 @@
+using FFXIVClientStructs.FFXIV.Client.System.Memory;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace FFXIVClientStructs.Interop;
+
+public unsafe ref struct RentedAtkValues: IDisposable {
+    public AtkValue* Pointer;
+    public Span<AtkValue> Span;
+
+    public RentedAtkValues(int count) {
+        Pointer = (AtkValue*)MemoryPool.Alloc((ulong)(sizeof(AtkValue) * count));
+        Span = new Span<AtkValue>(Pointer, count);
+        Span.Clear();
+    }
+
+    public void Dispose() {
+        if (Pointer == null) return;
+
+        foreach (var value in Span)
+            value.Dtor();
+
+        MemoryPool.Free(Pointer);
+        Pointer = null;
+        Span = [];
+    }
+
+    public ref AtkValue this[int index] => ref Span[index];
+
+    public static implicit operator AtkValue*(RentedAtkValues rented) => rented.Pointer;
+}


### PR DESCRIPTION
This PR proposes to add a helper to create an array of AtkValues.
It clears the memory after allocating it and implements IDisposable for safe use of Managed types.
When the scope ends, the Dispose function calls the Dtor on all values, freeing their managed memory, and then the array itself.

Example:

```cs
var returnValue = new AtkValue();

using var values = new RentedAtkValues(2);
values[0].SetInt(1);
values[1].SetManagedString("Test String"u8);

ReceiveEvent(&returnValue, values, 2, 2);
```