### PR TITLE
Fix Objective flag enum

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLookingForGroup.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentLookingForGroup.cs
@@ -163,10 +163,10 @@ public unsafe partial struct AgentLookingForGroup {
 
     [Flags]
     public enum Objective : byte {
-        None = 0,
-        DutyCompletion = 1 << 0,
-        Practice = 1 << 1,
-        Loot = 1 << 2,
+        None = 1 << 0,
+        DutyCompletion = 1 << 1,
+        Practice = 1 << 2,
+        Loot = 1 << 3,
     }
 
     [Flags]


### PR DESCRIPTION
Same as with `CompletionStatus`, None is now using 1.

Weird thing here is that Dalamud had this enum for 2+ years with the old order and i checked screenshots from before 7.5 using these values and working.
```cs
/// <summary>
/// Objective flags for the <see cref="PartyFinderGui"/> class.
/// </summary>
[Flags]
public enum ObjectiveFlags : uint
{
    /// <summary>
    /// No objective.
    /// </summary>
    None = 0,

    /// <summary>
    /// The duty completion objective.
    /// </summary>
    DutyCompletion = 1,

    /// <summary>
    /// The practice objective.
    /// </summary>
    Practice = 2,

    /// <summary>
    /// The loot objective.
    /// </summary>
    Loot = 4,
}
```