### PR TITLE
CompletionStatus adjust None

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLookingForGroup.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLookingForGroup.cs
@@ -171,7 +171,7 @@ public unsafe partial struct AgentLookingForGroup {
 
     [Flags]
     public enum CompletionStatus : byte {
-        None = 0,
+        None = 1 << 0,
         DutyComplete = 1 << 1,
         DutyIncomplete = 1 << 2,
         DutyCompleteWeeklyUnclaimed = 1 << 3,


### PR DESCRIPTION
Wasn't able to find a case where 0 is used by the game, instead no CompletionStatus set results always in a 1