### PR TITLE
AddonNamePlate, AtkTextNode TextFlags and ConfigModule

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonNamePlate.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonNamePlate.cs
@@ -19,12 +19,12 @@ public unsafe partial struct AddonNamePlate {
     // Client::UI::AddonNamePlate::BakePlateRenderer
     //   Component::GUI::AtkTextNodeRenderer
     //     Component::GUI::AtkResourceRendererBase
-    // might be 238 not 240 but not super relevant here
     [StructLayout(LayoutKind.Explicit, Size = 0x240)]
     public struct BakePlateRenderer {
         [FieldOffset(0xB0)] public Texture* Texture;
-        [FieldOffset(0x230)] public byte DisableFixedFontResolution; // added in 5.5
         [FieldOffset(0x1E0)] public AtkRenderTexture RenderTexture;
+        [FieldOffset(0x228)] public BakeData* CurrentBakeData;
+        [FieldOffset(0x230)] public byte DisableFixedFontResolution; // added in 5.5
     }
 
     // this is the pre-rendered texture data for a nameplate
@@ -35,6 +35,7 @@ public unsafe partial struct AddonNamePlate {
         [FieldOffset(0x2)] public short V;
         [FieldOffset(0x4)] public short Width;
         [FieldOffset(0x6)] public short Height;
+        [FieldOffset(0x8)] public short TextYOffset;
         [FieldOffset(0xA)] public byte Alpha;
         [FieldOffset(0xB)] public bool IsBaked;
     }
@@ -63,9 +64,9 @@ public unsafe partial struct AddonNamePlate {
         [FieldOffset(0x6D)] public byte HPLabelState;
         [FieldOffset(0x6E)] public bool ClickThrough;
         [FieldOffset(0x6F)] public bool IsPvpEnemy;
-        // [FieldOffset(0x70)] private bool UnkBool;
+        [FieldOffset(0x70)] public bool UseAttackCursor;
         [FieldOffset(0x71)] public bool NeedsToBeBaked;
-        // [FieldOffset(0x72)] private int UnkBakeState;
+        [FieldOffset(0x72)] public bool DrawOriginalText;
         public bool IsVisible => RootComponentNode->IsVisible();
 
         public bool IsPlayerCharacter => NamePlateKind == UIObjectKind.PlayerCharacter;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGearSet.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentGearSet.cs
@@ -9,9 +9,11 @@ namespace FFXIVClientStructs.FFXIV.Client.UI.Agent;
 // Client::UI::Agent::AgentGearSet
 //   Client::UI::Agent::AgentInterface
 //     Component::GUI::AtkModuleInterface::AtkEventInterface
+//   Client::UI::Misc::ConfigModule::ConfigEventInterface
 [Agent(AgentId.GearSet)]
 [GenerateInterop]
 [Inherits<AgentInterface>]
+[Inherits<ConfigModule.ConfigEventInterface>]
 [StructLayout(LayoutKind.Explicit, Size = 0xBD0)]
 public unsafe partial struct AgentGearSet {
     [FieldOffset(0x48), FixedSizeArray] internal FixedSizeArray14<ContextMenuParam> _contextMenuParams;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Arrays/NamePlateNumberArray.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Arrays/NamePlateNumberArray.cs
@@ -45,7 +45,10 @@ public unsafe partial struct NamePlateNumberArray {
         // [FieldOffset(16 * 4)] private int Unk;
         /// <summary>
         /// &amp; 0x1 - Is prefix title<br/>
+        /// &amp; 0x4 - PvP enemy<br/>
         /// &amp; 0x8 - Use Depth-based Priority (terrain obstruction)<br/>
+        /// &amp; 0x20 - Enable gauge<br/>
+        /// &amp; 0x40 - Use attack cursor<br/>
         /// &amp; 0x80 - Hide title<br/>
         /// &amp; 0x100 - Disable Alternate Part Id<br/>
         /// </summary>

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/ConfigModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/ConfigModule.cs
@@ -1,5 +1,6 @@
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Common.Configuration;
+using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 
@@ -18,30 +19,44 @@ public unsafe partial struct ConfigModule {
     [FieldOffset(0x28)] public UIModule* UIModule;
     [FieldOffset(0x300), FixedSizeArray] internal FixedSizeArray746<Option> _options;
 
+    [Obsolete("Use ValueSets")]
     [FieldOffset(0x6040), FixedSizeArray] internal FixedSizeArray2238<OptionValue> _values;
+    [FieldOffset(0x6040), FixedSizeArray] internal FixedSizeArray3<ValueSet> _valueSets;
 
     [StructLayout(LayoutKind.Explicit, Size = 0x20)]
     public struct Option {
-        [FieldOffset(0x00)] public ConfigOption ConfigOptionId;
+        [FieldOffset(0x00)] public ConfigOption OptionId;
         [FieldOffset(0x04)] public uint CategoryMask;
         [FieldOffset(0x08)] public uint MaxValueIndex;
         [FieldOffset(0x0C)] public byte BitIndex;
         [FieldOffset(0x0D)] public bool InvertValue;
-        [FieldOffset(0x0E)] private ushort Padding0E;
-        [FieldOffset(0x10)] private void* ValueChangeCallback;
-        [Obsolete("Incorrect offset. Use ConfigOptionId.")]
-        [FieldOffset(0x10)] public ConfigOption OptionId;
-        [FieldOffset(0x18)] private uint ValueChangeCallbackParamOffset;
+        [FieldOffset(0x10)] public OptionHandler Handler;
+
+        public ConfigEntry* GetConfigEntry() {
+            if (OptionId <= ConfigOption.None) return null;
+            return Framework.Instance()->SystemConfig.GetConfigOption(OptionId);
+        }
 
         public string GetName() {
-            if ((short)ConfigOptionId < 0) return string.Empty;
-            var framework = Framework.Instance();
-            if (framework == null) return string.Empty;
-            var entry = ((ConfigBase*)&framework->SystemConfig)->GetConfigOption((uint)ConfigOptionId);
+            var entry = GetConfigEntry();
             return entry == null || entry->Type == 0 || !entry->Name.HasValue ? string.Empty : entry->Name.ToString();
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = 0x10)]
+        public struct OptionHandler { // similar to how UIModuleHandler works
+            [FieldOffset(0x00)] public delegate* unmanaged<void*, int, Option*, int, int, int, int> FunctionPtr; // used by SetValueByIndex/GetValueByIndex to save/provide custom values
+            [FieldOffset(0x08)] public uint ConfigModuleOffset;
+
+            public delegate int FunctionDelegate(void* thisPtr, int optionIndex, Option* option, int mode, int newValue, int valueSetIndex);
         }
     }
 
-    [StructLayout(LayoutKind.Explicit, Size = 0x10)]
+    [GenerateInterop]
+    [StructLayout(LayoutKind.Explicit, Size = ConfigOptionCount * AtkValue.StructSize)]
+    public partial struct ValueSet {
+        [FieldOffset(0), FixedSizeArray] internal FixedSizeArray746<AtkValue> _values;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0x10), Obsolete("Use AtkValue")]
     public struct OptionValue;
 }

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/ConfigModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/ConfigModule.cs
@@ -1,5 +1,5 @@
-using System.Text;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
+using FFXIVClientStructs.FFXIV.Common.Configuration;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 
@@ -22,27 +22,23 @@ public unsafe partial struct ConfigModule {
 
     [StructLayout(LayoutKind.Explicit, Size = 0x20)]
     public struct Option {
-        [FieldOffset(0x00)] private void* Unk00;
-        [FieldOffset(0x08)] private ulong Unk08;
+        [FieldOffset(0x00)] public ConfigOption ConfigOptionId;
+        [FieldOffset(0x04)] public uint CategoryMask;
+        [FieldOffset(0x08)] public uint MaxValueIndex;
+        [FieldOffset(0x0C)] public byte BitIndex;
+        [FieldOffset(0x0D)] public bool InvertValue;
+        [FieldOffset(0x0E)] private ushort Padding0E;
+        [FieldOffset(0x10)] private void* ValueChangeCallback;
+        [Obsolete("Incorrect offset. Use ConfigOptionId.")]
         [FieldOffset(0x10)] public ConfigOption OptionId;
-        [FieldOffset(0x14)] private uint Unk14;
-        [FieldOffset(0x18)] private uint Unk18;
-        [FieldOffset(0x1C)] private ushort Unk1C;
+        [FieldOffset(0x18)] private uint ValueChangeCallbackParamOffset;
 
         public string GetName() {
-            if ((short)OptionId < 0) return string.Empty;
+            if ((short)ConfigOptionId < 0) return string.Empty;
             var framework = Framework.Instance();
             if (framework == null) return string.Empty;
-            var sysConfig = framework->SystemConfig;
-            var id = (uint)OptionId;
-            byte* namePtr = null;
-            if (sysConfig.ConfigCount > id) namePtr = (sysConfig.ConfigEntry + id)->Name;
-            if (namePtr == null && sysConfig.ConfigCount > id) namePtr = (sysConfig.ConfigEntry + id)->Name;
-            if (namePtr == null && sysConfig.ConfigCount > id) namePtr = (sysConfig.ConfigEntry + id)->Name;
-            if (namePtr == null) return string.Empty;
-            var l = 0;
-            while (namePtr[l] != 0) l++;
-            return l == 0 ? string.Empty : $"{Encoding.UTF8.GetString(namePtr, l)}";
+            var entry = ((ConfigBase*)&framework->SystemConfig)->GetConfigOption((uint)ConfigOptionId);
+            return entry == null || entry->Type == 0 || !entry->Name.HasValue ? string.Empty : entry->Name.ToString();
         }
     }
 

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/ConfigModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/ConfigModule.cs
@@ -1,6 +1,7 @@
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Common.Configuration;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using FFXIVClientStructs.FFXIV.Component.Text;
 using AtkEventInterface = FFXIVClientStructs.FFXIV.Component.GUI.AtkModuleInterface.AtkEventInterface;
 using ChangeEventInterface = FFXIVClientStructs.FFXIV.Common.Configuration.ConfigBase.ChangeEventInterface;
 
@@ -23,9 +24,18 @@ public unsafe partial struct ConfigModule {
 
     public const int ConfigOptionCount = 746;
     [FieldOffset(0x28)] public UIModule* UIModule;
+
+    [FieldOffset(0x88)] public Utf8String CharacterName;
+    [FieldOffset(0xF0)] public Utf8String WorldName;
+    [FieldOffset(0x158)] public uint CurrentClassJobLevel;
+    [FieldOffset(0x15C)] public uint CurrentClassJobId;
+    [FieldOffset(0x160)] public uint PlaceName;
+    [FieldOffset(0x168)] public StdDeque<TextParameter> CharacterInfoParameters;
+    [FieldOffset(0x190)] public Utf8String CharacterInfo;
+
     [FieldOffset(0x2F0)] public ConfigEventInterface* ConfigEventListeners;
     [FieldOffset(0x2F8)] public bool IsApplyingConfigChange;
-    [FieldOffset(0x2F9)] private bool Unk2F9;
+    [FieldOffset(0x2F9)] public bool HasClientSelectDataConfigFlags;
     [FieldOffset(0x300), FixedSizeArray] internal FixedSizeArray746<Option> _options;
 
     [Obsolete("Use ValueSets")]
@@ -84,6 +94,7 @@ public unsafe partial struct ConfigModule {
         [FieldOffset(0), FixedSizeArray] internal FixedSizeArray746<AtkValue> _values;
     }
 
+    // Client::UI::Misc::ConfigModule::ConfigEventInterface
     [GenerateInterop(isInherited: true)]
     [StructLayout(LayoutKind.Explicit, Size = 0x18)]
     public unsafe partial struct ConfigEventInterface {
@@ -91,7 +102,7 @@ public unsafe partial struct ConfigModule {
         [FieldOffset(0x10)] public ConfigModule* Owner;
 
         [VirtualFunction(0)]
-        public partial void OnConfigChange(int valueSetIndex, bool unk);
+        public partial void OnConfigChange(int valueSetIndex, bool hasClientSelectDataConfigFlags);
     }
 
     [StructLayout(LayoutKind.Explicit, Size = 0x10), Obsolete("Use AtkValue")]

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/ConfigModule.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/ConfigModule.cs
@@ -1,14 +1,20 @@
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Common.Configuration;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using AtkEventInterface = FFXIVClientStructs.FFXIV.Component.GUI.AtkModuleInterface.AtkEventInterface;
+using ChangeEventInterface = FFXIVClientStructs.FFXIV.Common.Configuration.ConfigBase.ChangeEventInterface;
 
 namespace FFXIVClientStructs.FFXIV.Client.UI.Misc;
 
 // Client::UI::Misc::ConfigModule
+//   Component::GUI::AtkModuleInterface::AtkEventInterface
+//   Common::Configuration::ConfigBase::ChangeEventInterface
 // For updating offsets:
 //    16 * (v6 + ConfigOptionCount * a6) + a1 + {ValuesFieldOffset}
 [GenerateInterop]
+[Inherits<AtkEventInterface>, Inherits<ChangeEventInterface>(parentOffset: 0x10)]
 [StructLayout(LayoutKind.Explicit, Size = 0xED10)]
+[VirtualTable("48 8D 05 ?? ?? ?? ?? 48 89 01 48 8B F9 4C 89 79 20 48 8D 05 ?? ?? ?? ?? 48 89 41 10 48 89 51 28", 3, 3)]
 public unsafe partial struct ConfigModule {
     public static ConfigModule* Instance() {
         var uiModule = UI.UIModule.Instance();
@@ -17,11 +23,32 @@ public unsafe partial struct ConfigModule {
 
     public const int ConfigOptionCount = 746;
     [FieldOffset(0x28)] public UIModule* UIModule;
+    [FieldOffset(0x2F0)] public ConfigEventInterface* ConfigEventListeners;
+    [FieldOffset(0x2F8)] public bool IsApplyingConfigChange;
+    [FieldOffset(0x2F9)] private bool Unk2F9;
     [FieldOffset(0x300), FixedSizeArray] internal FixedSizeArray746<Option> _options;
 
     [Obsolete("Use ValueSets")]
     [FieldOffset(0x6040), FixedSizeArray] internal FixedSizeArray2238<OptionValue> _values;
     [FieldOffset(0x6040), FixedSizeArray] internal FixedSizeArray3<ValueSet> _valueSets;
+
+    [MemberFunction("48 8B 81 ?? ?? ?? ?? 4C 8B C1 48 3B C2")]
+    public partial void RegisterConfigEvent(ConfigEventInterface* configEventInterface);
+
+    [MemberFunction("48 8B 81 ?? ?? ?? ?? 48 3B C2 75 ?? 48 8B 42")]
+    public partial void UnregisterConfigEvent(ConfigEventInterface* configEventInterface);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 4C 69 C7")]
+    public partial bool SetValueByIndex(int optionIndex, int value, int valueSetIndex, bool apply, bool notifyListeners);
+
+    [MemberFunction("E8 ?? ?? ?? ?? 33 DB 83 E7")]
+    public partial int GetValueByIndex(int optionIndex, int valueSetIndex);
+
+    [MemberFunction("48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 41 54 41 56 41 57 48 83 EC ?? 45 33 E4")]
+    public partial void ResetOptionsByCategoryMask(uint categoryMask, int valueSetIndex);
+
+    [MemberFunction("48 89 6C 24 ?? 48 89 74 24 ?? 41 56 48 83 EC ?? 45 32 F6")]
+    public partial bool IsValueChanged(int optionIndex, int valueSetIndex);
 
     [StructLayout(LayoutKind.Explicit, Size = 0x20)]
     public struct Option {
@@ -55,6 +82,16 @@ public unsafe partial struct ConfigModule {
     [StructLayout(LayoutKind.Explicit, Size = ConfigOptionCount * AtkValue.StructSize)]
     public partial struct ValueSet {
         [FieldOffset(0), FixedSizeArray] internal FixedSizeArray746<AtkValue> _values;
+    }
+
+    [GenerateInterop(isInherited: true)]
+    [StructLayout(LayoutKind.Explicit, Size = 0x18)]
+    public unsafe partial struct ConfigEventInterface {
+        [FieldOffset(0x08)] public ConfigEventInterface* NextInterface;
+        [FieldOffset(0x10)] public ConfigModule* Owner;
+
+        [VirtualFunction(0)]
+        public partial void OnConfigChange(int valueSetIndex, bool unk);
     }
 
     [StructLayout(LayoutKind.Explicit, Size = 0x10), Obsolete("Use AtkValue")]

--- a/FFXIVClientStructs/FFXIV/Common/Configuration/ConfigBase.cs
+++ b/FFXIVClientStructs/FFXIV/Common/Configuration/ConfigBase.cs
@@ -89,12 +89,14 @@ public unsafe partial struct ConfigBase {
     [MemberFunction("E8 ?? ?? ?? ?? 44 8B C3 39 58")]
     public partial ConfigEntry* GetConfigOption(uint index);
 
+    public ConfigEntry* GetConfigOption(ConfigOption configOption) => GetConfigOption((uint)configOption);
+
     // Common::Configuration::ConfigBase::ChangeEventInterface
     // implemented by objects that want to listen for config changes - rapture atk module, etc
     [GenerateInterop(isInherited: true)]
     [StructLayout(LayoutKind.Explicit, Size = 0x18)]
     public unsafe partial struct ChangeEventInterface {
-        [FieldOffset(0x8)] public ChangeEventInterface* NextInterface;
+        [FieldOffset(0x08)] public ChangeEventInterface* NextInterface;
         [FieldOffset(0x10)] public ConfigBase* Owner;
 
         [VirtualFunction(1)]

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkTextNode.cs
@@ -26,6 +26,7 @@ public unsafe partial struct AtkTextNode : ICreatable<AtkTextNode> {
     [FieldOffset(0x148)] public uint SelectStart;
     [FieldOffset(0x14C)] public uint SelectEnd;
 
+    [FieldOffset(0x160)] public byte NumberFormat;
     [FieldOffset(0x162)] public byte LineSpacing;
     [FieldOffset(0x163)] public byte CharSpacing;
     /// <remarks>Alignment bits 0-3, Font Type bits 4-7</remarks>
@@ -117,8 +118,14 @@ public enum TextFlags : ushort {
     WordWrap = 1 << 6,
     MultiLine = 1 << 7,
     OverflowHidden = 1 << 8,
-    FixedFontResolution = 1 << 9,
+    LinkData = 1 << 9,
+    [Obsolete("Use LinkData for this value or UseFixedFontResolution for fixed font resolution.")]
+    FixedFontResolution = LinkData,
     Ellipsis = 1 << 10,
+    // Unk11 = 1 << 11, // Copied to AtkTextNodeRenderer flags 0x20000000.
+    UseFixedFontResolution = 1 << 12, // TODO: Rename to FixedFontResolution
+    // Unk13 = 1 << 13, // Copied to AtkTextNodeRenderer +0x167 used by glyph/font fallback checks.
+    FontCache = 1 << 14,
 }
 
 public enum FontType : byte {
@@ -143,9 +150,9 @@ public unsafe struct LinkData {
 
     /// <remarks> The type of the Link payload. See LinkMacroPayloadType in Lumina. </remarks>
     [FieldOffset(0x1B)] public byte LinkType;
-    [FieldOffset(0x1C)] private ushort Unk1C;
-    [FieldOffset(0x1E)] private ushort Unk1E;
-    [FieldOffset(0x20)] private uint Unk20;
+    [FieldOffset(0x1C)] public ushort LinkId;
+    [FieldOffset(0x1E)] public ushort LinkIndex;
+    [FieldOffset(0x20)] public uint LinkGroupId;
     // These are the 3 link payload parameters. Usually SeStrings have int expressions.
     [FieldOffset(0x24), CExporterUnion("Value1")] public int IntValue1;
     [FieldOffset(0x24), CExporterUnion("Value1")] public uint UIntValue1;

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -11146,10 +11146,20 @@ classes:
       - ea: 0x14218C508
         base: Common::Configuration::ConfigBase::ChangeEventInterface
     funcs:
+      0x1407B8C40: RegisterOption
+      0x1407B8CA0: InitializeOptions
+      0x1407C4BE0: ReadConfigEntryValue
+      0x1407C4D50: ApplyConfigEntryValue
       0x1407C5F40: ctor
       0x1407C62D0: SetValueByIndex
       0x1407C6490: GetValueByIndex
+      0x1407C6520: ResetOptionsByCategoryMask
+      0x1407C69F0: IsValueChanged
       0x1407C7C00: Update
+      0x1407C8160: RegisterConfigEvent
+      0x1407C81D0: UnregisterConfigEvent
+      0x1407C8230: ReceiveEvent
+      0x1407C8300: OnConfigChange
   Client::UI::Misc::FieldMarkerModule:
     vtbls:
       - ea: 0x14218D2A0

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -12869,6 +12869,8 @@ classes:
     vtbls:
       - ea: 0x1421695D0
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x142169650
+        base: Client::UI::Misc::ConfigModule::ConfigEventInterface
     funcs:
       0x140503740: ctor
       0x140503810: Finalizer
@@ -13364,6 +13366,8 @@ classes:
     vtbls:
       - ea: 0x1421F4B98
         base: Client::UI::Agent::AgentInterface
+      - ea: 0x1421F4C18
+        base: Client::UI::Misc::ConfigModule::ConfigEventInterface
     funcs:
       0x140FF7170: ctor
       0x140FF7430: Finalizer


### PR DESCRIPTION
Some small AddonNamePlate changes.

Some tweaks to the TextFlags, FixedFontResolution was wrong, if you rather want I make it a breaking change let me know.

https://github.com/user-attachments/assets/c0e51ab0-a2c5-4e83-a4ae-386cba57ed68

OptionId in ConfigModule was wrong, that did give an opportunity to clean up GetName()
Added a CSV so you can see it working.

[ConfigModuleDump_20260808_155416.csv](https://github.com/user-attachments/files/30857101/ConfigModuleDump_20260808_155416.csv)

(I had it make a TSV earlier but GitHub does not like TSVs).
```
private static string WriteConfigModuleDump(ConfigModule* module, Framework* framework)
    {
        var directory = Service.PluginInterface.ConfigDirectory.FullName;
        Directory.CreateDirectory(directory);

        var path = Path.Combine(directory, $"ConfigModuleDump_{DateTime.Now:yyyyMMdd_HHmmss}.tsv");
        using var writer = new StreamWriter(path, false, new UTF8Encoding(false));

        writer.WriteLine("ConfigModule.Option entries");
        writer.WriteLine("EntryIndex\tConfigOptionId\tOldField0x10\tOldSystemGetName\tCurrentGetName\tCandidateNames\tCategoryMask0x04\tMaxValueIndex0x08\tBitIndex0x0C\tInvert0x0D\tWord0E\tQword00\tQword08\tQword10\tQword18\tCallback0x10\tCallbackContextOffset0x18\tMetadataDword1C\tRawBytes");

        for (var i = 0; i < ConfigModule.ConfigOptionCount; i++)
        {
            var option = (ConfigModule.Option*)((byte*)module + 0x300 + i * 0x20);
            var configOptionId = *(short*)option;
            var oldField = *(short*)((byte*)option + 0x10);
            var mask = *(uint*)((byte*)option + 0x04);
            var maxValueIndex = *(uint*)((byte*)option + 0x08);
            var bitIndex = *((byte*)option + 0x0C);
            var invert = *((byte*)option + 0x0D);
            var word0E = *(ushort*)((byte*)option + 0x0E);
            var qword00 = *(ulong*)((byte*)option + 0x00);
            var qword08 = *(ulong*)((byte*)option + 0x08);
            var qword10 = *(ulong*)((byte*)option + 0x10);
            var qword18 = *(ulong*)((byte*)option + 0x18);
            var callbackContextOffset = *(uint*)((byte*)option + 0x18);
            var metadataDword1C = *(uint*)((byte*)option + 0x1C);
            var oldName = oldField < 0 ? string.Empty : GetConfigName((ConfigBase*)&framework->SystemConfig, (uint)oldField);
            var currentName = option->GetName();
            var candidateNames = configOptionId < 0
                ? string.Empty
                : ResolveConfigName(framework, configOptionId, out _);

            writer.WriteLine(string.Join('\t',
                i.ToString(CultureInfo.InvariantCulture),
                configOptionId.ToString(CultureInfo.InvariantCulture),
                oldField.ToString(CultureInfo.InvariantCulture),
                Tsv(oldName),
                Tsv(currentName),
                Tsv(candidateNames),
                $"0x{mask:X}",
                maxValueIndex.ToString(CultureInfo.InvariantCulture),
                $"0x{bitIndex:X2}",
                $"0x{invert:X2}",
                $"0x{word0E:X4}",
                $"0x{qword00:X16}",
                $"0x{qword08:X16}",
                $"0x{qword10:X16}",
                $"0x{qword18:X16}",
                $"0x{qword10:X16}",
                $"0x{callbackContextOffset:X8}",
                $"0x{metadataDword1C:X8}",
                RawBytes((byte*)option, 0x20)));
        }

        writer.WriteLine();
        writer.WriteLine("ConfigBase entries");
        writer.WriteLine("Section\tIndex\tType\tName\tValue\tDefault\tMin\tMax");

        var systemConfig = &framework->SystemConfig;
        WriteConfigBaseDump(writer, "System", (ConfigBase*)systemConfig);
        WriteConfigBaseDump(writer, "UiConfig", &systemConfig->UiConfig);
        WriteConfigBaseDump(writer, "UiControl", &systemConfig->UiControlConfig);
        WriteConfigBaseDump(writer, "UiControlGamepad", &systemConfig->UiControlGamepadConfig);

        return path;
    }
```