### PR TITLE
Update Aetherflags

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGaugeEnums.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGaugeEnums.cs
@@ -67,10 +67,9 @@ public enum AetherFlags : byte {
     Aetherflow1 = 1 << 0,
     Aetherflow2 = 1 << 1,
     Aetherflow = Aetherflow1 | Aetherflow2,
-    IfritAttuned = 1 << 2,
-    TitanAttuned = 1 << 3,
-    GarudaAttuned = TitanAttuned | IfritAttuned,
-    PhoenixReady = 1 << 4,
+    PhoenixPrimed = 1 << 2,
+    SolarBahamutFirstPrimed = 1 << 3,
+    SolarBahamutSecondPrimed = PhoenixPrimed | SolarBahamutFirstPrimed,
     IfritReady = 1 << 5,
     TitanReady = 1 << 6,
     GarudaReady = 1 << 7


### PR DESCRIPTION
Update bits of the Aetherflags since they've been incorrectly attributed to the attunements (which is tracked via AttunementType instead) and instead indicate which demi-summon is "Primed" to fire off next.