### PR TITLE
Add RepresentationContainer

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/Character.cs
@@ -31,6 +31,7 @@ public unsafe partial struct Character {
 
     // 0x1AA8: start of some substructure
     [FieldOffset(0x1B28)] public ModelContainer ModelContainer;
+    [FieldOffset(0x1B80)] public RepresentationContainer RepresentationContainer;
 
     /// <remarks> Instance ID of an Event NPC. Used by QuestEventHandler. Seen for Event NPCs that turn into Battle NPCs (during quests, for example.) </remarks>
     [FieldOffset(0x1BC0)] public uint EventNpcInstanceId;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Character/RepresentationContainer.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Character/RepresentationContainer.cs
@@ -1,0 +1,22 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game.Character;
+
+// Client::Game::Character::RepresentationContainer
+//   Client::Game::Character::ContainerInterface
+[GenerateInterop]
+[Inherits<ContainerInterface>]
+[StructLayout(LayoutKind.Explicit, Size = 0x30)]
+public unsafe partial struct RepresentationContainer {
+    // not 100% on these
+    // 1 = Normal
+    // 2 = (Skips everything??)
+    // 3 = Blacklisted (using NameOverride)
+    // 4 = Alliance Member, Friend, in Custom Match or in Duel
+    // 5 = Cross-realm Party Member
+    [FieldOffset(0x10)] public byte NameType;
+
+    [FieldOffset(0x18)] public Utf8String* NameOverride; // "Unknown"
+    [FieldOffset(0x20)] public float UpdateTimer;
+    [FieldOffset(0x24)] private byte Unk24;
+    [FieldOffset(0x25)] private ushort Unk25; // some flags based on Status
+    [FieldOffset(0x28)] private byte Unk28; // some flags for Scheduler
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/RaptureAtkModule.cs
@@ -151,6 +151,7 @@ public unsafe partial struct RaptureAtkModule {
         [FieldOffset(0x24)] public uint ClassJobId;
         [FieldOffset(0x2C)] public uint Icon;
         [FieldOffset(0x30)] public Utf8String Name;
+        [FieldOffset(0x98)] public byte* NameOverride;
         [FieldOffset(0xA0)] public Utf8String FcName;
         [FieldOffset(0x108)] public Utf8String Title;
         [FieldOffset(0x170)] public Utf8String DisplayTitle;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -11533,7 +11533,6 @@ classes:
     funcs:
       0x1408D87E0: ctor
       0x140896A90: IsValidClientObject
-      0x1408D4DC0: CalculateMovementSpeedMultiplier
       0x14090C660: GetVfxDuration
       0x140907910: GetGMRank
       0x140908620: GetPartMasterId
@@ -11670,14 +11669,15 @@ classes:
       # 0x1413136A0: ctor # inlined at 0x1408CF5C4
       0x1408A8CD0: GetCompanionDataID
       0x1408A8AE0: SetupCompanion
-  Client::Game::Character::BlacklistProxyContainer: # real name is unknown, probably has nothing to do with blacklist
+  Client::Game::Character::RepresentationContainer:
     vtbls:
       - ea: 0x14218C398
         base: Client::Game::Character::ContainerInterface
     funcs:
+      0x1408D4D80: SendTitleIdUpdate
+      0x1408D4DC0: CalculateMovementSpeedMultiplier
       0x1408D53A0: FreezeMotion
       0x1408D56D0: ResumeMotion
-      0x1408D4D80: SendTitleIdUpdate
   Client::Game::Character::ContainerInterface:
     vtbls:
       - ea: 0x14218C148


### PR DESCRIPTION
Tried to give this a new/better name than BlacklistProxyContainer. 🤷‍♂️
It seems to serve to following functionalities:

- Sends Title id of local player when changing titles.
- Logs a message and shows a ScreenImage when a player learned a new Black Mage (and most likely Beastmaster*) spell. (*empty columns)
- Determines the name type and sets NameOverride to "Unknown" when the player is blacklisted.
- Determines the movement speed and freezes/unfreezes motion when certain statuses are applied.