### PR TITLE
Fix size issue in AgentRaidFinder

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRaidFinder.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentRaidFinder.cs
@@ -16,7 +16,7 @@ public partial struct AgentRaidFinder {
     [GenerateInterop]
     [StructLayout(LayoutKind.Explicit, Size = 0x110)]
     public partial struct TabData {
-        [FieldOffset(0x00), FixedSizeArray] internal FixedSizeArray5<TabEntryData> _entries;
+        [FieldOffset(0x00), FixedSizeArray] internal FixedSizeArray8<TabEntryData> _entries;
 
         [FieldOffset(0xA0)] public int EntryCount;
 


### PR DESCRIPTION
It's definitely at least 6, as the current ultimate tab uses 6 entries.
The mentioned sub_140C815F0 `E8 ?? ?? ?? ?? BE E0 01 00 00` seems to indicate it is 8:
`if ( (unsigned int)v17 < 8 )`