### PR TITLE
Untangle visibility, targetable, and other fields in spawn packets

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Network/SpawnPackets.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Network/SpawnPackets.cs
@@ -122,9 +122,11 @@ public partial struct CommonSpawnData {
 [StructLayout(LayoutKind.Explicit, Size = 0x40)]
 public struct SpawnObjectPacket {
     [FieldOffset(0x00)] public byte ObjectIndex;
-    [FieldOffset(0x01)] public byte ObjectKind;
-    [FieldOffset(0x02)] public byte TargetableStatus;
-    [FieldOffset(0x03)] public byte Visibility;
+    [FieldOffset(0x01)] public byte ObjectKind; // TODO: Use ObjectKind enum
+    [FieldOffset(0x02), Obsolete("Use IsTargetable")] public byte TargetableStatus;
+    [FieldOffset(0x02)] public bool IsTargetable;
+    [FieldOffset(0x03), Obsolete("Use IsHidden")] public byte Visibility;
+    [FieldOffset(0x03)] public bool IsHidden;
     /// <remarks> <see cref="HousingObjectId"/> when <see cref="ObjectKind.HousingEventObject"/>. </remarks>
     [FieldOffset(0x04)] public uint BaseId;
     [FieldOffset(0x08)] public uint EntityId;
@@ -136,16 +138,15 @@ public struct SpawnObjectPacket {
     /// <remarks> Used for <see cref="ObjectKind.EventObj"/>. </remarks>
     [FieldOffset(0x18)] public uint GimmickId;
     [FieldOffset(0x1C)] public float Radius;
-    [FieldOffset(0x20)] private ushort Unk20; // SharedGroupTimelineState?
     [FieldOffset(0x22)] public ushort Rotation;
     /// <remarks> Used for <see cref="ObjectKind.EventObj"/>. </remarks>
     [FieldOffset(0x24)] public ushort FateId;
     /// <remarks> Used for <see cref="ObjectKind.EventObj"/>. </remarks>
     [FieldOffset(0x26)] public byte EventState;
-    [FieldOffset(0x27)] private byte Unk27;
-    [FieldOffset(0x28)] private uint Unk28;
-    [FieldOffset(0x2C)] private uint Unk2C;
-    [FieldOffset(0x30)] private uint Unk30;
+    /// <remarks> Used by <see cref="ObjectKind.GatheringPoint"/>, <see cref="ObjectKind.EventObj"/>, <see cref="ObjectKind.AreaObject"/>. </remarks>
+    [FieldOffset(0x2C)] public uint Arg1;
+    /// <remarks> Used by <see cref="ObjectKind.GatheringPoint"/>, <see cref="ObjectKind.EventObj"/>, <see cref="ObjectKind.HousingEventObject"/>. </remarks>
+    [FieldOffset(0x30)] public uint Arg2;
     [FieldOffset(0x34)] public float PositionX;
     [FieldOffset(0x38)] public float PositionY;
     [FieldOffset(0x3C)] public float PositionZ;
@@ -161,15 +162,17 @@ public partial struct SpawnTreasurePacket {
     [FieldOffset(0x0E)] public byte ObjectIndex;
     [FieldOffset(0x0F)] public byte ItemCount;
     [FieldOffset(0x10)] public byte EventState;
-    [FieldOffset(0x11)] public byte CofferKind;
-    [FieldOffset(0x12)] public byte Visibility;
+    [FieldOffset(0x11)] public byte CofferKind; // TODO: Change to Treasure.TreasureKind
+    [FieldOffset(0x12), Obsolete("Use IsHidden")] public byte Visibility;
+    [FieldOffset(0x12)] public bool IsHidden;
 
     [FieldOffset(0x14)] public float CountdownTime;
     [FieldOffset(0x18)] public float CountdownStartTime;
     [FieldOffset(0x1C)] public float ClaimTime;
     [FieldOffset(0x20)] public EventId EventId;
     [FieldOffset(0x24)] public uint ExportedSGRowId;
-    [FieldOffset(0x28)] public byte TargetableStatus;
+    [FieldOffset(0x28), Obsolete("Use NotTargetable")] public byte TargetableStatus;
+    [FieldOffset(0x28)] public bool NotTargetable;
 
     [FieldOffset(0x2A)] public ushort PositionX;
     [FieldOffset(0x2C)] public ushort PositionY;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/EventObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/EventObject.cs
@@ -10,8 +10,11 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Object;
 public unsafe partial struct EventObject {
     [FieldOffset(0x1A0), CExporterExcel("EObj")] public nint EObjRowPtr;
     [FieldOffset(0x1A8), CExporterExcel("ExportedSG")] public nint ExportedSGRowPtr;
-    [FieldOffset(0x1B2)] public ushort SharedTimelineState; // ActorControl category 0x199 (SetSharedTimelineState) sets this field
+    [FieldOffset(0x1B2)] public ushort SharedTimelineState; // ActorControl category 0x199 (SetSharedTimelineState) sets this field and it can also be set when spawned by SpawnObjectPacket.
+    /// <summary>Arbritrary value set in SpawnObjectPacket. How it's used depends on GameObject.SubKind.</summary>
+    [FieldOffset(0x1B4)] public uint Arg;
     [FieldOffset(0x1B8)] public byte Flags;
+
     /// <summary>Changes the currently playing timelines based on a bitmask.</summary>
     /// <param name="sharedTimelineState">Only sets SharedTimelineState, does not have any other effect in this function.</param>
     /// <param name="bitmask">Each bit represents a timeline index in the SharedGroup. Setting a bit means play, an unset bit means stop.</param>

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -42,7 +42,9 @@ public unsafe partial struct GameObject {
     /// <remarks> Calculated in <see cref="UpdateNextDistanceAndTargetStatus"/> right before <c>GameObjectManager.Update</c> sets it to <see cref="CurrentDistance"/> via <see cref="SetDistance"/>. </remarks>
     [FieldOffset(0x96)] public byte NextDistance;
     [FieldOffset(0x96), Obsolete("Renamed to NextDistance")] public byte YalmDistanceFromPlayerZ;
+    [FieldOffset(0x97)] public byte Visibility;
     [FieldOffset(0x9A)] public ObjectTargetableFlags TargetableStatus; // Determines whether the game object can be targeted by the user
+    [FieldOffset(0x9B)] public ObjectUpdateFlags UpdateFlags;
     [FieldOffset(0xB0)] public Vector3 Position;
     [FieldOffset(0xC0)] public float Rotation;
     [FieldOffset(0xC4)] public float Scale;
@@ -152,6 +154,9 @@ public unsafe partial struct GameObject {
 
     [VirtualFunction(34)]
     public partial void SetReadyToDraw();
+
+    [VirtualFunction(36)]
+    public partial void Update();
 
     [VirtualFunction(47)]
     public partial void GetCenterPosition(Vector3* outCenter);
@@ -275,6 +280,19 @@ public unsafe partial struct GameObject {
     [MemberFunction("E8 ?? ?? ?? ?? 84 C0 74 ?? 33 FF 48 89 B4 24")]
     public partial bool IsSharedGroupLoaded();
 
+    /// <summary>Sets EventState to a new value.</summary>
+    [MemberFunction("80 89 ?? ?? ?? ?? ?? 88 51")]
+    public partial void SetEventState(byte eventState);
+
+    /// <summary>Sets Visibility to a new value.</summary>
+    /// <param name="visibility">0 shows the object, 1 hides it.</param>
+    [MemberFunction("E8 ?? ?? ?? ?? 8B 4F ?? 89 8E")]
+    public partial void SetVisibility(byte visibility);
+
+    /// <summary>Sets EventId to a new value.</summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 0F B7 56 ?? 48 8B 4F")]
+    public partial void SetEventId(EventId eventId);
+
     [StructLayout(LayoutKind.Explicit, Size = 0x08)]
     public struct NamePlateColors {
         [FieldOffset(0x00), CExporterIgnore] public ulong Data;
@@ -385,6 +403,7 @@ public enum TargetType {
 
 [Flags]
 public enum ObjectTargetableFlags : byte {
+    Unk0 = 1 << 0, // Seen in SpawnObject/SpawnTreasure packets
     IsTargetable = 1 << 1,
     Unk1 = 1 << 2, // This flag is used but purpose is unclear
     ReadyToDraw = 1 << 6
@@ -406,4 +425,17 @@ public enum VisibilityFlags : ulong {
     None = 0,
     Model = 1ul << 1,
     Nameplate = 1ul << 11
+}
+
+[Flags]
+public enum ObjectUpdateFlags : byte {
+    /// <summary>Seen when Name is modified.</summary>
+    Name = 1,
+    Unk2 = 2,
+    /// <summary>Seen when EventId is modified.</summary>
+    EventId = 4,
+    /// <summary>Seen when TargetableStatus is modified.</summary>
+    TargetableStatus = 8,
+    Unk16 = 16,
+    Unk32 = 32,
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -11674,6 +11674,7 @@ classes:
       0x140899B70: SetEventId
       0x140899BE0: SetFateId
       0x140899C00: SetEventState
+      0x140899C80: SetVisibility
       0x14089A340: GetAsCharacter
       0x14089A370: GetAsBattleCharaMaybe # might be some other cast, or even Character too?
       0x14089A540: DistanceBetweenHitboxesXZ # static


### PR DESCRIPTION
These various fields are really strangely defined and were bothering me for a while. So I took the time to finally untangle them and hopefully they make more sense now.

The first one is targetable status, this plugs into the GameObject field of the same name but is *not* the flag itself. The disassembly (from Ghidra) looks daunting but what it's actually doing is checking if the field is 0 - or false - and if so, setting two flags: Unk0 | IsTargetable. Higher values don't do anything, I confirmed by recreating the code in Godbolt.

The next field is Visibility, it also plugs into the GameObject field of the same name but the name is somewhat confusing. On first glance, you would think every object spawned would have a Visibility of 1 - or true - but the field means the opposite! If you spawn an object with Visibility set to 0, its shown and vice versa. I renamed this field to something more suitable. I didn't bother changing the GameObject field for now.

There's a couple of fields that were included in the struct but not read by the client, so I marked those to be removed at a later date.

The final two fields are in SpawnObjectPacket, and are meant for general purpose across all types of objects. For example, the initial SharedGroupTimeline state is passed in Arg1 for EventObj. I renamed those fields as their actual purpose is already known in a way.

The remaining changes is just helpers to make the functions these fields plug into more readable. A lot of the GameObject methods I stumbled upon use this strange update flag system, so I started detailing that but didn't put too much effort into that yet.