### PR TITLE
Optimize Resolver

### DIFF
--- a/InteropGenerator.Runtime/Resolver.cs
+++ b/InteropGenerator.Runtime/Resolver.cs
@@ -160,15 +160,15 @@ public sealed class Resolver {
                 var addresses = group.ToArray();
                 bucketLengths[firstByte] = addresses.Length;
 
-                int ulongCount = addresses.Sum(x => x.Address.Bytes.Length) * 2;
+                var ulongCount = addresses.Sum(x => x.Address.Bytes.Length) * 2;
 
                 buckets[firstByte] = (BucketAddressEntry*)NativeMemory.Alloc((nuint)addresses.Length * (nuint)sizeof(BucketAddressEntry));
                 bucketData[firstByte] = (ulong*)NativeMemory.Alloc((nuint)ulongCount * sizeof(ulong));
 
-                ulong* dataPtr = bucketData[firstByte];
-                for (int i = 0; i < addresses.Length; i++) {
+                var dataPtr = bucketData[firstByte];
+                for (var i = 0; i < addresses.Length; i++) {
                     var address = addresses[i];
-                    int bytesLen = address.Address.Bytes.Length;
+                    var bytesLen = address.Address.Bytes.Length;
 
                     buckets[firstByte][i] = new BucketAddressEntry {
                         ValuePtr = &addressValues[address.GlobalIndex],
@@ -192,7 +192,7 @@ public sealed class Resolver {
             var textPtr = (byte*)_targetSpace + _textSectionOffset;
 
             Parallel.ForEach(partitioner, (range, loopState) => {
-                for (int location = range.Item1; !loopState.IsStopped && location < range.Item2; location++) {
+                for (var location = range.Item1; !loopState.IsStopped && location < range.Item2; location++) {
                     var currentByte = textPtr[location];
                     var bucket = buckets[currentByte];
                     if (bucket == null)
@@ -204,7 +204,7 @@ public sealed class Resolver {
 
                     var targetLocationAsUlong = (ulong*)(textPtr + location);
 
-                    for (int i = 0; i < bucketLength; i++) {
+                    for (var i = 0; i < bucketLength; i++) {
                         ref readonly var target = ref bucket[i];
                         if (*target.ValuePtr != 0)
                             continue;
@@ -220,7 +220,7 @@ public sealed class Resolver {
 
                         var outLocation = location;
                         var originalAddress = remainingAddresses[target.AddressIndex];
-                        foreach (ushort relOffset in originalAddress.RelativeFollowOffsets) {
+                        foreach (var relOffset in originalAddress.RelativeFollowOffsets) {
                             var relativeOffset = *(int*)(textPtr + outLocation + relOffset);
                             outLocation = outLocation + relOffset + 4 + relativeOffset;
                         }
@@ -237,7 +237,7 @@ public sealed class Resolver {
                 }
             });
 
-            for (int i = 0; i < remainingAddresses.Length; i++) {
+            for (var i = 0; i < remainingAddresses.Length; i++) {
                 var foundAddress = addressValues[i];
 
                 if (foundAddress != 0) {
@@ -245,7 +245,7 @@ public sealed class Resolver {
 
                     address.Value = foundAddress;
 
-                    int outLocation = (int)(foundAddress - _baseAddress - _textSectionOffset);
+                    var outLocation = (int)(foundAddress - _baseAddress - _textSectionOffset);
                     if (_resolverCache?.Cache.TryAdd(address.CacheKey, outLocation + _textSectionOffset) == true)
                         _cacheChanged |= true;
                 }
@@ -253,7 +253,7 @@ public sealed class Resolver {
         } finally {
             NativeMemory.Free(addressValues);
 
-            for (int i = 0; i < 256; i++) {
+            for (var i = 0; i < 256; i++) {
                 if (buckets[i] != null)
                     NativeMemory.Free(buckets[i]);
 
@@ -265,7 +265,7 @@ public sealed class Resolver {
         SaveCache();
     }
 
-    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    [StructLayout(LayoutKind.Sequential)]
     private unsafe struct BucketAddressEntry {
         public nint* ValuePtr;
         public ulong* BytesPtr;

--- a/InteropGenerator.Runtime/Resolver.cs
+++ b/InteropGenerator.Runtime/Resolver.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace InteropGenerator.Runtime;
@@ -139,66 +140,138 @@ public sealed class Resolver {
         if (_resolverCache is not null && ResolveFromCache())
             return;
 
-        var remainingAddresses = Addresses.Where(a => a.Value == 0);
-        int remainingCount = remainingAddresses.Count();
+        var remainingAddresses = Addresses.Where(a => a.Value == 0).ToArray();
+        var remainingCount = remainingAddresses.Length;
         if (remainingCount == 0)
             return;
 
-        var buckets = new Address[256][];
-        foreach (var group in remainingAddresses.GroupBy(a => (byte)a.Bytes[0]))
-            buckets[group.Key] = [.. group];
+        var addressValues = (nint*)NativeMemory.AllocZeroed((nuint)remainingCount * (nuint)sizeof(nint));
+        var buckets = new BucketAddressEntry*[256];
+        var bucketData = new ulong*[256];
+        var bucketLengths = new int[256]; // the amount of addresses in a bucket
 
-        var partitioner = Partitioner.Create(0, _textSectionSize, _textSectionSize / Environment.ProcessorCount);
+        try {
+            var grouped = remainingAddresses
+                .Select((addr, idx) => new { Address = addr, GlobalIndex = idx })
+                .GroupBy(item => (byte)item.Address.Bytes[0]);
 
-        Parallel.ForEach(partitioner, (range, loopState) => {
+            foreach (var group in grouped) {
+                byte firstByte = group.Key;
+                var addresses = group.ToArray();
+                bucketLengths[firstByte] = addresses.Length;
+
+                int ulongCount = addresses.Sum(x => x.Address.Bytes.Length) * 2;
+
+                buckets[firstByte] = (BucketAddressEntry*)NativeMemory.Alloc((nuint)addresses.Length * (nuint)sizeof(BucketAddressEntry));
+                bucketData[firstByte] = (ulong*)NativeMemory.Alloc((nuint)ulongCount * sizeof(ulong));
+
+                ulong* dataPtr = bucketData[firstByte];
+                for (int i = 0; i < addresses.Length; i++) {
+                    var address = addresses[i];
+                    int bytesLen = address.Address.Bytes.Length;
+
+                    buckets[firstByte][i] = new BucketAddressEntry {
+                        ValuePtr = &addressValues[address.GlobalIndex],
+                        BytesPtr = dataPtr,
+                        MaskPtr = dataPtr + bytesLen,
+                        BytesLen = bytesLen,
+                        AddressIndex = address.GlobalIndex
+                    };
+
+                    fixed (ulong* pSrcBytes = address.Address.Bytes)
+                    fixed (ulong* pSrcMask = address.Address.Mask) {
+                        Buffer.MemoryCopy(pSrcBytes, dataPtr, bytesLen * sizeof(ulong), bytesLen * sizeof(ulong));
+                        Buffer.MemoryCopy(pSrcMask, dataPtr + bytesLen, bytesLen * sizeof(ulong), bytesLen * sizeof(ulong));
+                    }
+
+                    dataPtr += bytesLen * 2;
+                }
+            }
+
+            var partitioner = Partitioner.Create(0, _textSectionSize, _textSectionSize / Environment.ProcessorCount);
             var textPtr = (byte*)_targetSpace + _textSectionOffset;
 
-            for (int location = range.Item1; !loopState.IsStopped && location < range.Item2; location++) {
-                var currentByte = textPtr[location];
-                var bucket = buckets[currentByte];
-                if (bucket is null)
-                    continue;
-
-                var targetLocationAsUlong = (ulong*)(textPtr + location);
-
-                for (int i = 0; i < bucket.Length; i++) {
-                    var address = bucket[i];
-                    if (Volatile.Read(ref address.Value) != 0)
+            Parallel.ForEach(partitioner, (range, loopState) => {
+                for (int location = range.Item1; !loopState.IsStopped && location < range.Item2; location++) {
+                    var currentByte = textPtr[location];
+                    var bucket = buckets[currentByte];
+                    if (bucket == null)
                         continue;
 
-                    int count;
-                    var length = address.Bytes.Length;
-
-                    for (count = 0; count < length; count++) {
-                        if ((address.Mask[count] & address.Bytes[count]) != (address.Mask[count] & targetLocationAsUlong[count]))
-                            break;
-                    }
-
-                    if (count != length)
+                    var bucketLength = bucketLengths[currentByte];
+                    if (bucketLength == 0)
                         continue;
 
-                    int outLocation = location;
-                    foreach (ushort relOffset in address.RelativeFollowOffsets) {
-                        int relativeOffset = *(int*)(textPtr + outLocation + relOffset);
-                        outLocation = outLocation + relOffset + 4 + relativeOffset;
-                    }
+                    var targetLocationAsUlong = (ulong*)(textPtr + location);
 
-                    nint finalAddress = _baseAddress + _textSectionOffset + outLocation;
+                    for (int i = 0; i < bucketLength; i++) {
+                        ref readonly var target = ref bucket[i];
+                        if (*target.ValuePtr != 0)
+                            continue;
 
-                    if (Interlocked.CompareExchange(ref address.Value, finalAddress, 0) == 0) {
-                        if (_resolverCache?.Cache.TryAdd(address.CacheKey, outLocation + _textSectionOffset) == true)
-                            _cacheChanged |= true;
+                        int count;
+                        for (count = 0; count < target.BytesLen; count++) {
+                            if ((target.MaskPtr[count] & target.BytesPtr[count]) != (target.MaskPtr[count] & targetLocationAsUlong[count]))
+                                break;
+                        }
 
-                        if (Interlocked.Decrement(ref remainingCount) == 0) {
-                            loopState.Stop();
-                            return;
+                        if (count != target.BytesLen)
+                            continue;
+
+                        var outLocation = location;
+                        var originalAddress = remainingAddresses[target.AddressIndex];
+                        foreach (ushort relOffset in originalAddress.RelativeFollowOffsets) {
+                            var relativeOffset = *(int*)(textPtr + outLocation + relOffset);
+                            outLocation = outLocation + relOffset + 4 + relativeOffset;
+                        }
+
+                        var finalAddress = _baseAddress + _textSectionOffset + outLocation;
+
+                        if (Interlocked.CompareExchange(ref *target.ValuePtr, finalAddress, 0) == 0) {
+                            if (Interlocked.Decrement(ref remainingCount) == 0) {
+                                loopState.Stop();
+                                return;
+                            }
                         }
                     }
                 }
+            });
+
+            for (int i = 0; i < remainingAddresses.Length; i++) {
+                var foundAddress = addressValues[i];
+
+                if (foundAddress != 0) {
+                    var address = remainingAddresses[i];
+
+                    address.Value = foundAddress;
+
+                    int outLocation = (int)(foundAddress - _baseAddress - _textSectionOffset);
+                    if (_resolverCache?.Cache.TryAdd(address.CacheKey, outLocation + _textSectionOffset) == true)
+                        _cacheChanged |= true;
+                }
             }
-        });
+        } finally {
+            NativeMemory.Free(addressValues);
+
+            for (int i = 0; i < 256; i++) {
+                if (buckets[i] != null)
+                    NativeMemory.Free(buckets[i]);
+
+                if (bucketData[i] != null)
+                    NativeMemory.Free(bucketData[i]);
+            }
+        }
 
         SaveCache();
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    private unsafe struct BucketAddressEntry {
+        public nint* ValuePtr;
+        public ulong* BytesPtr;
+        public ulong* MaskPtr;
+        public int BytesLen;
+        public int AddressIndex;
     }
 
     public void RegisterAddress(Address address) {

--- a/InteropGenerator.Runtime/Resolver.cs
+++ b/InteropGenerator.Runtime/Resolver.cs
@@ -153,7 +153,7 @@ public sealed class Resolver {
         Parallel.ForEach(partitioner, (range, loopState) => {
             var textPtr = (byte*)_targetSpace + _textSectionOffset;
 
-            for (int location = range.Item1; location < range.Item2; location++) {
+            for (int location = range.Item1; !loopState.IsStopped && location < range.Item2; location++) {
                 var currentByte = textPtr[location];
                 var bucket = buckets[currentByte];
                 if (bucket is null)

--- a/InteropGenerator.Runtime/Resolver.cs
+++ b/InteropGenerator.Runtime/Resolver.cs
@@ -1,14 +1,11 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace InteropGenerator.Runtime;
 
 public sealed class Resolver {
     private static readonly Lazy<Resolver> Instance = new(() => new Resolver());
-
-    private readonly List<Address>?[] _preResolveArray = new List<Address>[256];
 
     public readonly HashSet<Address> Addresses = new();
 
@@ -25,7 +22,6 @@ public sealed class Resolver {
 
     private int _textSectionOffset;
     private int _textSectionSize;
-    private int _totalBuckets;
 
     private Resolver() {
     }
@@ -90,87 +86,85 @@ public sealed class Resolver {
         var sectionCursor = sectionHeader;
         for (var i = 0; i < numSections; i++) {
             var sectionName = BitConverter.ToInt64(sectionCursor);
-
-            // .text
-            if (sectionName == 0x747865742E) {
-                // .text
+            if (sectionName == 0x747865742E) { // .text
                 _textSectionOffset = BitConverter.ToInt32(sectionCursor.Slice(12, 4));
                 _textSectionSize = BitConverter.ToInt32(sectionCursor.Slice(8, 4));
+                break;
             }
 
             sectionCursor = sectionCursor[40..]; // advance by 40
         }
     }
-    private void LoadCache(string version) {
-        if (_cacheFile is not { Exists: true }) {
-            _resolverCache = new ResolverCache(version, new ConcurrentDictionary<string, long>());
-            return;
-        }
 
+    private void LoadCache(string version) {
         try {
-            var json = File.ReadAllText(_cacheFile.FullName);
-            _resolverCache = JsonSerializer.Deserialize(json, ResolverCacheSerializerContext.Default.ResolverCache);
-            if (_resolverCache is null ||
-                _resolverCache.Version != version)
-                _resolverCache = new ResolverCache(version, new ConcurrentDictionary<string, long>());
-        } catch {
-            _resolverCache = new ResolverCache(version, new ConcurrentDictionary<string, long>());
-        }
+            if (_cacheFile is { Exists: true }) {
+                using var file = File.OpenRead(_cacheFile.FullName);
+                _resolverCache = JsonSerializer.Deserialize(file, ResolverCacheSerializerContext.Default.ResolverCache);
+
+                if (_resolverCache?.Version == version)
+                    return;
+            }
+        } catch { }
+
+        _resolverCache = new ResolverCache(version, new ConcurrentDictionary<string, long>());
     }
 
     private void SaveCache() {
-        if (_cacheFile == null || _resolverCache == null || _cacheChanged == false)
+        if (_cacheFile == null || _resolverCache == null || !_cacheChanged)
             return;
+
         var json = JsonSerializer.Serialize(_resolverCache, ResolverCacheSerializerContext.Default.ResolverCache);
         if (string.IsNullOrWhiteSpace(json))
             return;
+
         if (_cacheFile.Directory is { Exists: false })
             Directory.CreateDirectory(_cacheFile.Directory.FullName);
+
         File.WriteAllText(_cacheFile.FullName, json);
     }
 
     private bool ResolveFromCache() {
         foreach (var address in Addresses) {
-            if (address.Value == 0) {
-                if (_resolverCache!.Cache.TryGetValue(address.CacheKey, out var offset)) {
-                    address.Value = (nint)(offset + _baseAddress);
-                    var firstByte = (byte)address.Bytes[0];
-                    if (_preResolveArray[firstByte] != null) {
-                        _preResolveArray[firstByte]!.Remove(address);
-                        if (_preResolveArray[firstByte]!.Count == 0) {
-                            _preResolveArray[firstByte] = null;
-                            _totalBuckets--;
-                        }
-                    }
-                }
-            }
+            if (address.Value == 0 && _resolverCache!.Cache.TryGetValue(address.CacheKey, out var offset))
+                address.Value = (nint)(offset + _baseAddress);
         }
-
         return Addresses.All(a => a.Value != 0);
     }
 
-    // This function is a bit messy, but everything to make it cleaner is slower, so don't bother.
     public unsafe void Resolve() {
         if (_targetSpace == 0)
-            throw new Exception("[FFXIVClientStructs.Resolver] Attempted to call Resolve() without initializing the search space.");
+            throw new Exception("[InteropGenerator.Runtime.Resolver] Attempted to call Resolve() without initializing the search space.");
 
-        if (_resolverCache is not null) {
-            if (ResolveFromCache())
-                return;
-        }
+        if (_resolverCache is not null && ResolveFromCache())
+            return;
 
-        var targetSpan = new ReadOnlySpan<byte>(_targetSpace.ToPointer(), _targetLength)[_textSectionOffset..];
+        var remainingAddresses = Addresses.Where(a => a.Value == 0);
+        int remainingCount = remainingAddresses.Count();
+        if (remainingCount == 0)
+            return;
 
-        for (var location = 0; location < _textSectionSize; location++) {
-            if (_preResolveArray[targetSpan[location]] is not null) {
-                var availableAddresses = _preResolveArray[targetSpan[location]]!.ToArray();
+        var buckets = new Address[256][];
+        foreach (var group in remainingAddresses.GroupBy(a => (byte)a.Bytes[0]))
+            buckets[group.Key] = [.. group];
 
-                var targetLocationAsUlong = MemoryMarshal.Cast<byte, ulong>(targetSpan[location..]);
+        var partitioner = Partitioner.Create(0, _textSectionSize, _textSectionSize / Environment.ProcessorCount);
 
-                var avLen = availableAddresses.Length;
+        Parallel.ForEach(partitioner, (range, loopState) => {
+            var textPtr = (byte*)_targetSpace + _textSectionOffset;
 
-                for (var i = 0; i < avLen; i++) {
-                    var address = availableAddresses[i];
+            for (int location = range.Item1; location < range.Item2; location++) {
+                var currentByte = textPtr[location];
+                var bucket = buckets[currentByte];
+                if (bucket is null)
+                    continue;
+
+                var targetLocationAsUlong = (ulong*)(textPtr + location);
+
+                for (int i = 0; i < bucket.Length; i++) {
+                    var address = bucket[i];
+                    if (Volatile.Read(ref address.Value) != 0)
+                        continue;
 
                     int count;
                     var length = address.Bytes.Length;
@@ -180,61 +174,38 @@ public sealed class Resolver {
                             break;
                     }
 
-                    if (count == length) {
-                        var outLocation = location;
+                    if (count != length)
+                        continue;
 
-                        foreach (var relOffset in address.RelativeFollowOffsets) {
-                            var relativeOffset =
-                                BitConverter.ToInt32(targetSpan.Slice(outLocation + relOffset, 4));
-                            outLocation = outLocation + relOffset + 4 + relativeOffset;
-                        }
+                    int outLocation = location;
+                    foreach (ushort relOffset in address.RelativeFollowOffsets) {
+                        int relativeOffset = *(int*)(textPtr + outLocation + relOffset);
+                        outLocation = outLocation + relOffset + 4 + relativeOffset;
+                    }
 
-                        address.Value = _baseAddress + _textSectionOffset + outLocation;
+                    nint finalAddress = _baseAddress + _textSectionOffset + outLocation;
 
+                    if (Interlocked.CompareExchange(ref address.Value, finalAddress, 0) == 0) {
                         if (_resolverCache?.Cache.TryAdd(address.CacheKey, outLocation + _textSectionOffset) == true)
-                            _cacheChanged = true;
+                            _cacheChanged |= true;
 
-                        _preResolveArray[targetSpan[location]]!.Remove(address);
-                        if (_preResolveArray[targetSpan[location]]!.Count == 0) {
-                            _preResolveArray[targetSpan[location]] = null;
-                            _totalBuckets--;
-                            if (_totalBuckets == 0)
-                                goto outLoop;
+                        if (Interlocked.Decrement(ref remainingCount) == 0) {
+                            loopState.Stop();
+                            return;
                         }
                     }
                 }
             }
-        }
-outLoop:;
+        });
 
         SaveCache();
     }
 
     public void RegisterAddress(Address address) {
-        if (Addresses.Add(address)) {
-            var firstByte = (byte)address.Bytes[0];
-
-            if (_preResolveArray[firstByte] is null) {
-                _preResolveArray[firstByte] = new List<Address>();
-                _totalBuckets++;
-            }
-
-            _preResolveArray[firstByte]!.Add(address);
-        }
+        Addresses.Add(address);
     }
 
     public void UnregisterAddress(Address address) {
-        if (Addresses.Remove(address) &&
-            address.Value != 0) {
-            var firstByte = (byte)address.Bytes[0];
-
-            if (_preResolveArray[firstByte] != null) {
-                _preResolveArray[firstByte]!.Remove(address);
-                if (_preResolveArray[firstByte]!.Count == 0) {
-                    _preResolveArray[firstByte] = null;
-                    _totalBuckets--;
-                }
-            }
-        }
+        Addresses.Remove(address);
     }
 }


### PR DESCRIPTION
The Resolver can be made faster using `Parallel.ForEach`, avoiding `List` operations and array allocations in the loop, and by aligning data in memory.
On my machine (12 cores/24 threads), this implementation reduces the time to resolve without cache from 2857ms to 224ms.
I have checked the resulting json and all signatures are resolving correctly. 🥳