### PR TITLE
Event Object animations!!

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
@@ -62,6 +62,22 @@ public unsafe partial struct EventHandler {
     [VirtualFunction(209)]
     public partial uint GetNameplateIconForObject(GameObject* gameObject);
 
+    /// <summary>Changes the currently playing timelines based on the difference between oldSharedTimelineState and newSharedTimelineState.</summary>
+    /// <param name="gameObject">The game object to update.</param>
+    /// <param name="oldSharedTimelineState">The new SharedTimelineState value.</param>
+    /// <param name="newSharedTimelineState">The old SharedTimelineState value.</param>
+    /// <param name="timelineIndices">Seems to modify newSharedTimelineState in in some EventHandlers.</param>
+    [VirtualFunction(253)]
+    public partial void UpdateSharedTimelineState(GameObject* gameObject, ushort oldSharedTimelineState, ushort newSharedTimelineState, ulong timelineIndices);
+
+    /// <summary>Changes the currently playing timelines based on a bitmask.</summary>
+    /// <param name="gameObject">The game object to update.</param>
+    /// <param name="sharedTimelineState">The new SharedTimelineState value.</param>
+    /// <param name="bitmask">The new timeline bitmask.</param>
+    /// <param name="unused">Unused and can be left empty.</param>
+    [VirtualFunction(254)]
+    public partial void UpdateTimelinesByBitmask(GameObject* gameObject, uint sharedTimelineState, uint bitmask, ulong unused);
+
     [VirtualFunction(258)]
     public partial void GetDescription(Utf8String* outDescription);
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
@@ -45,7 +45,7 @@ public unsafe partial struct ContentDirector {
 
     [StructLayout(LayoutKind.Explicit, Size = 0xC)]
     public struct MapEffectItem {
-        [FieldOffset(0x00)] public uint LayoutId; // ContentDirectorManagedSG.Unknown0
+        [FieldOffset(0x00)] public uint LayoutId;
         [FieldOffset(0x05)] public byte Unknown1; // ContentDirectorManagedSG.Unknown1
         [FieldOffset(0x08)] public ushort State;
         [FieldOffset(0x0A)] public byte Flags;

--- a/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
@@ -34,6 +34,19 @@ public unsafe partial struct ContentDirector {
     [VirtualFunction(329)]
     public partial uint GetContentTimeMax();
 
+    /// <summary>Changes the state of a map effect.</summary>
+    /// <param name="index">Index into MapEffects.</param>
+    /// <param name="state">The new state for this MapEffect.</param>
+    /// <param name="timelineIndex">Which timeline to play.</param>
+    [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 8B FA 41 0F B7 E8")]
+    public partial void ApplyMapEffect(uint index, ushort state, ushort timelineIndex);
+
+    /// <summary>Handles changes the timeline for a map effect</summary>
+    /// <param name="index">Index into MapEffects.</param>
+    /// <param name="timelineIndex">Which timeline to play.</param>
+    [MemberFunction("E8 ?? ?? ?? ?? 3A C3 74 ?? 44 0F B7 C5")]
+    public partial bool PlayMapEffectTimeline(uint index, ushort timelineIndex);
+
     [GenerateInterop]
     [StructLayout(LayoutKind.Explicit, Size = 0x608)]
     public partial struct MapEffectList {

--- a/FFXIVClientStructs/FFXIV/Client/Game/Network/MapEffectPacket.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Network/MapEffectPacket.cs
@@ -1,0 +1,11 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game.Network;
+
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0x10)]
+public partial struct MapEffectPacket {
+    [FieldOffset(0x00)] public uint EventId;
+    [FieldOffset(0x04)] public ushort State;
+    [FieldOffset(0x06)] public ushort TimelineIndex;
+    /// <remarks> Which map effect this applies to. </remarks>
+    [FieldOffset(0x08)] public byte Index;
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/EventObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/EventObject.cs
@@ -12,12 +12,28 @@ public unsafe partial struct EventObject {
     [FieldOffset(0x1A8), CExporterExcel("ExportedSG")] public nint ExportedSGRowPtr;
     [FieldOffset(0x1B2)] public ushort SharedTimelineState; // ActorControl category 0x199 (SetSharedTimelineState) sets this field
     [FieldOffset(0x1B8)] public byte Flags;
-
+    /// <summary>Changes the currently playing timelines based on a bitmask.</summary>
+    /// <param name="sharedTimelineState">Only sets SharedTimelineState, does not have any other effect in this function.</param>
+    /// <param name="bitmask">Each bit represents a timeline index in the SharedGroup. Setting a bit means play, an unset bit means stop.</param>
+    /// <param name="unknown">Unused, can be left as zero.</param>
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 4D 85 F6 0F 84 ?? ?? ?? ?? 8B 44 24 70 BE ?? ?? ?? ??")]
-    public partial void PlayAnimation(uint entityId, uint actionId, ulong unknown);
+    public partial void PlayAnimation(uint sharedTimelineState, uint bitmask, ulong unknown);
+
+    /// <summary>Changes the currently playing timelines based on a bitmask.</summary>
+    /// <param name="sharedTimelineState">The new SharedTimelineState value.</param>
+    /// <param name="bitmask">The new timeline bitmask.</param>
+    [MemberFunction("48 89 5C 24 ?? 41 56 48 83 EC ?? 48 89 6C 24 ?? 44 0F B7 F2")]
+    public partial void UpdateTimelinesByBitmask(ushort sharedTimelineState, uint bitmask);
 
     /// <param name="outHandlers">Should point to array that can fit up to 32 pointers.</param>
     /// <returns>Num elements filled.</returns>
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 4D 85 F6 0F 84 ?? ?? ?? ?? 8B 44 24 70 BE ?? ?? ?? ??")]
     public partial int GetEventHandlers(EventHandler** outHandlers);
+
+    /// <summary>Changes the currently playing timelines based on the difference between oldSharedTimelineState and newSharedTimelineState.</summary>
+    /// <param name="sharedTimelineState">The new SharedTimelineState value.</param>
+    /// <param name="checkIfLayoutReady">If we should check if the layout is ready before continuing.</param>
+    /// <param name="unused">Unused and can be left empty.</param>
+    [MemberFunction("E8 ?? ?? ?? ?? 49 8B 06 44 0F B6 C5")]
+    public partial void SetSharedTimelineState(ushort sharedTimelineState, bool checkIfLayoutReady, ulong unused);
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/EventObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/EventObject.cs
@@ -1,3 +1,5 @@
+using EventHandler = FFXIVClientStructs.FFXIV.Client.Game.Event.EventHandler;
+
 namespace FFXIVClientStructs.FFXIV.Client.Game.Object;
 
 // Client::Game::Object::EventObject
@@ -5,7 +7,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Object;
 [GenerateInterop]
 [Inherits<GameObject>]
 [StructLayout(LayoutKind.Explicit, Size = 0x1C0)]
-public partial struct EventObject {
+public unsafe partial struct EventObject {
     [FieldOffset(0x1A0), CExporterExcel("EObj")] public nint EObjRowPtr;
     [FieldOffset(0x1A8), CExporterExcel("ExportedSG")] public nint ExportedSGRowPtr;
     [FieldOffset(0x1B2)] public ushort SharedTimelineState; // ActorControl category 0x199 (SetSharedTimelineState) sets this field
@@ -13,4 +15,9 @@ public partial struct EventObject {
 
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 4D 85 F6 0F 84 ?? ?? ?? ?? 8B 44 24 70 BE ?? ?? ?? ??")]
     public partial void PlayAnimation(uint entityId, uint actionId, ulong unknown);
+
+    /// <param name="outHandlers">Should point to array that can fit up to 32 pointers.</param>
+    /// <returns>Num elements filled.</returns>
+    [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 4D 85 F6 0F 84 ?? ?? ?? ?? 8B 44 24 70 BE ?? ?? ?? ??")]
+    public partial int GetEventHandlers(EventHandler** outHandlers);
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -253,6 +253,10 @@ public unsafe partial struct GameObject {
     [MemberFunction("E8 ?? ?? ?? ?? 48 85 FF 0F 84 ?? ?? ?? ?? F3 0F 10 97")]
     public partial Vector3* GetNamePlateWorldPosition(Vector3* vector);
 
+    /// <summary>If we have a SharedGroupLayoutInstance and it's loaded.</summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 ?? 33 FF 48 89 B4 24")]
+    public partial bool IsSharedGroupLoaded();
+
     [StructLayout(LayoutKind.Explicit, Size = 0x08)]
     public struct NamePlateColors {
         [FieldOffset(0x00), CExporterIgnore] public ulong Data;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -124,6 +124,18 @@ public unsafe partial struct GameObject {
     [VirtualFunction(17)]
     public partial void SetDrawObject(DrawObject* drawObject);
 
+    /// <summary> Start playing this timeline. </summary>
+    [VirtualFunction(20)]
+    public partial bool PlayTimeline(uint index, uint a2);
+
+    /// <summary> Stops this timeline's playback. </summary>
+    [VirtualFunction(21)]
+    public partial bool StopTimeline(uint index);
+
+    /// <summary> Checks if this timeline is currently playing. </summary>
+    [VirtualFunction(22)]
+    public partial bool IsTimelinePlaying(uint index);
+
     [VirtualFunction(23)]
     public partial DrawObject* GetDrawObject();
 
@@ -146,6 +158,12 @@ public unsafe partial struct GameObject {
 
     [VirtualFunction(48)]
     public partial uint GetNameId();
+
+    /// <summary>Changes the currently playing timelines based on the difference between oldSharedTimelineState and newSharedTimelineState.</summary>
+    /// <param name="oldSharedTimelineState">The old SharedTimelineState value.</param>
+    /// <param name="newSharedTimelineState">The new SharedTimelineState value.</param>
+    [VirtualFunction(49)]
+    public partial void UpdateSharedTimelineState(ushort oldSharedTimelineState, ushort newSharedTimelineState);
 
     [VirtualFunction(54)]
     public partial TargetType GetTargetType();

--- a/FFXIVClientStructs/FFXIV/Client/LayoutEngine/Group/SharedGroupLayoutInstance.cs
+++ b/FFXIVClientStructs/FFXIV/Client/LayoutEngine/Group/SharedGroupLayoutInstance.cs
@@ -46,7 +46,11 @@ public unsafe partial struct SharedGroupLayoutInstance {
     [FieldOffset(0x120)] public uint PrefabFlags1; // 0x1 = load started; 0x3 = load failed or contents added; 0x4 = failed to add contents
     [FieldOffset(0x12C)] public uint PrefabFlags2; // 0x8 = colliders active
 
-    // [FieldOffset(0x14C), FixedSizeArray] internal FixedSizeArray16<byte> _timelineIndices; // used by EventObjAnimation ActorControl packet, some kind of simple lookup table
+    /// <remarks>Used by EventObjAnimation ActorControl packet, it's some kind of simple lookup table.</remarks>
+    [FieldOffset(0x154), FixedSizeArray] internal FixedSizeArray16<byte> _timelineIndices;
+
+    /// <remarks> Set in PlayAnimation, it's an index into TimelineIndices.</remarks>
+    [FieldOffset(0x16D)] public byte PlayingTimelineIndex;
 
     [MemberFunction("E8 ?? ?? ?? ?? 41 FF C7 4D 8D 76 ?? 44 3B 7B")]
     public partial bool InitAnimationHandlers(void* fileData);
@@ -70,6 +74,26 @@ public unsafe partial struct SharedGroupLayoutInstance {
     /// <returns>The sRGB color for the given object stain.</returns>
     [MemberFunction("33 C0 81 F9 ?? ?? ?? ?? 0F 42 C1")]
     public static partial ByteColor* GetObjectStainColorByIndex(byte stainIndex);
+
+    /// <summary> Checks if this timeline is currently playing. </summary>
+    /// <summary> Stops this timeline's playback. </summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 85 EF 74 ?? 84 C0")]
+    public partial bool IsTimelinePlaying(uint index);
+
+    /// <summary> Stops this timeline's playback. </summary>
+    /// <param name="index">Index into TimelineIndices.</param>
+    [MemberFunction("E8 ?? ?? ?? ?? EB ?? 41 80 F9")]
+    public partial bool StopTimeline(uint index);
+
+    /// <summary> Start playing this timeline. </summary>
+    /// <param name="index">Index into TimelineIndices.</param>
+    [MemberFunction("E8 ?? ?? ?? ?? 0F B6 B6")]
+    public partial bool PlayTimeline(uint index, uint a1);
+
+    /// <summary> Checks if the timeline index is in range, and actually backed by something. </summary>
+    /// <param name="index">Index into TimelineIndices.</param>
+    [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 ?? 3B FD")]
+    public partial bool IsTimelineIndexValid(uint index);
 
     /// <summary>
     /// Attempts to set the stain on the models in this group.

--- a/FFXIVClientStructs/FFXIV/Client/LayoutEngine/Group/SharedGroupLayoutInstance.cs
+++ b/FFXIVClientStructs/FFXIV/Client/LayoutEngine/Group/SharedGroupLayoutInstance.cs
@@ -87,6 +87,7 @@ public unsafe partial struct SharedGroupLayoutInstance {
 
     /// <summary> Start playing this timeline. </summary>
     /// <param name="index">Index into TimelineIndices.</param>
+    /// <param name="a1"></param>
     [MemberFunction("E8 ?? ?? ?? ?? 0F B6 B6")]
     public partial bool PlayTimeline(uint index, uint a1);
 

--- a/FFXIVClientStructs/FFXIV/Client/LayoutEngine/ILayoutInstance.cs
+++ b/FFXIVClientStructs/FFXIV/Client/LayoutEngine/ILayoutInstance.cs
@@ -69,6 +69,10 @@ public unsafe partial struct ILayoutInstance {
     [VirtualFunction(21)]
     public partial bool HavePrimary();
 
+    /// <summary>If the primary object has been loaded.</summary>
+    [VirtualFunction(21)]
+    public partial bool IsPrimaryLoaded();
+
     [VirtualFunction(23)]
     public partial Graphics.Scene.Object* GetGraphics();
 
@@ -150,6 +154,10 @@ public unsafe partial struct ILayoutInstance {
 
     [VirtualFunction(72)]
     public partial Vector4* GetBoundingSphereImpl(Vector4* result);
+
+    /// <summary>If we have a primary object and its been loaded. Basically HavePrimary() and IsPrimaryLoaded() in one call.</summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 3C ?? 75 ?? 8B D5")]
+    public partial bool IsPrimaryReady();
 
     // vf73: getWorldBB, uses AABB with padded vec3's
     // vf74: get transform split into RT matrix + scale

--- a/FFXIVClientStructs/FFXIV/Client/Network/PacketDispatcher.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Network/PacketDispatcher.cs
@@ -93,6 +93,9 @@ public unsafe partial struct PacketDispatcher {
     [MemberFunction("40 53 57 48 81 EC ?? ?? ?? ?? 48 8B FA 8B")]
     public static partial void HandleActorCastPacket(uint entityId, ActorCastPacket* packet);
 
+    [MemberFunction("E8 ?? ?? ?? ?? B0 ?? 48 8B 5C 24 ?? 48 8B 74 24 ?? 48 83 C4 ?? 5F C3 0F B6 7B")]
+    public static partial void HandleMapEffectPacket(MapEffectPacket* packet);
+
     [VirtualFunction(1)]
     public partial void OnReceivePacket(uint targetId, nint packet);
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -9636,6 +9636,7 @@ classes:
       17: GetTransform
       18: SetTransform
       21: HavePrimary
+      22: IsPrimaryLoaded
       23: GetGraphics
       24: GetGraphics2
       25: SetGraphics
@@ -9663,6 +9664,8 @@ classes:
       70: GetTransformImpl
       71: SetTransformImpl
       72: GetBoundingSphereImpl
+    funcs:
+      0x1406FA0E0: IsPrimaryReady
   Client::LayoutEngine::LayoutWorld:
     instances:
       - ea: 0x142A8BB60
@@ -11641,6 +11644,7 @@ classes:
       0x1408985D0: UpdateVisualRotation
       0x140898780: UpdateVisualScale
       0x140898AB0: GetEventHandlers
+      0x1408991E0: IsSharedGroupLoaded
       0x140899230: IsReadyToDraw
       0x140899B70: SetEventId
       0x140899BE0: SetFateId

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -11613,7 +11613,6 @@ classes:
       24: GetCharacterBase
       25: UpdateRadius
       26: Highlight
-      #30: TryGetEventHandler
       30: GetEventHandlersImpl
       34: SetReadyToDraw
       36: Update

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -9873,6 +9873,10 @@ classes:
       0x1407077C0: InitAnimationHandlers
       0x1407071A0: InitTimelines
       0x1406FE9F0: ReapplyStain
+      0x1407065C0: IsTimelineIndexValid
+      0x140706420: PlayTimeline
+      0x140706520: StopTimeline
+      0x1407065F0: IsTimelinePlaying
       0x1407985B0: GetObjectStainColorByIndex # static
   Client::LayoutEngine::Layer::TreasureLayoutInstance:
     vtbls:
@@ -11609,6 +11613,9 @@ classes:
       15: SetTargetStatus
       16: SetDistance
       17: SetDrawObject
+      20: PlayTimeline
+      21: StopTimeline
+      22: IsTimelinePlaying
       23: GetDrawObject
       24: GetCharacterBase
       25: UpdateRadius
@@ -11618,6 +11625,7 @@ classes:
       36: Update
       47: GetCenterPosition
       48: GetNameId
+      49: UpdateSharedTimelineState
       54: GetTargetType
       55: PositionModified
       56: RotationModified
@@ -16037,6 +16045,8 @@ classes:
       232: GetOccupiedConditionId
       233: GetOccupiedPermissionId
       251: GetScriptVersion
+      253: UpdateSharedTimelineState
+      254: UpdateTimelinesByBitmask
       258: GetDescription
       259: GetReliefText
       260: GetTimeRemaining # pass current unix timestamp as a2
@@ -26223,7 +26233,9 @@ classes:
         base: Client::Game::Object::GameObject
     funcs:
       0x140898A40: GetEventHandlers
+      0x14174DCC0: SetSharedTimelineState
       0x14174DE10: PlayAnimation
+      0x14174DF40: UpdateTimelinesByBitmask
   Client::Game::Object::Treasure:
     vtbls:
       - ea: 0x1422C5020

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -26222,6 +26222,7 @@ classes:
       - ea: 0x1422C4DB0
         base: Client::Game::Object::GameObject
     funcs:
+      0x140898A40: GetEventHandlers
       0x14174DE10: PlayAnimation
   Client::Game::Object::Treasure:
     vtbls:

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -18003,6 +18003,7 @@ classes:
     funcs:
       0x140B6D8A0: ctor
       0x140B6F470: ApplyMapEffect
+      0x140B6F2E0: PlayMapEffectTimeline
       0x140B703F0: IsPlayCutscene
   Client::Game::InstanceContent::InstanceContentDirector:
     vtbls:


### PR DESCRIPTION
This whole system has been confusing me for a while, so I started documenting the functions I found in the disassembly the best I could. Now I have... this - which is adding a bunch of random crap so methods like EventObject.PlayAnimation can look like this :heart_eyes:

```c
void Client::Game::Object::EventObject.PlayAnimation
               (EventObject *this,uint sharedTimelineState,uint bitmask,ulonglong unknown)

{
  byte *pbVar1;
  char cVar2;
  int numEventHandlers;
  uint uVar3;
  uint index;
  undefined1 auStackY_168 [32];
  EventHandler *eventHandlers [32];
  ulonglong local_38;
  
  local_38 = g_StackCookie ^ (ulonglong)auStackY_168;
  numEventHandlers = Client::Game::Object::EventObject.GetEventHandlers(this,eventHandlers);
  if (numEventHandlers == 0) {
    cVar2 = Client::Game::Object::GameObject.IsSharedGroupLoaded((GameObject *)this);
    if (cVar2 != '\0') {
      index = 0;
      uVar3 = 1;
      do {
        cVar2 = (*((this->Union).VTable)->IsTimelinePlaying)((GameObject *)this,index);
        if ((uVar3 & bitmask & 0xffff) == 0) {
          if (cVar2 == '\x01') {
            (*((this->Union).VTable)->StopTimeline)((GameObject *)this,index);
          }
        }
        else if (cVar2 == '\0') {
          (*((this->Union).VTable)->PlayTimeline)((GameObject *)this,index,0);
        }
        index = index + 1;
        uVar3 = uVar3 << 1 | (uint)((int)uVar3 < 0);
      } while (index < 0x10);
    }
    if (this->SharedTimelineState != (ushort)sharedTimelineState) {
      this->SharedTimelineState = (ushort)sharedTimelineState;
    }
  }
  else {
    (*eventHandlers[0]->VTable->UpdateTimelinesByBitmask)
              (eventHandlers[0],(GameObject *)this,sharedTimelineState & 0xffff,bitmask & 0xffff,
               unknown);
  }
  cVar2 = Client::Game::Object::GameObject.IsSharedGroupLoaded((GameObject *)this);
  if (cVar2 == '\0') {
    pbVar1 = (byte *)((longlong)&this->Union + 0x9b);
    *pbVar1 = *pbVar1 | 8;
    this->Flags = 0;
  }
  return;
}
``` 

This PR looks bigger than it really is, `SharedGroupLayoutInstance` and `EventObject` duplicate a bunch of API surface and then also through `EventHandler`. I almost certainly made a mistake somewhere because they can't decide whether indices are shorts or ints, and there's a billion functions with the word `Timeline` in them. I tried to break up the commits so someone could be pulled though.

Thanks to https://github.com/aers/FFXIVClientStructs/pull/1851 for figuring out that this is a bitmask, I took some of their documentation.
