### PR TITLE
Change WKSMission Score type from ushort to uint

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSMissionModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/WKS/WKSMissionModule.cs
@@ -20,7 +20,7 @@ public unsafe partial struct WKSMissionModule {
         /// <remarks> RowId of WKSMissionUnit sheet. </remarks>
         [FieldOffset(0x00)] public ushort MissionUnitRowId;
 
-        [FieldOffset(0x0C)] public ushort Score; // TODO: uint
+        [FieldOffset(0x0C)] public uint Score;
 
         [FieldOffset(0x10)] public MissionRank Rank;
         [FieldOffset(0x14)] private byte Unk14; // bool? status?


### PR DESCRIPTION
WAs marked with a // TODO originally, doesn't properly return right with the new cosmic missions that go above the ushort limit