### PR TITLE
Fix HousingFurniture.Stain offset

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/HousingFurniture.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/HousingFurniture.cs
@@ -5,8 +5,8 @@ namespace FFXIVClientStructs.FFXIV.Client.Game;
 [StructLayout(LayoutKind.Explicit, Size = 0x30)]
 public unsafe struct HousingFurniture {
     [FieldOffset(0x00)] public uint Id; // If Indoors: (0x20000 | Id) = HousingFurniture Row, If Outdoors: (0x30000 | Id) = HousingFurniture Row
-    [FieldOffset(0x04)] public byte Stain;
     [FieldOffset(0x10)] public Vector3 Position;
     [FieldOffset(0x20)] public float Rotation;
     [FieldOffset(0x24)] public int Index; // Index into the HousingObjectManager
+    [FieldOffset(0x28)] public byte Stain;
 }


### PR DESCRIPTION
The rest of the defined fields seem to have stayed the same so I'm not sure what prompted this shift.