### PR TITLE
Gathering point data

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/GatheringEventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/GatheringEventHandler.cs
@@ -6,23 +6,24 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Event;
 [Inherits<EventHandler>]
 [StructLayout(LayoutKind.Explicit, Size = 0x428)]
 public unsafe partial struct GatheringEventHandler {
+    [FieldOffset(0x2C8)] public int Icon;
     /// <remarks> Index into the GatheringPoint Excel sheet. </remarks>
     [FieldOffset(0x2E8)] public uint RowId;
     /// <remarks> Index into the GatheringPointBase Excel sheet. </remarks>
     [FieldOffset(0x2EC)] public uint BaseRowId;
-    [FieldOffset(0x2C8)] public int Icon;
     [FieldOffset(0x2F0)] public ushort GatheringPointBonus0;
     [FieldOffset(0x2F2)] public ushort GatheringPointBonus1;
-    [FieldOffset(0x308)] private byte Unknown0; // GatheringPoint.Unknown0
-    [FieldOffset(0x30B)] public byte Count;
-    [FieldOffset(0x30E)] public ushort GatheringSubCategory;
     [FieldOffset(0x306)] public GatheringType GatheringType;
-    /// <remarks> From the Type column in the GatheringPoint Excel sheet. </remarks>
     [FieldOffset(0x307)] public byte Type;
+    [FieldOffset(0x308)] private byte Unknown0; // GatheringPoint.Unknown0
+    /// <remarks> From the Type column in the GatheringPoint Excel sheet. </remarks>
     [FieldOffset(0x309)] public byte GatheringLevel;
     /// <remarks> Flags are currently unknown, they are set in Setup. </remarks>
     [FieldOffset(0x310)] public byte Flags;
     [FieldOffset(0x311)] private byte Unknown1; // GatheringPoint.Unknown1
+    [FieldOffset(0x30A)] public byte RemainingCount;
+    [FieldOffset(0x30B)] public byte Count;
+    [FieldOffset(0x30E)] public ushort GatheringSubCategory;
 
     /// <summary>Reads Excel data and some fields sent by the server that were stored in GatheringPointObject.</summary>
     /// <param name="rowId">Index into the GatheringPoint Excel sheet.</param>

--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/GatheringEventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/GatheringEventHandler.cs
@@ -1,6 +1,43 @@
+using GatheringPointObject = FFXIVClientStructs.FFXIV.Client.Game.Object.GatheringPointObject;
+
 namespace FFXIVClientStructs.FFXIV.Client.Game.Event;
 
 [GenerateInterop(isInherited: true)]
 [Inherits<EventHandler>]
 [StructLayout(LayoutKind.Explicit, Size = 0x428)]
-public unsafe partial struct GatheringEventHandler;
+public unsafe partial struct GatheringEventHandler {
+    /// <remarks> Index into the GatheringPoint Excel sheet. </remarks>
+    [FieldOffset(0x2E8)] public uint RowId;
+    /// <remarks> Index into the GatheringPointBase Excel sheet. </remarks>
+    [FieldOffset(0x2EC)] public uint BaseRowId;
+    [FieldOffset(0x2C8)] public int Icon;
+    [FieldOffset(0x2F0)] public ushort GatheringPointBonus0;
+    [FieldOffset(0x2F2)] public ushort GatheringPointBonus1;
+    [FieldOffset(0x308)] private byte Unknown0; // GatheringPoint.Unknown0
+    [FieldOffset(0x30B)] public byte Count;
+    [FieldOffset(0x30E)] public ushort GatheringSubCategory;
+    [FieldOffset(0x306)] public GatheringType GatheringType;
+    /// <remarks> From the Type column in the GatheringPoint Excel sheet. </remarks>
+    [FieldOffset(0x307)] public byte Type;
+    [FieldOffset(0x309)] public byte GatheringLevel;
+    /// <remarks> Flags are currently unknown, they are set in Setup. </remarks>
+    [FieldOffset(0x310)] public byte Flags;
+    [FieldOffset(0x311)] private byte Unknown1; // GatheringPoint.Unknown1
+
+    /// <summary>Reads Excel data and some fields sent by the server that were stored in GatheringPointObject.</summary>
+    /// <param name="rowId">Index into the GatheringPoint Excel sheet.</param>
+    /// <param name="gatheringPointRow">Row data for this gathering point.</param>
+    /// <param name="gatheringPointObject">The object used to read the relevant fields from.</param>
+    [MemberFunction("48 89 5C 24 ?? 57 48 83 EC ?? 44 0F B6 91")]
+    public partial void Setup(uint rowId, [CExporterExcel("GatheringPoint")] void* gatheringPointRow, GatheringPointObject *gatheringPointObject);
+}
+
+/// <summary> Corresponds to rows in the GatheringPoint Excel sheet. </summary>
+public enum GatheringType : byte {
+    Mining = 0,
+    Quarrying = 1,
+    Logging = 2,
+    Harvesting = 3,
+    Spearfishing = 4,
+    Spearfishing2 = 5,
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs
@@ -293,6 +293,9 @@ public unsafe partial struct GameObject {
     [MemberFunction("E8 ?? ?? ?? ?? 0F B7 56 ?? 48 8B 4F")]
     public partial void SetEventId(EventId eventId);
 
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 16 48 8B 4F"), GenerateStringOverloads]
+    public partial void SetName(CStringPointer name);
+
     [StructLayout(LayoutKind.Explicit, Size = 0x08)]
     public struct NamePlateColors {
         [FieldOffset(0x00), CExporterIgnore] public ulong Data;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GatheringPointObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GatheringPointObject.cs
@@ -20,9 +20,13 @@ public unsafe partial struct GatheringPointObject {
     public unsafe partial struct GatheringPointObjectImplBase {
         [FieldOffset(0x08)] public GatheringPointEventHandler* EventHandler;
         [FieldOffset(0x10)] public byte RemainingCount;
+        [FieldOffset(0x11)] private bool Unk11;
+        [FieldOffset(0x12)] private bool Unk12;
+        [FieldOffset(0x13)] private bool Unk13; // Unsure where it's read, but needed for nodes to spawn.
         [FieldOffset(0x14)] private bool Unk14;
         [FieldOffset(0x15)] private bool Unk15;
         [FieldOffset(0x16)] private byte Unk16;
+        [FieldOffset(0x17)] private byte Unk17;
 
         [FieldOffset(0x18)] public GatheringPointObject* Object;
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/Object/GatheringPointObject.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Object/GatheringPointObject.cs
@@ -10,11 +10,27 @@ public unsafe partial struct GatheringPointObject {
     [FieldOffset(0x1C0)] public GatheringPointObjectImpl ObjectImpl;
     [FieldOffset(0x1E0)] public GatheringPointObjectImplBase* Impl;
 
+    /// <summary>This takes care of adding a child AVFX object and everything.</summary>
+    [MemberFunction("E8 ?? ?? ?? ?? 48 8B 4F ?? 8B 57")]
+    public partial void Setup();
+
     [GenerateInterop(isInherited: true)]
+    [VirtualTable("48 8D 0D ?? ?? ?? ?? 48 8D 87", 3, 14)]
     [StructLayout(LayoutKind.Explicit, Size = 0x20)]
     public unsafe partial struct GatheringPointObjectImplBase {
         [FieldOffset(0x08)] public GatheringPointEventHandler* EventHandler;
+        [FieldOffset(0x10)] public byte RemainingCount;
+        [FieldOffset(0x14)] private bool Unk14;
+        [FieldOffset(0x15)] private bool Unk15;
+        [FieldOffset(0x16)] private byte Unk16;
+
         [FieldOffset(0x18)] public GatheringPointObject* Object;
+
+        [VirtualFunction(4)]
+        public partial GatheringType GetGatheringType();
+
+        [VirtualFunction(12)]
+        public partial CStringPointer GetName();
     }
 
     [GenerateInterop]

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -17252,6 +17252,7 @@ classes:
         base: Client::Game::Event::EventHandler
     funcs:
       0x140E8A4C0: ctor
+      0x140E87E40: Setup
   Client::Game::Event::ShopEventHandler: # 0x04
     vtbls:
       - ea: 0x1422C6048
@@ -26274,6 +26275,9 @@ classes:
   Client::Game::Object::GatheringPointObject::GatheringPointObjectImplBase:
     vtbls:
       - ea: 0x1422C5290
+    vfuncs:
+      0: dtor
+      12: GetName
   Client::Game::Object::GatheringPointObject::GatheringPointObjectImpl:
     vtbls:
       - ea: 0x1422C5300
@@ -26282,6 +26286,8 @@ classes:
     vtbls:
       - ea: 0x1422C5370
         base: Client::Game::Object::GameObject
+    funcs:
+      0x1417503C0: Setup
   Client::Game::Object::AreaObject:
     vtbls:
       - ea: 0x1422C55E0


### PR DESCRIPTION
I was trying to figure out what the fields passed in SpawnObject meant
for GatheringPoints, and ended up doing... this. Gathering points are
mostly made up from Excel sheet data, with a few things plastered on and
can be customized by the server (that's the fields added in
GatheringPointObjectImplBase, although a lot of them are unknown still.)

I also added two very useful and relevant setup functions:
GatheringPointObject's for the actual visible AVFX and
GatheringEventHandler's for most of the data for these structures.