### PR TITLE
Add ExitFromWindow to Framework

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
+++ b/FFXIVClientStructs/FFXIV/Client/System/Framework/Framework.cs
@@ -154,6 +154,9 @@ public unsafe partial struct Framework {
     [MemberFunction("89 51 ?? C6 41 ?? ?? 48 8B 0D")]
     public partial void Exit(int exitCode);
 
+    [MemberFunction("E8 ?? ?? ?? ?? 33 C0 E9 ?? ?? ?? ?? 48 8B 05")]
+    public partial void ExitFromWindow();
+
     [MemberFunction("E8 ?? ?? ?? ?? 80 7B 1D 01")]
     public partial UIModule* GetUIModule();
 

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4000,6 +4000,7 @@ classes:
     funcs:
       0x1400CEB10: ctor
       0x1400D1F30: Exit
+      0x1400D2B10: ExitFromWindow
       0x1400D2520: SetInactive
       0x1400D25E0: UpdateClipCursor
       0x1400D26E0: PauseResumeFrameTicks


### PR DESCRIPTION
Triggered by `WM_CLOSE` message in XIV's lpfnWndProc

<img width="863" height="266" alt="image" src="https://github.com/user-attachments/assets/57b364fe-8f57-4101-bcf8-1ab3c82a1471" />
