### PR TITLE
Add QuestEffectManager, QuestEffectBase

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/QuestEffectManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/QuestEffectManager.cs
@@ -1,0 +1,43 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game;
+
+// Client::Game::QuestEffectManager
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0x1A8)]
+public unsafe partial struct QuestEffectManager {
+    [StaticAddress("4C 8B 35 ?? ?? ?? ?? 0F B7 C8", 3)]
+    public static partial QuestEffectManager* Instance();
+
+    [FieldOffset(0x00), FixedSizeArray] internal FixedSizeArray47<Pointer<QuestEffectBase>> _effectHandlers;
+    // [FieldOffset(0x178)] private StdList<?> UnkList;
+    [FieldOffset(0x188)] private ushort UnkQuestId;
+    [FieldOffset(0x18A)] private ushort UnkQuestEffectId;
+    [FieldOffset(0x18C)] private ushort UnkColliderInstanceId;
+    [FieldOffset(0x190)] public byte Flags;
+    // [FieldOffset(0x198)] private StdList<?> UnkList2;
+}
+
+// Client::Game::QuestEffectBase
+[GenerateInterop]
+[StructLayout(LayoutKind.Explicit, Size = 0x10)]
+public unsafe partial struct QuestEffectBase {
+    [VirtualFunction(0)]
+    public partial QuestEffectBase* Dtor(byte freeFlags);
+
+    [VirtualFunction(1)]
+    public partial int GetResult(uint param1, uint param2, ushort questId);
+
+    // [VirtualFunction(2)]
+    // public partial bool Vf2(int param1, ushort a3);
+
+    // [VirtualFunction(3)]
+    // public partial void Vf3(int param1);
+
+    // [VirtualFunction(4)]
+    // public partial bool Vf4();
+
+    [VirtualFunction(5)]
+    public partial uint GetLogMessageId();
+
+    [VirtualFunction(6)]
+    public partial bool SuppressLogMessage();
+}

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -2421,6 +2421,46 @@ classes:
       0x141969520: GetInstance
       0x141968D30: ctor
       0x1419696A0: dtor
+  Client::Game::QuestEffectBase:
+    vtbls:
+      - ea: 0x1423152A0
+    vfuncs:
+      0: dtor
+      1: GetResult
+      5: GetLogMessageId
+      6: SuppressLogMessage
+  Client::Game::QuestEffectTransformationStatus:
+    vtbls:
+      - ea: 0x1424310A8
+        base: Client::Game::QuestEffectBase
+    funcs:
+      0x141C2DAE0: ctor
+  Client::Game::QuestEffectQuestStatusParam:
+    vtbls:
+      - ea: 0x142315310
+        base: Client::Game::QuestEffectBase
+  Client::Game::QuestEffectSequentialEvent:
+    vtbls:
+      - ea: 0x1424310E0
+        base: Client::Game::QuestEffectBase
+    funcs:
+      0x141C2DD80: ctor
+  Client::Game::QuestEffectFreeWork:
+    vtbls:
+      - ea: 0x142315348
+        base: Client::Game::QuestEffectBase
+  Client::Game::QuestEffectInventoryItem:
+    vtbls:
+      - ea: 0x142315380
+        base: Client::Game::QuestEffectBase
+  Client::Game::QuestEffectDemiatma:
+    vtbls:
+      - ea: 0x1423153B8
+        base: Client::Game::QuestEffectBase
+  Client::Game::QuestEffectPlayerLevel:
+    vtbls:
+      - ea: 0x142315498
+        base: Client::Game::QuestEffectBase
   Client::Game::DawnManager:
     instances:
       - ea: 0x142AB4B90


### PR DESCRIPTION
I'm not much smarter after working on this.

QuestEffect Handlers/Types:
```
1 = Player has Status 565
2 = Player has Status 2579
3 = Player riding Mount (Param1 = Mount Id)
4 = Player has Status 404
5 = Player has Status (Param1 = QuestStatusParam Id)
6-8 = Unknown SequentialEvent checks
9-23 = Unknown FreeWork checks
24 = Player has Status 2727
25-33 = Unknown FreeWork checks
34 = Has Inventory Item (NormalQuantity >= Param2; Param1 = ItemId, Param2 = Quantity)
35 = Has Inventory Item (NormalQuantity - HighQualityQuantity >= Param2; Param1 = ItemId, Param2 = Quantity)
36 = Has Inventory Item (HighQualityQuantity < Param2; Param1 = ItemId, Param2 = Quantity)
37 = Unknown EventItem check
38 = Has Inventory Item (NormalQuantity < Param2; Param1 = ItemId, Param2 = Quantity)
39 = Has Inventory Item (NormalQuantity - HighQualityQuantity < Param2; Param1 = ItemId, Param2 = Quantity)
40 = Has Inventory Item (HighQualityQuantity < Param2; Param1 = ItemId, Param2 = Quantity)
41 = Has Demiatma items
42 = Unknown CustomTodo for Quest 70917 (Aether, Aether, Everywhere)
43 = Unknown CustomTodo for Quest 71041
44 = Current ClassJob Level (Param1 = Minimum Level)
45 = Unknown Beastmaster check (active Pet.Unknown18 == Param1; Param1 = Unknown18)
46 = Unknown Beastmaster check
```