### PR TITLE
Add CurrentDataCenterCharacters to LobbyUIClient

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/LobbyUIClient.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/LobbyUIClient.cs
@@ -1,4 +1,5 @@
 using FFXIVClientStructs.FFXIV.Application.Network.LobbyClient;
+using FFXIVClientStructs.FFXIV.Application.Network.WorkDefinitions;
 using FFXIVClientStructs.FFXIV.Client.Network;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
@@ -17,6 +18,8 @@ public unsafe partial struct LobbyUIClient {
     [FieldOffset(0x30)] public StdVector<LobbyDataCenterWorldEntry> CurrentDataCenterWorlds;
 
     [FieldOffset(0x48)] public LobbySubscriptionInfo* SubscriptionInfo;
+
+    [FieldOffset(0xF8)] public StdVector<LobbyUIClientCharacterEntry> CurrentDataCenterCharacters;
 }
 
 [GenerateInterop]
@@ -38,4 +41,28 @@ public struct LobbySubscriptionInfo // name probably totally wrong
     [FieldOffset(0x30)] public uint TotalDaysSubscribed;
     [FieldOffset(0x34)] public uint DaysRemaining;
     [FieldOffset(0x38)] public uint DaysUntilNextVeteranRank;
+}
+
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0x758)]
+public unsafe partial struct LobbyUIClientCharacterEntry {
+    [FieldOffset(0x08)] public ulong ContentId;
+    [FieldOffset(0x10)] public byte Index;
+    [FieldOffset(0x11)] public CharaSelectCharacterEntryLoginFlags LoginFlags;
+
+    [FieldOffset(0x18)] public ushort CurrentWorldId;
+    [FieldOffset(0x1A)] public ushort HomeWorldId;
+
+    [FieldOffset(0x2C), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _name;
+    [FieldOffset(0x4C), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _currentWorldName;
+    [FieldOffset(0x6C), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _homeWorldName;
+    [FieldOffset(0x8C), FixedSizeArray(isString: true)] internal FixedSizeArray1024<byte> _rawJson;
+
+    [FieldOffset(0x4C0)] public ClientSelectData ClientSelectData;
+    [FieldOffset(0x600)] public ClientSelectData ClientSelectData2;
+
+    [FieldOffset(0x740)] public ulong ContentIdMirror;
+    [FieldOffset(0x748)] public byte Flag;
+    [FieldOffset(0x74C)] private int Unk74C;
+    [FieldOffset(0x750)] public byte DeletedFlag;
 }


### PR DESCRIPTION
other findings:
`sub_1404AA330` - rebuild all character infos cache of current data center from network packet
`LobbyUIClient::vf28` - network callback, character list received. then trigger sub_1404AA330
`LobbyUIClient::vf30` - network callback, logged in. then trigger sub_1404AA330
`LobbyUIClient::vf33` - network callback, character deleted. then trigger sub_1404AA330