### PR TITLE
Fill out hierarchy of director update handlers

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
@@ -54,6 +54,19 @@ public unsafe partial struct EventHandler {
     [VirtualFunction(60)]
     public partial void ProcessActionTimelineCallback(Character.Character* character, ushort actionTimelineId, ulong callbackParam);
 
+    /// <summary>
+    /// Called to dispatch a director update (see EventFramework.ProcessDirectorUpdate).
+    /// </summary>
+    /// <param name="parameters">Pointer to seven uints (category, arg1, arg2, arg3, arg4, arg5, arg6).</param>    [VirtualFunction(61)]
+    [VirtualFunction(61)]
+    public partial void ProcessDirectorUpdate(uint *parameters);
+
+    /// <summary>
+    /// Implemented by certain EventHandlers (e.g. GoldSaucerArcadeMachineEventHandler) so they can handle the director update instead.
+    /// </summary>
+    [VirtualFunction(62)]
+    public partial void ProcessEventSpecificDirectorUpdate(uint category, uint arg1, uint arg2, uint arg3, uint arg4);
+
     [VirtualFunction(70)]
     public partial void CancelByPlayerMovement(bool a2, bool a3);
 

--- a/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/ContentDirector.cs
@@ -27,6 +27,10 @@ public unsafe partial struct ContentDirector {
     [VirtualFunction(304)]
     public partial uint GetMaxLevel();
 
+    /// <summary>Processes updates specific for this director. This handles the categories between 0 and 0x80000000.</summary>
+    [VirtualFunction(325)]
+    public partial void ProcessDirectorSpecificDirectorUpdate(uint category, uint* parameters);
+
     /// <summary>
     /// Gets the max time for the content in seconds
     /// </summary>
@@ -46,6 +50,10 @@ public unsafe partial struct ContentDirector {
     /// <param name="timelineIndex">Which timeline to play.</param>
     [MemberFunction("E8 ?? ?? ?? ?? 3A C3 74 ?? 44 0F B7 C5")]
     public partial bool PlayMapEffectTimeline(uint index, ushort timelineIndex);
+
+    /// <summary>Processes updates shared between all content (e.g. setting the background music). This handles categories above 0x80000000.</summary>
+    [MemberFunction("48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 81 C2 ?? ?? ?? ?? 41 8B E9")]
+    public partial void ProcessCommonDirectorUpdate(uint category, uint arg1, uint arg2, uint arg3, uint arg4);
 
     [GenerateInterop]
     [StructLayout(LayoutKind.Explicit, Size = 0x608)]

--- a/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/InstanceContentDirector.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/InstanceContentDirector.cs
@@ -9,7 +9,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
 [Inherits<ContentDirector>]
 [VirtualTable("48 8D 05 ?? ?? ?? ?? B9 ?? ?? ?? ?? ?? ?? ?? 33 ED 48 8D 05", 3, 406)]
 [StructLayout(LayoutKind.Explicit, Size = 0x1F98)]
-public partial struct InstanceContentDirector {
+public unsafe partial struct InstanceContentDirector {
     [FieldOffset(0xD30 + 0x00), CExporterExcelBegin("InstanceContent")] public uint NewPlayerBonusGil;
     [FieldOffset(0xD30 + 0x04)] public uint NewPlayerBonusExp;
     [FieldOffset(0xD30 + 0x08)] public uint FinalBossExp;
@@ -82,6 +82,14 @@ public partial struct InstanceContentDirector {
     [FieldOffset(0xD30 + 0xA7), CExporterExcelEnd] private byte Unknown14_Unknown15_Unknown16_Unknown17_Unknown18;
 
     [FieldOffset(0xDE0)] public ContentDirector.MapEffectList ManagedSharedGroups;
+
+    /// <summary>Dispatches updates specific to the content. This ends up calling ProcessContentSpecificDirectorUpdate and unrolls the parameters array.</summary>
+    [VirtualFunction(380)]
+    public partial void DispatchContentSpecificDirectorUpdate(uint category, uint* parameters);
+
+    /// <summary>Processes updates specific to the content. This handles the categories between 0 and 0x40000000.</summary>
+    [VirtualFunction(381)]
+    public partial void ProcessContentSpecificDirectorUpdate(uint category, uint arg1, uint arg2, uint arg3, uint arg4);
 }
 
 public enum InstanceContentType : byte {

--- a/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/PublicContentDirector.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/InstanceContent/PublicContentDirector.cs
@@ -10,7 +10,7 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.InstanceContent;
 [Inherits<ContentDirector>]
 [VirtualTable("48 8D 05 ?? ?? ?? ?? BA ?? ?? ?? ?? ?? ?? ?? 33 C9 48 8D 05 ?? ?? ?? ?? 48 89 83", 3, 389)]
 [StructLayout(LayoutKind.Explicit, Size = 0x1380)]
-public partial struct PublicContentDirector {
+public unsafe partial struct PublicContentDirector {
     [FieldOffset(0xD30 + 0x00), CExporterExcelBegin("PublicContent")] public uint NameOffset;
     [FieldOffset(0xD30 + 0x04)] public uint MapIcon;
     [FieldOffset(0xD30 + 0x08)] public uint TextDataStart;
@@ -31,6 +31,14 @@ public partial struct PublicContentDirector {
     [FieldOffset(0xD30 + 0x31), CExporterExcelEnd] private byte Unknown4;
 
     [FieldOffset(0xD64)] public ContentDirector.MapEffectList ManagedSharedGroups;
+
+    /// <summary>Dispatches updates specific to the content. This ends up calling ProcessContentSpecificDirectorUpdate and unrolls the parameters array.</summary>
+    [VirtualFunction(373)]
+    public partial void DispatchContentSpecificDirectorUpdate(uint category, uint* parameters);
+
+    /// <summary>Processes updates specific to the content. This handles the categories between 0 and 0x40000000.</summary>
+    [VirtualFunction(374)]
+    public partial void ProcessContentSpecificDirectorUpdate(uint category, uint arg1, uint arg2, uint arg3, uint arg4);
 }
 
 public enum PublicContentDirectorType : byte {

--- a/FFXIVClientStructs/FFXIV/Client/Game/MassivePcContent/MassivePcContentDirector.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/MassivePcContent/MassivePcContentDirector.cs
@@ -11,4 +11,12 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.MassivePcContent;
 [StructLayout(LayoutKind.Explicit, Size = 0x918)]
 public unsafe partial struct MassivePcContentDirector {
     [FieldOffset(0x600), FixedSizeArray] internal FixedSizeArray2<StdVector<MassivePcContentTodo>> _massivePcContentTodos;
+
+    /// <summary>Processes updates specific for this director. This handles the categories between 0 and 0x80000000.</summary>
+    [VirtualFunction(325)]
+    public partial void ProcessDirectorSpecificDirectorUpdate(uint category, uint* parameters);
+
+    /// <summary>Processes updates shared between all content (e.g. setting the background music). This handles categories above 0x80000000.</summary>
+    [MemberFunction("48 89 5C 24 ?? 57 48 83 EC ?? 81 C2 ?? ?? ?? ?? 41 8B F8")]
+    public partial void ProcessCommonDirectorUpdate(uint category, uint arg1, uint arg2, uint arg3, uint arg4);
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -19360,6 +19360,9 @@ classes:
     vtbls:
       - ea: 0x1421A93E0
         base: Client::Game::InstanceContent::ContentDirector
+    vfuncs:
+      373: DispatchContentSpecificDirectorUpdate
+      374: ProcessContentSpecificDirectorUpdate
     funcs:
       0x140BB0EE0: ctor
       0x140BB1690: OnEndCutscene

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -16260,6 +16260,7 @@ classes:
       59: ProcessFormatStringCallback
       60: ProcessActionTimelineCallback
       61: ProcessDirectorUpdate
+      62: ProcessEventSpecificDirectorUpdate
       70: CancelByPlayerMovement
       76: ProcessListenItemCallback
       159: CancelInteraction
@@ -18224,6 +18225,7 @@ classes:
     vfuncs:
       303: GetCurrentLevel
       304: GetMaxLevel
+      325: ProcessDirectorSpecificDirectorUpdate
       329: GetContentTimeMax
       330: GetContentTypeIconId
       335: SetExperience
@@ -18232,6 +18234,7 @@ classes:
       0x140B702C0: ApplyMapEffect
       0x140B70130: PlayMapEffectTimeline
       0x140B71240: IsPlayCutscene
+      0x140B6EF90: ProcessCommonDirectorUpdate
   Client::Game::InstanceContent::InstanceContentDirector:
     vtbls:
       - ea: 0x142313930
@@ -18239,6 +18242,8 @@ classes:
       - ea: 0x1423145E0
         base: Client::Game::InstanceContent::ContentSheetWaiterInterface
     vfuncs:
+      380: DispatchContentSpecificDirectorUpdate
+      381: ProcessContentSpecificDirectorUpdate
       403: HandleGMCommand
     funcs:
       0x1419A8DD0: ctor
@@ -19479,9 +19484,11 @@ classes:
       312: SetAdditionalTodoLargeBlueText
       313: SetAdditionalTodoLargeGrayText
       314: SetAdditionalTodoJoinButton
+      325: ProcessDirectorSpecificDirectorUpdate
       334: ClearAdditionalTodo
     funcs:
       0x141A1E7F0: ctor
+      0x141A20360: ProcessCommonDirectorUpdate
       0x141A24240: IsPlayCutscene
       0x141A24310: OnEndCutscene
       0x141A243E0: OnFinishCutscene


### PR DESCRIPTION
Fill out hierarchy of director update handlers

This system is how almost all content are updated and managed (apart
from any dedicated packets of course). The category is the most
interesting thing here, and broken into three distinct groups:

* 0x80000000 and above means that the update is specialized at the
Director level. This includes common and boring stuff like setting the
BGM.
* 0x40000000 and above means that the update is specialized at the
Director ContentType level. This means PublicContent, InstanceContent,
etc. can have their own set of updates here.
* Anything below 0x40000000 can be handled in two places: in the
specialized content classes and event handlers. One example to look at
is InstanceContentCrystallineConflictDirector which has to handle
special updates related to being promoted/demoted in rankings.

Now that these functions are named, I can find out how a handler
responds to a specific update much more easily :-)