### PR TITLE
Fix ExcelSheet

### DIFF
--- a/FFXIVClientStructs/FFXIV/Common/Component/Excel/ExcelSheet.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Component/Excel/ExcelSheet.cs
@@ -35,7 +35,7 @@ public unsafe partial struct ExcelSheet {
     public partial uint GetAllocatedRowCount();
 
     [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8B F9 48 8D 74 24")]
-    public partial IExcelRowWrapper* GetRowByDescriptor(ExcelRowDescriptor* descriptor, uint* outErrorCode = null);
+    public partial IExcelRowWrapper* GetRowByDescriptor(ExcelRowDescriptor* descriptor, uint* outErrorCode = null); // No xref possibly inlined somewhere
 
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 4F ?? 49 89 44 0E")]
     public partial IExcelRowWrapper* GetSubRowByDescriptor(ExcelRowDescriptor* descriptor, uint* outErrorCode = null);

--- a/FFXIVClientStructs/FFXIV/Common/Component/Excel/ExcelSheet.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Component/Excel/ExcelSheet.cs
@@ -34,8 +34,14 @@ public unsafe partial struct ExcelSheet {
     [MemberFunction("E8 ?? ?? ?? ?? 8B D0 BD")]
     public partial uint GetAllocatedRowCount();
 
-    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 4F ?? 49 89 44 0E")]
+    [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8B F9 48 8D 74 24")]
     public partial IExcelRowWrapper* GetRowByDescriptor(ExcelRowDescriptor* descriptor, uint* outErrorCode = null);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 4F ?? 49 89 44 0E")]
+    public partial IExcelRowWrapper* GetSubRowByDescriptor(ExcelRowDescriptor* descriptor, uint* outErrorCode = null);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 48 85 C0 74 ?? B0 ?? EB")]
+    public partial IExcelRowWrapper* GetRowByIndex(uint rowIndex, ExcelRowDescriptor* descriptor);
 
     [MemberFunction("E8 ?? ?? ?? ?? 8B D3 48 8B F8")]
     public partial IExcelRowWrapper* GetRowById(uint rowId, uint* outErrorCode = null);

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -4776,7 +4776,8 @@ classes:
       0x14207D4D0: GetSubRowByDescriptor
       0x14207D610: GetRowById
       0x14207D750: GetColumnStringByDescriptor
-      0x14207D960: GetRowByDescriptor
+      0x14207D960: GetRowByIndex
+      0x14207D9D0: GetRowByDescriptor
       0x14207DB00: GetSheetName
       0x14207DB10: GetColumnOffset
       0x14207DBC0: GetColumnIndex2


### PR DESCRIPTION
- GetRowByDescriptor was actually GetSubRowByDescriptor
- Add the real GetRowByDescriptor (no xrefs)
- Add GetRowByIndex