### PR TITLE
data: name retainer request surface and RetainerEventHandler

### DIFF
--- a/ida/data.yml
+++ b/ida/data.yml
@@ -914,7 +914,9 @@ classes:
     funcs:
       0x1411073E0: Initialize
       0x141107540: Update
-      0x1411075C0: RequestVenturesTimers
+      0x1411075C0: RequestVenturesTimers # client Lua name is RequestRetainerList; fetches full roster plus venture fields
+      0x1411076F0: RequestRetainerSingleData # (this, callbackInterface, retainerId); submits request kind 3
+      0x141107760: ProcessRequestPackets # commits grouped 0x339 retainer records and 0xDD roster metadata before kind 2 completion
       0x141107C90: GetRetainerBySortedIndex
       0x141107CC0: GetRetainerByHiredIndex
       0x141107D20: GetActiveRetainer
@@ -922,6 +924,7 @@ classes:
       0x141107D80: SetRetainerObjectId
       0x141107D90: IsRetainerSummoned
       0x141107DB0: GetRetainerCount
+      0x1411083B0: CreateBindRetainerPixie # materializes a local retainer actor for event scenes; no server request
   Client::Game::SatisfactionSupplyManager:
     instances:
       - ea: 0x142AB4BC0
@@ -1912,6 +1915,9 @@ classes:
       0x140843950: ctor
       0x1408439F0: dtor
       0x140843A60: Request # (this, callbackInterface, commandId, arg1, arg2)
+      0x140843DE0: RegisterCallback # stores raw callback in first free vector slot; no refcount
+      0x140843F80: Dispatch # clears slot before invoking callback vfunc 1
+      0x140843FC0: DispatchEmpty # clears slot before invoking callback vfunc 1 with no response
   Client::Game::ContentsReplayManager:
     instances:
       - ea: 0x142A80808
@@ -17925,6 +17931,28 @@ classes:
     vtbls:
       - ea: 0x142408220
         base: Client::Game::Event::CustomTalkResidentEventHandler
+  Client::Game::Event::RetainerEventHandler: # working name; no RTTI name recovered. 0x5F8 bytes: 0x468 CustomTalkResidentEventHandler base plus 0x190 tail with two ServerRequestCallbackInterface instances at +0x468/+0x470 and six 0x30 agent result bridges at +0x478..+0x590
+    vtbls:
+      - ea: 0x142453DD0
+        base: Client::Game::Event::CustomTalkResidentEventHandler
+    funcs:
+      0x141C3EDF0: Create # allocates 0x5F8 and invokes ctor
+      0x141C91F70: ctor
+      0x141C92220: dtor
+      0x141C92530: RegisterRetainerRequests # installs the retainer Lua bindings and menu constants
+      0x141C92EF0: OnDepopRetainer
+      0x141C92FA0: RequestRetainerList # Lua binding; submits request kind 2
+      0x141C93030: RequestRetainerSingleData # Lua binding; submits request kind 3 with retainer ID
+      0x141C930E0: UpdateRetainerTaskAccept # Lua binding; request kind 5
+      0x141C93190: UpdateRetainerTaskCancel # Lua binding; request kind 6
+      0x141C93230: UpdateRetainerClassJob # Lua binding; request kind 7
+      0x141C932E0: UpdateVentureTutorialFlagOn # Lua binding; request kind 8
+      0x141C93390: UpdateRetainerFlagOn # Lua binding; request kind 9
+      0x141C93440: CreateBindRetainerPixie # Lua binding
+      0x141C94520: SetCurrentRetainerId # Lua binding; writes RetainerManager.LastSelectedRetainerId
+      0x141C945F0: SetCurrentRetainerEntityId # Lua binding; writes RetainerManager.RetainerObjectId
+      0x141C95120: OnReceivePacket # primary callback at handler +0x468; dispatches request kinds 2-9
+      0x141C95360: OnBindingComplete # callback at handler +0x470; receives GameObject.ObjectIndex
   Client::Game::Event::JournalCallback:
     vtbls:
       - ea: 0x1421C2560


### PR DESCRIPTION
**Disclosure:** this pull request was prepared and submitted by an AI agent acting on behalf of the account owner, who reviewed and approved the change. The underlying analysis was performed with the owner's tooling and direction.

## What this adds

Names for the undocumented retainer script handler family in `ida/data.yml`, recovered by static analysis of the pinned `2026.06.18.0000.0000` build (Ghidra 12.1.2, SHA-256 `4236E770E673150E85F8D10BEAB2FC4834C82F86AAB8A555A9175439FC906A6D`):

- **`Client::Game::Event::RetainerEventHandler`** (working name — no RTTI name recovered): a `0x5F8`-byte `CustomTalkResidentEventHandler` derivative. Its `0x190` tail holds two `ServerRequestCallbackInterface` instances (`+0x468`, `+0x470`) and six `0x30` agent result bridges (`+0x478`..`+0x590`). Entries cover the factory, ctor/dtor, the Lua registration function, all Lua-registered request wrappers (request kinds 2–9, named from their embedded Lua registration strings), the binding/depop/context setters, and both callback receivers.
- **`Client::Game::RetainerManager`**: `RequestRetainerSingleData` (kind 3, splits the 64-bit retainer ID into two 32-bit args), the grouped response processor (commits `0x339` retainer records and `0xDD` roster metadata before kind 2 completion), and `CreateBindRetainerPixie` (materializes a local retainer actor for event scenes — it submits no server request). Also documents that `RequestVenturesTimers` is the full-roster fetch the client Lua calls `RequestRetainerList`.
- **`Client::Game::ServerRequestCallbackManager`**: callback registration and both dispatch paths. The manager stores raw callback pointers in the first free vector slot with no refcounting and clears the slot before invoking vfunc 1 — useful contract knowledge for anyone modeling the interface.

## Evidence notes

- The Lua binding names (`RequestRetainerList`, `UpdateRetainerTaskAccept`, `CreateBindRetainerPixie`, etc.) come from the client's own registration strings, so those names are direct evidence rather than guesses.
- `RetainerEventHandler` is explicitly marked as a working name; the class comment records the recovered size and tail layout so the entry is useful even if renamed later.
- Kinds 2 and 3 are asynchronous cache operations: response data is committed to `RetainerManager` before the callback resumes the retainer Lua coroutine. Neither establishes an event scene by itself; `IsReady` reflects data-operation completion, not selection state.

Happy to adjust names, comments, or scope to maintainer preference.
