### PR TITLE
Adding 3D render flag

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Render/Manager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Render/Manager.cs
@@ -18,6 +18,7 @@ public unsafe partial struct Manager {
     // [FieldOffset(0x2E160)] private UnknownRenderer UnknownRenderer; // 0x230 BGAmbient something?
     [FieldOffset(0x2E390)] public WaterRenderer WaterRenderer;
     [FieldOffset(0x2E910)] public VerticalFogRenderer VerticalFogRenderer;
+	[FieldOffset(0x38358)] public bool Is3DRenderingDisabled;
 
     // [FieldOffset(0x487F8)] private UnknownRenderer1 UnknownRenderer1; // 0xE0
     // [FieldOffset(0x488E0)] private UnknownRenderer2 UnknownRenderer2; // 0x7A10 Grass?


### PR DESCRIPTION
Setting this to true will take the render short path: It clears the back buffer with a solid color, runs post-effects and then returns, skipping all 3D world rendering.
I'm using this actively over around two months now and so far also some other users of it didn't report any problems either. It keeps my GPU load down to ~0-3% without any errors or crashes.

I would have added 0x3834C too as this seemed like a bitflag for Shader Init States, but I haven't grasped the full picture yet...

[FieldOffset(0x3834C)] public uint ShaderInitFlags;

somebody smarter with this needs to properly check that out, especially individual flags and the naming.

if you guys are fine with it though, I'd just push another PR to this one