### PR TITLE
Fix return type of TextModuleInterface.FormatUtf8String

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/Text/TextModuleInterface.cs
+++ b/FFXIVClientStructs/FFXIV/Component/Text/TextModuleInterface.cs
@@ -7,7 +7,7 @@ public unsafe partial struct TextModuleInterface {
     public partial StdDeque<TextParameter>* GetGlobalParameters();
 
     [VirtualFunction(3)]
-    public partial Utf8String* FormatUtf8String(Utf8String* input, StdDeque<TextParameter>* localParameters, Utf8String* output);
+    public partial bool FormatUtf8String(Utf8String* input, StdDeque<TextParameter>* localParameters, Utf8String* output);
 
     [VirtualFunction(7)]
     public partial Utf8String* EncodeString(Utf8String* ouput, Utf8String* input);


### PR DESCRIPTION
It's the return value of TextModuleInterface.FormatString.

Not sure exactly, since it looks like it's checked for -1 as int at `74 ?? 85 C0 74 ?? 83 F8 ?? 75 ?? 0F B6 D0`, but maybe that was their initialization value of the local variable.