### PR TITLE
Add a bit more BonePhysicsModule stuff I care about

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Physics/BonePhysicsModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Physics/BonePhysicsModule.cs
@@ -39,6 +39,13 @@ public unsafe partial struct BonePhysicsModule {
     /// </summary>
     [MemberFunction("E8 ?? ?? ?? ?? 48 8B 03 48 8B CB FF C6")]
     public partial void Load(BonePhysicsResourceHandle* handle, uint resourceIndex);
+
+    [MemberFunction("48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 0F 29 74 24 ?? 48 8B FA 48 8B D9")]
+    public partial bool Initialize(Skeleton *skeleton);
+
+    /// <summary> When set, Characters set OverrideSimulationTime to true for their BonePhysicsModules. Currently this is set to false by default. </summary>
+    [StaticAddress("38 1D ?? ?? ?? ?? F3 0F 10 3D", 2)]
+    public static partial bool* GetForceOverrideSimulationTime();
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x78)]

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -20,7 +20,7 @@ globals:
   0x1428860B0: g_LanguageCharArr # byte[] no pointer
   0x1428884E8: g_Client::Game::Control::InputManager_MouseButtonHoldState
   0x1428885E0: g_GlobalUIScale
-  0x1428A40D0: g_60FPS # Used as a divisor in BoneSimulator calculations
+  0x1428A40D0: g_BoneSimulatorFrameRate # 60FPS, used as a divisor in BoneSimulator calculations
   0x1428A40D4: g_ForceOverrideSimulationTime # BonePhysicsModule.GetForceOverrideSimulationTime
   0x1428B5C78: g_StackCookie
   0x1428B5C70: g_InverseStackCookie

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -20,6 +20,8 @@ globals:
   0x1428860B0: g_LanguageCharArr # byte[] no pointer
   0x1428884E8: g_Client::Game::Control::InputManager_MouseButtonHoldState
   0x1428885E0: g_GlobalUIScale
+  0x1428A40D0: g_60FPS # Used as a divisor in BoneSimulator calculations
+  0x1428A40D4: g_ForceOverrideSimulationTime # BonePhysicsModule.GetForceOverrideSimulationTime
   0x1428B5C78: g_StackCookie
   0x1428B5C70: g_InverseStackCookie
   0x1428D1CF8: g_stdout


### PR DESCRIPTION
I finally found the global that appears to help paper over issues >60 FPS, so I added that boolean. I'm unsure who it is under, BonePhysicsModule makes the most sense I think.

Additionally, I added the Initialize member function as that's another place where the g_60FPS global is used for certain calculations.