### PR TITLE
Change ZoneClient and ChatClient to public access

### DIFF
--- a/FFXIVClientStructs/FFXIV/Application/Network/NetworkModule.cs
+++ b/FFXIVClientStructs/FFXIV/Application/Network/NetworkModule.cs
@@ -35,8 +35,8 @@ public unsafe partial struct NetworkModule {
     [FieldOffset(0xAB0)] public ZoneLoginCallbackInterface* ZoneLoginCallback;
     [FieldOffset(0xAB8)] public LogoutCallbackInterface* LogoutCallback;
 
-    [FieldOffset(0xA70)] private ZoneClient* ZoneClient;
-    [FieldOffset(0xA78)] private ChatClient* ChatClient;
+    [FieldOffset(0xA70)] public ZoneClient* ZoneClient;
+    [FieldOffset(0xA78)] public ChatClient* ChatClient;
 
     [FieldOffset(0xAA1)] public bool WinSockInitialized;
     [FieldOffset(0xAA8)] public NetworkModulePacketReceiverCallback* PacketReceiverCallback;


### PR DESCRIPTION
given that the structures of ZoneClient and ChatClient have been largely reverse-engineered, making them public enables support for plugins such as those for latency testing.