### PR TITLE
Add 'Failed' status to WKSManager enum

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSManager.cs
@@ -61,5 +61,6 @@ public unsafe partial struct WKSManager {
         Bronze,
         Silver,
         Gold
+        Failed = 5,
     }
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSManager.cs
@@ -60,7 +60,7 @@ public unsafe partial struct WKSManager {
         None,
         Bronze,
         Silver,
-        Gold
+        Gold,
         Failed = 5,
     }
 }


### PR DESCRIPTION
Current rank returns `5` whenever you run out of time but also have failed to meet any of the ranks within a mission, so added it to the enums to give it a proper value