### PR TITLE
Change Unk5 to LockedInList in EnemyListNumberArray

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Arrays/EnemyListNumberArray.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Arrays/EnemyListNumberArray.cs
@@ -39,6 +39,6 @@ public unsafe partial struct EnemyListNumberArray {
         [FieldOffset(2 * 4)] public int CastPercent;
         [FieldOffset(3 * 4)] public int EntityId;
         [FieldOffset(4 * 4)] public bool ActiveInList;
-        [FieldOffset(5 * 4)] private int Unk5;
+        [FieldOffset(5 * 4)] public bool LockedInList;
     }
 }


### PR DESCRIPTION
from AgentHud.UpdateEnemyList

will check if the BattleChara has a status with Flags 42. if so then write in enemylist and locked the node from being interacted with.

a typical (maybe also only) example is Sanduruva from Tower of Zot

<img width="1095" height="553" alt="image" src="https://github.com/user-attachments/assets/96b92621-fd09-44dd-8982-82788135db5e" />
