### PR TITLE
Add item and action tooltip mappings

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonActionDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonActionDetail.cs
@@ -1,0 +1,14 @@
+using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI;
+
+// Client::UI::AddonActionDetail
+//   Client::UI::AddonActionDetailBase
+[Addon("ActionDetail")]
+[GenerateInterop]
+[Inherits<AddonActionDetailBase>]
+[StructLayout(LayoutKind.Explicit, Size = 0x360)]
+public unsafe partial struct AddonActionDetail {
+    [MemberFunction("48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 40 48 8B 42 28 4C 8B FA 48 8B F1 49 8B E8")]
+    public partial void GenerateTooltip(NumberArrayData* numberArray, StringArrayData* stringArray);
+}

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonActionDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonActionDetail.cs
@@ -9,6 +9,21 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 [Inherits<AddonActionDetailBase>]
 [StructLayout(LayoutKind.Explicit, Size = 0x360)]
 public unsafe partial struct AddonActionDetail {
+    [FieldOffset(0x270)] private AtkTextNode* Unk270;
+    [FieldOffset(0x278)] private AtkTextNode* Unk278;
+    [FieldOffset(0x280)] private AtkTextNode* Unk280;
+    [FieldOffset(0x288)] private AtkTextNode* Unk288;
+    [FieldOffset(0x290)] private AtkTextNode* Unk290;
+    [FieldOffset(0x298)] private AtkTextNode* Unk298;
+    [FieldOffset(0x2F8)] private AtkResNode* Unk2F8;
+    [FieldOffset(0x300)] private AtkResNode* Unk300;
+    [FieldOffset(0x320)] private AtkTextNode* Unk320;
+    [FieldOffset(0x328)] private AtkTextNode* Unk328;
+    [FieldOffset(0x330)] private AtkResNode* Unk330;
+    [FieldOffset(0x338)] private AtkResNode* Unk338;
+    [FieldOffset(0x340)] private AtkResNode* Unk340;
+    [FieldOffset(0x350)] private AtkTextNode* Unk350;
+
     [MemberFunction("48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 40 48 8B 42 28 4C 8B FA 48 8B F1 49 8B E8")]
     public partial void GenerateTooltip(NumberArrayData* numberArray, StringArrayData* stringArray);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonActionDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonActionDetail.cs
@@ -9,20 +9,41 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 [Inherits<AddonActionDetailBase>]
 [StructLayout(LayoutKind.Explicit, Size = 0x360)]
 public unsafe partial struct AddonActionDetail {
+    // Types recovered from AddonActionDetail.ctor's Get*NodeById calls and GenerateTooltip; their UI roles are still unknown.
+    [FieldOffset(0x250)] private AtkResNode* Unk250;
+    [FieldOffset(0x258)] private AtkResNode* Unk258;
+    [FieldOffset(0x260)] private AtkComponentIcon* Unk260;
+    [FieldOffset(0x268)] private AtkResNode* Unk268;
     [FieldOffset(0x270)] private AtkTextNode* Unk270;
     [FieldOffset(0x278)] private AtkTextNode* Unk278;
     [FieldOffset(0x280)] private AtkTextNode* Unk280;
     [FieldOffset(0x288)] private AtkTextNode* Unk288;
     [FieldOffset(0x290)] private AtkTextNode* Unk290;
     [FieldOffset(0x298)] private AtkTextNode* Unk298;
+    [FieldOffset(0x2A0)] private AtkTextNode* Unk2A0;
+    [FieldOffset(0x2A8)] private AtkTextNode* Unk2A8;
+    [FieldOffset(0x2B0)] private AtkTextNode* Unk2B0;
+    [FieldOffset(0x2B8)] private AtkTextNode* Unk2B8;
+    [FieldOffset(0x2C0)] private AtkTextNode* Unk2C0;
+    [FieldOffset(0x2C8)] private AtkTextNode* Unk2C8;
+    [FieldOffset(0x2D0)] private AtkResNode* Unk2D0;
+    [FieldOffset(0x2D8)] private AtkResNode* Unk2D8;
+    [FieldOffset(0x2E0)] private AtkResNode* Unk2E0;
+    [FieldOffset(0x2E8)] private AtkResNode* Unk2E8;
+    [FieldOffset(0x2F0)] private AtkResNode* Unk2F0;
     [FieldOffset(0x2F8)] private AtkResNode* Unk2F8;
     [FieldOffset(0x300)] private AtkResNode* Unk300;
+    [FieldOffset(0x308)] private AtkImageNode* Unk308;
+    [FieldOffset(0x310)] private AtkImageNode* Unk310;
+    [FieldOffset(0x318)] private AtkImageNode* Unk318;
     [FieldOffset(0x320)] private AtkTextNode* Unk320;
     [FieldOffset(0x328)] private AtkTextNode* Unk328;
     [FieldOffset(0x330)] private AtkResNode* Unk330;
-    [FieldOffset(0x338)] private AtkResNode* Unk338;
-    [FieldOffset(0x340)] private AtkResNode* Unk340;
+    [FieldOffset(0x338)] private AtkTextNode* Unk338;
+    [FieldOffset(0x340)] private AtkTextNode* Unk340;
+    [FieldOffset(0x348)] private AtkResNode* Unk348;
     [FieldOffset(0x350)] private AtkTextNode* Unk350;
+    [FieldOffset(0x358)] private AtkResNode* Unk358;
 
     [MemberFunction("48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 40 48 8B 42 28 4C 8B FA 48 8B F1 49 8B E8")]
     public partial void GenerateTooltip(NumberArrayData* numberArray, StringArrayData* stringArray);

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonActionDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonActionDetail.cs
@@ -45,6 +45,9 @@ public unsafe partial struct AddonActionDetail {
     [FieldOffset(0x350)] private AtkTextNode* Unk350;
     [FieldOffset(0x358)] private AtkResNode* Unk358;
 
+    [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC 30 48 8B 42 28 48 8B F1 48 8B B9 ?? ?? ?? ??")]
+    public partial void UpdateGroupPositions(NumberArrayData* numberArray);
+
     [MemberFunction("48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC 40 48 8B 42 28 4C 8B FA 48 8B F1 49 8B E8")]
     public partial void GenerateTooltip(NumberArrayData* numberArray, StringArrayData* stringArray);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonActionDetailBase.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonActionDetailBase.cs
@@ -1,0 +1,12 @@
+using FFXIVClientStructs.FFXIV.Component.GUI;
+
+namespace FFXIVClientStructs.FFXIV.Client.UI;
+
+// Client::UI::AddonActionDetailBase
+//   Component::GUI::AtkUnitBase
+//     Component::GUI::AtkEventListener
+//   Component::GUI::AtkManagedInterface
+[GenerateInterop(isInherited: true)]
+[Inherits<AtkUnitBase>, Inherits<AtkManagedInterface>]
+[StructLayout(LayoutKind.Explicit, Size = 0x248)]
+public unsafe partial struct AddonActionDetailBase;

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonItemDetail.cs
@@ -139,6 +139,18 @@ public unsafe partial struct AddonItemDetail {
     [MemberFunction("48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC ?? 48 8B 42 ?? 4C 8B EA")]
     public partial void GenerateTooltip(NumberArrayData* numberArray, StringArrayData* stringArray);
 
+    [MemberFunction("40 53 56 57 41 56 48 83 EC 78 48 8B DA 0F 29 74 24 50 49 8B 50 28 48 8B F9 48 8B 89 E0 04 00 00")]
+    public partial void SetEquipRestrictionInfo(NumberArrayData* numberArray, StringArrayData* stringArray);
+
+    [MemberFunction("48 89 54 24 10 41 54 41 55 41 57 48 83 EC 70 48 8B 42 28 4C 8B F9 48 8B 89 B0 06 00 00 4D 8B E8 4C 8B E2 F6 40 14 10")]
+    public partial void SetBonuses(NumberArrayData* numberArray, StringArrayData* stringArray);
+
+    [MemberFunction("4C 89 44 24 18 48 89 4C 24 08 53 57 41 55 48 83 EC 50 48 8B 42 28 48 8B D9 48 8B 89 A8 05 00 00 49 8B F8 4C 8B EA 8B 40 14")]
+    public partial void SetMateria(NumberArrayData* numberArray, StringArrayData* stringArray);
+
+    [MemberFunction("40 56 57 41 56 48 83 EC 30 48 8B 42 28 49 8B F0 4C 8B F2 48 8B F9 F6 40 14 40 75 32 48 8B 89 B8 04 00 00")]
+    public partial void SetSpiritbondInfo(NumberArrayData* numberArray, StringArrayData* stringArray);
+
     [StructLayout(LayoutKind.Explicit, Size = 0x30)]
     public struct MateriaEntry {
         [FieldOffset(0x00)] public AtkComponentBase* Group;

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonItemDetail.cs
@@ -110,26 +110,8 @@ public unsafe partial struct AddonItemDetail {
     [FieldOffset(0x6B0)] public AtkResNode* BonusesGroup;
     [FieldOffset(0x6B8)] public AtkTextNode* BonusesTitle;
     [FieldOffset(0x6C0), FixedSizeArray] internal FixedSizeArray4<BonusEntry> _bonuses;
-    // [FieldOffset(0x720), FixedSizeArray] internal FixedSizeArray6<same size as BonusEntry> _unk; // not sure what this is, but it's set in the same function as Bonuses
-    // remove these when array is known:
-    [FieldOffset(0x720)] private AtkComponentNode* Unk720;
-    [FieldOffset(0x728)] private AtkTextNode* Unk728;
-    [FieldOffset(0x730)] private AtkTextNode* Unk730;
-    [FieldOffset(0x738)] private AtkComponentNode* Unk738;
-    [FieldOffset(0x740)] private AtkTextNode* Unk740;
-    [FieldOffset(0x748)] private AtkTextNode* Unk748;
-    [FieldOffset(0x750)] private AtkComponentNode* Unk750;
-    [FieldOffset(0x758)] private AtkTextNode* Unk758;
-    [FieldOffset(0x760)] private AtkTextNode* Unk760;
-    [FieldOffset(0x768)] private AtkComponentNode* Unk768;
-    [FieldOffset(0x770)] private AtkTextNode* Unk770;
-    [FieldOffset(0x778)] private AtkTextNode* Unk778;
-    [FieldOffset(0x780)] private AtkComponentNode* Unk780;
-    [FieldOffset(0x788)] private AtkTextNode* Unk788;
-    [FieldOffset(0x790)] private AtkTextNode* Unk790;
-    [FieldOffset(0x798)] private AtkComponentNode* Unk798;
-    [FieldOffset(0x7A0)] private AtkTextNode* Unk7A0;
-    [FieldOffset(0x7A8)] private AtkTextNode* Unk7A8;
+    // SetBonuses initializes six additional entries with the same layout; their purpose is still unknown.
+    [FieldOffset(0x720), FixedSizeArray] internal FixedSizeArray6<BonusEntry> _unkBonusEntries;
     [FieldOffset(0x7B4)] public short OffsetX;
     [FieldOffset(0x7B6)] public short OffsetY;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonItemDetail.cs
@@ -136,6 +136,9 @@ public unsafe partial struct AddonItemDetail {
     [MemberFunction("E8 ?? ?? ?? ?? 41 8D 45 ?? 83 F8 ?? 77 ?? 48 8B 07 48 8B CF FF 50 ?? B2 ?? 48 8B CF 44 0F BF F0")]
     public partial void UpdateGroupPositions(NumberArrayData* numberArray, StringArrayData* stringArray);
 
+    [MemberFunction("48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 83 EC ?? 48 8B 42 ?? 4C 8B EA")]
+    public partial void GenerateTooltip(NumberArrayData* numberArray, StringArrayData* stringArray);
+
     [StructLayout(LayoutKind.Explicit, Size = 0x30)]
     public struct MateriaEntry {
         [FieldOffset(0x00)] public AtkComponentBase* Group;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentActionDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentActionDetail.cs
@@ -18,7 +18,7 @@ public unsafe partial struct AgentActionDetail {
     [FieldOffset(0x3C)] public uint ActionId;
     [FieldOffset(0x40)] public uint OriginalId; // Example: Summon Topaz
     [FieldOffset(0x44)] public uint AdjustedId; // Example: Summon Titan II
-    [FieldOffset(0x4C)] private int Unk4C;
+    [FieldOffset(0x4C)] public uint Flags;
     [FieldOffset(0x50)] private int Unk50;
     [FieldOffset(0x54)] private int Unk54;
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentActionDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentActionDetail.cs
@@ -18,10 +18,15 @@ public unsafe partial struct AgentActionDetail {
     [FieldOffset(0x3C)] public uint ActionId;
     [FieldOffset(0x40)] public uint OriginalId; // Example: Summon Topaz
     [FieldOffset(0x44)] public uint AdjustedId; // Example: Summon Titan II
+    [FieldOffset(0x4C)] private int Unk4C;
+    [FieldOffset(0x50)] private int Unk50;
+    [FieldOffset(0x54)] private int Unk54;
 
+    [FieldOffset(0x68)] private byte Unk68;
     [FieldOffset(0x69)] public bool IsLovmActionDetail;
+    [FieldOffset(0x6C)] private byte Unk6C;
 
-    // flag & 1 = get AdjustedActionId
+    // flags & 1 = get AdjustedActionId
     [MemberFunction("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? 83 F8 0F")]
-    public partial void HandleActionHover(DetailKind actionKind, uint actionId, int flag, bool isLovmActionDetail, int a5, int a6);
+    public partial void HandleActionHover(DetailKind actionKind, uint actionId, int flags, bool isLovmActionDetail, int unk50, int unk54);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
@@ -33,10 +33,18 @@ public unsafe partial struct AgentItemDetail {
     [FieldOffset(0x128)] public byte Flag1; // Related to checking the inventory
     [FieldOffset(0x134)] public int MaxStackSize;
     [FieldOffset(0x138)] public uint ItemId;
+    [FieldOffset(0x13C)] private int Unk13C;
     [FieldOffset(0x148)] public Utf8String String1;
     [FieldOffset(0x1B0)] public Utf8String String2;
     [FieldOffset(0x21A)] public byte Flag2; // This needs to be set to 1 for the item detail tooltip to show
+    [FieldOffset(0x21C)] private byte Unk21C;
     [FieldOffset(0x21E)] public byte Flag3; // If set to zero, avoids an early return in addon->Show()
+
+    /// <remarks>
+    /// <paramref name="unk128"/> is written as a 32-bit value at offset <c>0x128</c>.
+    /// </remarks>
+    [MemberFunction("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 8B FA 41 8B E9 BA A1 00 00 00 41 8B F0 48 8B D9 E8 ?? ?? ?? ??")]
+    public partial void HandleItemHover(DetailKind detailKind, uint typeOrId, uint index, int buyQuantity, uint unk128);
 
     [MemberFunction("40 55 53 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 F9 48 81 EC A8 00 00 00 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 45 F7 48 8B 5D 7F 4C 8B F1 8B 4D 77 49 8B F9 44 8B 6D 6F 49 8B F0 4C 89 4D AF 4C 8B FA")]
     public partial bool OnItemHovered(InventoryItem** item, InventoryType* inventoryType, ushort* slot, uint index, uint typeOrId, InventoryItem* fallbackItem);

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
@@ -1,4 +1,5 @@
 using FFXIVClientStructs.FFXIV.Client.Enums;
+using FFXIVClientStructs.FFXIV.Client.Game;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
@@ -36,4 +37,7 @@ public unsafe partial struct AgentItemDetail {
     [FieldOffset(0x1B0)] public Utf8String String2;
     [FieldOffset(0x21A)] public byte Flag2; // This needs to be set to 1 for the item detail tooltip to show
     [FieldOffset(0x21E)] public byte Flag3; // If set to zero, avoids an early return in addon->Show()
+
+    [MemberFunction("40 55 53 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 F9 48 81 EC A8 00 00 00 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 45 F7 48 8B 5D 7F 4C 8B F1 8B 4D 77 49 8B F9 44 8B 6D 6F 49 8B F0 4C 89 4D AF 4C 8B FA")]
+    public partial bool OnItemHovered(InventoryItem** item, InventoryType* inventoryType, ushort* slot, uint index, uint typeOrId, InventoryItem* fallbackItem);
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
@@ -30,7 +30,7 @@ public unsafe partial struct AgentItemDetail {
     [FieldOffset(0x11C)] public uint TypeOrId;
     [FieldOffset(0x120)] public uint Index; // The index of the item in the inventory. 0 for chat, ??? for KeyItems, position top-bottom inside a shop.
     [FieldOffset(0x124)] public int BuyQuantity; // The quantity selected for buying, which is previewed on the tooltip as "in bag" quantity, -1 outside shops
-    [FieldOffset(0x128)] public byte Flag1; // Related to checking the inventory
+    [FieldOffset(0x128)] public uint Flag1; // Related to checking the inventory
     [FieldOffset(0x134)] public int MaxStackSize;
     [FieldOffset(0x138)] public uint ItemId;
     [FieldOffset(0x13C)] private int Unk13C;
@@ -41,10 +41,10 @@ public unsafe partial struct AgentItemDetail {
     [FieldOffset(0x21E)] public byte Flag3; // If set to zero, avoids an early return in addon->Show()
 
     /// <remarks>
-    /// <paramref name="unk128"/> is written as a 32-bit value at offset <c>0x128</c>.
+    /// <paramref name="flag1"/> is written as a 32-bit value at offset <c>0x128</c>.
     /// </remarks>
     [MemberFunction("48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 8B FA 41 8B E9 BA A1 00 00 00 41 8B F0 48 8B D9 E8 ?? ?? ?? ??")]
-    public partial void HandleItemHover(DetailKind detailKind, uint typeOrId, uint index, int buyQuantity, uint unk128);
+    public partial void HandleItemHover(DetailKind detailKind, uint typeOrId, uint index, int buyQuantity, uint flag1);
 
     [MemberFunction("40 55 53 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 F9 48 81 EC A8 00 00 00 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 45 F7 48 8B 5D 7F 4C 8B F1 8B 4D 77 49 8B F9 44 8B 6D 6F 49 8B F0 4C 89 4D AF 4C 8B FA")]
     public partial bool OnItemHovered(InventoryItem** item, InventoryType* inventoryType, ushort* slot, uint index, uint typeOrId, InventoryItem* fallbackItem);

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
@@ -36,6 +36,8 @@ public unsafe partial struct AgentItemDetail {
     [FieldOffset(0x13C)] private int Unk13C;
     [FieldOffset(0x148)] public Utf8String String1;
     [FieldOffset(0x1B0)] public Utf8String String2;
+    // OnGameEvent writes this byte for login/logout events; its specific state meaning is unconfirmed.
+    [FieldOffset(0x218)] private byte Unk218;
     // HandleItemHover writes 0x0100 at 0x219, resetting this byte and setting Flag2.
     [FieldOffset(0x219)] private byte Unk219;
     [FieldOffset(0x21A)] public byte Flag2; // This needs to be set to 1 for the item detail tooltip to show

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentItemDetail.cs
@@ -36,6 +36,8 @@ public unsafe partial struct AgentItemDetail {
     [FieldOffset(0x13C)] private int Unk13C;
     [FieldOffset(0x148)] public Utf8String String1;
     [FieldOffset(0x1B0)] public Utf8String String2;
+    // HandleItemHover writes 0x0100 at 0x219, resetting this byte and setting Flag2.
+    [FieldOffset(0x219)] private byte Unk219;
     [FieldOffset(0x21A)] public byte Flag2; // This needs to be set to 1 for the item detail tooltip to show
     [FieldOffset(0x21C)] private byte Unk21C;
     [FieldOffset(0x21E)] public byte Flag3; // If set to zero, avoids an early return in addon->Show()

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -20105,6 +20105,7 @@ classes:
     funcs:
       0x1412D7A80: ctor
       0x1412D8430: GenerateTooltip
+      0x1412D8850: UpdateGroupPositions
   Client::UI::AddonSynthesis: # 89
     vtbls:
       - ea: 0x14223C9D8


### PR DESCRIPTION
## Summary

Adds the item and action tooltip mappings used by the corresponding UI agents and addons.

- Adds `AgentItemDetail.HandleItemHover` and `AgentItemDetail.OnItemHovered`.
- Adds `AgentActionDetail.HandleActionHover` and records the fields it initializes.
- Adds the item-detail tooltip helpers and the action-detail UI node pointers used while generating tooltip text.
- Regenerates `ida/ffxiv_structs.yml` from the updated layouts.

This is intentionally a draft while the RE evidence gets a second set of eyes.

## `AgentItemDetail`

`HandleItemHover` has a unique direct match at RVA `0x1036950`. Its final explicit argument is read from the stack and stored with `mov dword [rbx + 0x128], eax` (VA `0x1410369A1`). `Flag1` is therefore mapped as a `uint`, and the argument is named `flag1` rather than left as an unknown value.

`OnItemHovered` is added from its own direct match at RVA `0x1038DC0`.

## `AgentActionDetail`

The existing `E8` signature has one call-site match and resolves to the `HandleActionHover` target at RVA `0xEE1F80`. The method initializes the existing action identifiers and the confirmed fields at `0x4C`, `0x50`, `0x54`, `0x68`, and `0x6C`; names remain `Unk*` where static analysis only establishes storage and width.

## Addons

`AddonItemDetail.GenerateTooltip` calls the following helpers with the same `(NumberArrayData*, StringArrayData*)` pair:

- `SetEquipRestrictionInfo` at RVA `0x12DAFB0`
- `SetSpiritbondInfo` at RVA `0x12DB330`
- `SetBonuses` at RVA `0x12DB850`
- `SetMateria` at RVA `0x12DBB80`

The `AddonActionDetail` node fields are kept private and conservatively typed as `AtkTextNode*` or `AtkResNode*` only where their uses establish the node type.

## Evidence

The signatures above each matched exactly once in the local `ffxiv_dx11.exe` used for this pass:

`4236E770E673150E85F8D10BEAB2FC4834C82F86AAB8A555A9175439FC906A6D`

For the `E8` action-detail signature, the call-site and relative target are treated separately; the wrapper remains a member-function mapping for the resolved target.

### Methodology

This work followed the Dalamud reverse-engineering guidelines and combined static signature analysis, disassembly, existing ClientStructs/IDA metadata, layout and API validation, and limited read-only runtime corroboration. Runtime observations were complementary; ABI-facing claims were based on corroborating static evidence and validation.

## Validation

- `dotnet restore .\\FFXIVClientStructs.slnx`
- `dotnet build .\\FFXIVClientStructs.slnx --no-restore`
- `dotnet format .\\FFXIVClientStructs.slnx --verify-no-changes`
- `dotnet run --project .\\CExporter\\CExporter.csproj -c Release -- --no-write`
- `dotnet run --project .\\CExporter\\CExporter.csproj -c Release`

`ida/errors.txt` was empty after the write-mode export.

### Language assistance

Codex (an LLM) was used to help translate, organize, and edit the English wording in the documentation and this PR description. It was not used to establish offsets, sizes, signatures, layouts, or other ABI details.

The reverse-engineering work, validation, and all technical claims were independently verified by the author, who remains responsible for the technical accuracy of this PR.
