### PR TITLE
IsWalking updates for patch 7.5

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Control/Control.cs
@@ -13,7 +13,8 @@ public unsafe partial struct Control {
     [FieldOffset(0x00)] public CameraManager CameraManager;
     [FieldOffset(0x190)] public TargetSystem TargetSystem;
 
-    [FieldOffset(0x7633)] public bool IsWalking;
+    [FieldOffset(0x7518)] public bool IsWalkingDuringAutorun;
+    [FieldOffset(0x7637)] public bool IsWalking;
     [FieldOffset(0x7698)] public uint LocalPlayerEntityId;
     [FieldOffset(0x76A0)] public BattleChara* LocalPlayer;
     [FieldOffset(0x76B0)] public Matrix4x4 ViewProjectionMatrix;


### PR DESCRIPTION
Patch 7.5 updated the `IsWalking` offset in `Control` from `0x7633` to `0x7637`.
<img width="588" height="347" alt="2026-05-01_12-52-48" src="https://github.com/user-attachments/assets/2a1e7885-b41b-4294-a679-1259b9479ec2" />
<img width="591" height="347" alt="2026-05-01_12-52-32" src="https://github.com/user-attachments/assets/57a74910-94f0-4d25-b182-5cfd50b59d71" />

---

Also, adding the `IsWalkingDuringAutorun` offset (`0x7518`), which hasn't changed but has been brought up before
https://discord.com/channels/581875019861328007/1246473943548825730/1456338344891125790
<img width="593" height="310" alt="2026-05-01_13-03-57" src="https://github.com/user-attachments/assets/21ee05f0-9e3e-4baf-837e-be82ba378358" />
