### PR TITLE
Rename AtkValueType.String8 to ConstString

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkValue.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkValue.cs
@@ -9,9 +9,9 @@ public enum AtkValueType {
     UInt = 0x5,
     UInt64 = 0x6,
     Float = 0x7,
-    String = 0x8, // 1 byte per character (ASCII/UTF-8)
-    WideString = 0x9, // 2 bytes per character (UTF-16)
-    String8 = 0xA, // assumed to be a const char*
+    String = 0x8, // char*
+    WideString = 0x9, // wchar_t* or char16_t*
+    ConstString = 0xA, // const char*
     Vector = 0xB,
     Pointer = 0xC,
     AtkValues = 0xD,
@@ -21,6 +21,8 @@ public enum AtkValueType {
     Managed = 0x20,
     ManagedString = Managed | String,
     ManagedVector = Managed | Vector,
+
+    [Obsolete("Renamed to ConstString")] String8 = 0xA,
 }
 
 /// <summary>

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2710,8 +2710,8 @@ classes:
       0x140636FC0: GetInt
       0x140637000: GetUInt  # these two could be backwards
       0x140637040: GetFloat
-      0x140637060: GetManagedString
-      0x140637080: GetString
+      0x140637060: GetString
+      0x140637080: GetConstString
       0x1406370A0: SetManagedString
       0x140637130: Copy # = operator
       0x1406371A0: EqualTo # == operator


### PR DESCRIPTION
It straight up copies the pointer in `AddonArmouryBoard_OnRefresh` (`0x141325E62`), for example.
That further confirms that the type has to be a `const char*`.

And the `GetManagedString` function is just returning a `char*`, doesn't matter if it's managed or not, so I renamed it to `GetString`.
The other function, previously called `GetString`, seems to be used for `String8`/`ConstString` types, so I renamed that to `GetConstString`.