### PR TITLE
Add XBM Components

### DIFF
--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentXBMContentStageEventMap.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentXBMContentStageEventMap.cs
@@ -1,0 +1,53 @@
+using FFXIVClientStructs.FFXIV.Common.Component.Excel;
+
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
+
+// Component::GUI::AtkComponentXBMContentStageEventMap
+//   Component::GUI::AtkComponentBase
+//     Component::GUI::AtkEventListener
+// common CreateAtkComponent function "E8 ?? ?? ?? ?? 4C 8B F0 48 85 C0 0F 84 ?? ?? ?? ?? 49 8B 4D 08"
+// type 27
+[GenerateInterop]
+[Inherits<AtkComponentBase>]
+[StructLayout(LayoutKind.Explicit, Size = 0x968)]
+public unsafe partial struct AtkComponentXBMContentStageEventMap {
+    [FieldOffset(0xC0), FixedSizeArray] internal FixedSizeArray5<Entry> _entries;
+
+    [FieldOffset(0x930)] public ushort GridSize;
+    [FieldOffset(0x932)] public ushort GridHalfSize;
+    [FieldOffset(0x934)] public uint XBMContentStageEventMapRowId;
+    [FieldOffset(0x938)] public byte LoadState;
+
+    [FieldOffset(0x940)] public AtkComponentBase* CurrentEventMarkerComponent;
+    [FieldOffset(0x948)] public EventMapRowEntry* EventMapEntries;
+    [FieldOffset(0x950)] public ulong EventMapEntryCapacity;
+    [FieldOffset(0x958)] public byte EventMapEntryCount;
+    [FieldOffset(0x959)] public byte CurrentEventIndex;
+    [FieldOffset(0x95A)] public bool IsEventMapLoaded;
+    [FieldOffset(0x95B)] public bool ShouldReloadEventMap;
+    [FieldOffset(0x95C)] public bool IsEventMapLoading;
+    [FieldOffset(0x95D)] public bool UseEventHandlerState;
+    [FieldOffset(0x960)] public ExcelSheetWaiter* SheetWaiter;
+
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = 0x1B0)]
+    public partial struct Entry {
+        [FieldOffset(0x00)] public uint TemplateNodeId;
+        [FieldOffset(0x04)] public byte ComponentCount;
+        [FieldOffset(0x05), FixedSizeArray] internal FixedSizeArray30<byte> _eventMapEntryIndices;
+        [FieldOffset(0x28), FixedSizeArray] internal FixedSizeArray30<Pointer<AtkComponentBase>> _components;
+        [FieldOffset(0x118), FixedSizeArray] internal FixedSizeArray30<uint> _timelineStates;
+        [FieldOffset(0x190), FixedSizeArray] internal FixedSizeArray30<bool> _isCurrentEvent;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0xD)]
+    public partial struct EventMapRowEntry {
+        [FieldOffset(0x00)] public byte X;
+        [FieldOffset(0x01)] public byte Y;
+        [FieldOffset(0x02)] public byte Type;
+        [FieldOffset(0x03)] public byte EventIndex;
+        [FieldOffset(0x04)] public byte LinkedEventIndex;
+        [FieldOffset(0x08)] public uint State;
+        [FieldOffset(0x0C)] public bool IsStateLoaded;
+    }
+}

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentXBMItem.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentXBMItem.cs
@@ -1,0 +1,27 @@
+using FFXIVClientStructs.FFXIV.Client.System.String;
+
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
+
+// Component::GUI::AtkComponentXBMItem
+//   Component::GUI::AtkComponentBase
+//     Component::GUI::AtkEventListener
+// common CreateAtkComponent function "E8 ?? ?? ?? ?? 4C 8B F0 48 85 C0 0F 84 ?? ?? ?? ?? 49 8B 4D 08"
+// type 26
+[GenerateInterop]
+[Inherits<AtkComponentBase>]
+[StructLayout(LayoutKind.Explicit, Size = 0x228)]
+public unsafe partial struct AtkComponentXBMItem {
+    [FieldOffset(0xC0)] public AtkComponentIcon* IconComponent;
+    [FieldOffset(0xC8)] public AtkTextNode* NameTextNode;
+    [FieldOffset(0xD0)] public AtkTextNode* TypeTextNode;
+    [FieldOffset(0xD8)] public AtkTextNode* DescriptionTextNode;
+    [FieldOffset(0xE0)] public Utf8String NameText;
+    [FieldOffset(0x148)] public Utf8String TypeText;
+    [FieldOffset(0x1B0)] public Utf8String DescriptionText;
+
+    [FieldOffset(0x218)] public uint XBMItemId;
+    [FieldOffset(0x21C)] public ushort OriginalDescriptionHeight;
+    [FieldOffset(0x21E)] public bool ShowPossessionCount;
+    [FieldOffset(0x21F)] public bool ResizeDescriptionToText;
+    [FieldOffset(0x220)] public bool IsItemLoaded;
+}

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldComponentDataXBMContentStageEventMap.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldComponentDataXBMContentStageEventMap.cs
@@ -1,0 +1,8 @@
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
+
+[GenerateInterop]
+[Inherits<AtkUldComponentDataBase>]
+[StructLayout(LayoutKind.Explicit, Size = 0x20)]
+public unsafe partial struct AtkUldComponentDataXBMContentStageEventMap {
+    [FieldOffset(0x0C), FixedSizeArray] internal FixedSizeArray5<uint> _templateNodeIds;
+}

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldComponentDataXBMItem.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldComponentDataXBMItem.cs
@@ -1,0 +1,11 @@
+namespace FFXIVClientStructs.FFXIV.Component.GUI;
+
+[GenerateInterop]
+[Inherits<AtkUldComponentDataBase>]
+[StructLayout(LayoutKind.Explicit, Size = 0x20)]
+public unsafe partial struct AtkUldComponentDataXBMItem {
+    [FieldOffset(0x0C)] public uint IconComponentNodeId;
+    [FieldOffset(0x10)] public uint NameTextNodeId;
+    [FieldOffset(0x14)] public uint TypeTextNodeId;
+    [FieldOffset(0x18)] public uint DescriptionTextNodeId;
+}

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldManager.cs
@@ -218,6 +218,10 @@ public enum ComponentType : byte {
     Preview = 23,
     HoldButton = 24,
     Portrait = 25,
-    Unk26 = 26, // related to the XBMItem sheet
-    Unk27 = 27, // related to the XBMContentStageEventMap sheet
+    XBMItem = 26,
+    XBMContentStageEventMap = 27,
+    [Obsolete("Use XBMItem")]
+    Unk26 = XBMItem,
+    [Obsolete("Use XBMContentStageEventMap")]
+    Unk27 = XBMContentStageEventMap,
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldManager.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldManager.cs
@@ -220,8 +220,4 @@ public enum ComponentType : byte {
     Portrait = 25,
     XBMItem = 26,
     XBMContentStageEventMap = 27,
-    [Obsolete("Use XBMItem")]
-    Unk26 = XBMItem,
-    [Obsolete("Use XBMContentStageEventMap")]
-    Unk27 = XBMContentStageEventMap,
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -9678,6 +9678,14 @@ classes:
     funcs:
       0x1406DF370: ctor # no xrefs, inlined in AtkUldManager_CreateAtkComponent
       0x1406DF360: GetCollisionNode
+  Component::GUI::AtkComponentXBMItem:
+    vtbls:
+      - ea: 0x142174618
+        base: Component::GUI::AtkComponentBase
+  Component::GUI::AtkComponentXBMContentStageEventMap:
+    vtbls:
+      - ea: 0x1421746B8
+        base: Component::GUI::AtkComponentBase
   Client::LayoutEngine::IManagerBase:
     vtbls:
       - ea: 0x142175860


### PR DESCRIPTION
Sadly they seem to be hardcoded to use XBMItems
Tested it by comparing with ULD using SetupComponentFromULDResourceHandle.

Spoilered because BeastMaster stuff.
<details>
  <summary>BeastMaster ULD Images</summary>
<img width="792" height="693" alt="ffxiv_dx11_2026-07-24_19-33-20" src="https://github.com/user-attachments/assets/34158fbb-1b7d-4fac-9a95-e568c61e445a" />
<img width="1155" height="670" alt="ffxiv_dx11_2026-07-24_19-35-13" src="https://github.com/user-attachments/assets/3b32b4f1-bb17-43da-ba61-4d4ef7ec5faf" />
<img width="1047" height="615" alt="ffxiv_dx11_2026-07-24_19-36-13" src="https://github.com/user-attachments/assets/b4a57b9e-26f3-4c5b-9186-623e46d7e015" />

</details>

Feel free to suggest better names