### PR TITLE
AtkUnitBase bitfield update

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUnitBase.cs
@@ -73,6 +73,7 @@ public unsafe partial struct AtkUnitBase : ICreatable<AtkUnitBase> {
     [FieldOffset(0x1C0)] public float HideTransitionScale;
     [FieldOffset(0x1C4)] public float Scale;
     [BitField<bool>(nameof(EnableFilter), 2)]
+    [BitField<bool>(nameof(IgnoreUIDisplayMode), 4)] // if true, addon contents will remain visible when UI is hidden via Toggle UI Display Mode
     [BitField<bool>(nameof(DisableUserScaling), 11)] // sets Scale to 1.0
     [BitField<bool>(nameof(DisableUnfocusedCloseOnEsc), 20)] // if true, won't close on esc when unfocused
     [BitField<bool>(nameof(IsScalingWithGlobalUIScale), 21)] // multiplies scale by g_GlobalUIScale
@@ -153,6 +154,9 @@ public unsafe partial struct AtkUnitBase : ICreatable<AtkUnitBase> {
 
     /// <summary> Disables the "Scale Window" option in the title bar context menu </summary>
     public partial bool DisableUserScaling { get; set; }
+
+    /// <summary> Forces the addon to remain visible (but uninteractable) when using Toggle UI Display Mode </summary>
+    public partial bool IgnoreUIDisplayMode { get; set; }
 
     public uint DepthLayer {
         get => BitOps.GetBits(Flags198, 16, 0b1111u);


### PR DESCRIPTION
- adds IgnoreUIDisplayMode bool to AtkUnitBase
  - this takes the 0x10 position on Flags1C8 and, when set, forces UI elements which otherwise become temporarily hidden from the `Toggle UI Display Mode` vanilla hotkey to instead stay visible and uninteractive while the UI is disabled.
  - this can be found in use on vanilla addons with GroupPoseStampImage, used during GPose to keep stickers onscreen while UI is hidden

see [#clientstructs-dev](https://discord.com/channels/581875019861328007/1246473943548825730/1502819901989978224) discussion