### PR TITLE
Fix srclang VFT gap filling

### DIFF
--- a/ida/ffxiv_structimporter.py
+++ b/ida/ffxiv_structimporter.py
@@ -975,14 +975,33 @@ if api is None:
                     size = int(struct.vtable_size / 8)
                 else:
                     size = int(self.get_struct_size(s) / 8)
+
                 for i in range(size):
-                    if self.get_struct_member_id(s, i * 8) == idc.BADADDR:
+                    offset = i * 8
+                    member_id = self.get_struct_member_id(s, offset)
+                    udm_idx, udm = s.get_udm_by_offset(offset * 8)
+
+                    # srclang ends up with gap UDMs in VFTs that need to be deleted and filled back out as vf## placeholders
+                    is_vft_gap = (
+                        udm is not None
+                        and udm.name.startswith("gap")
+                        and udm.type.dstr().startswith("_BYTE[")
+                    )
+                    if is_vft_gap:
+                        result = s.del_udm(udm_idx)
+                        if result == ida_typeinf.TERR_OK:
+                            member_id = idc.BADADDR
+                        else:
+                            print(
+                                f"Error: failed to delete VFT gap UDM {fullname}.{udm.name} "
+                                f"at slot {i}: {ida_typeinf.tinfo_errstr(result)}"
+                            )
+                    if member_id == idc.BADADDR:
                         name = "vf{0}".format(i)
-                        
                         fallback_name = self.get_fallback_vfunc_name(struct.type, i)
                         if fallback_name:
                             name = fallback_name
-                        
+
                         self.create_struct_member(
                             s,
                             name,

--- a/ida/ida_wrapper.py
+++ b/ida/ida_wrapper.py
@@ -1084,10 +1084,10 @@ class IdaInterface(BaseIdaInterface):
                 offset (int): The offset of the member in the struct
 
             Returns:
-                int: The member id inside of the struct or -1 if not found
+                int: The member id inside of the struct or idc.BADADDR if not found
             """
-            idx, _ = sid.get_udm_by_offset(offset)
-            return idx
+            idx, _ = sid.get_udm_by_offset(offset * 8)
+            return idc.BADADDR if idx == -1 else idx
 
         def get_enum_id(self, name: str):
             """Get the id of an enum by its name


### PR DESCRIPTION
This fixes an issue with the srclang importer failing to fill gaps in VFT structs as `gap` UDMs were created but not visible in the UI, and therefor would cause `create_struct_member` to silently fail. With this change, we now check for these gap UDMs and delete them before filling out empty slots.

Before:
```
00000290     Client::UI::UIInputModule *(__fastcall *GetUIInputModule)(Client::UI::UIModuleInterface *this);
00000298     // padding byte (hidden gap udm)
00000299     // padding byte
0000029A     // padding byte
0000029B     // padding byte
0000029C     // padding byte
0000029D     // padding byte
0000029E     // padding byte
0000029F     // padding byte
000002A0     Client::UI::Misc::LogFilterConfig *(__fastcall *GetLogFilterConfig)(Client::UI::UIModuleInterface *this);
000002A8     // padding byte (hidden gap udm)
000002A9     // padding byte
000002AA     // padding byte
000002AB     // padding byte
000002AC     // padding byte
000002AD     // padding byte
000002AE     // padding byte
000002AF     // padding byte
000002B0     __int64 EnableCutsceneInputMode;
```

After:
```
00000290     Client::UI::UIInputModule *(__fastcall *GetUIInputModule)(Client::UI::UIModuleInterface *this);
00000298     __int64 vf83;
000002A0     Client::UI::Misc::LogFilterConfig *(__fastcall *GetLogFilterConfig)(Client::UI::UIModuleInterface *this);
000002A8     __int64 vf85;
000002B0     __int64 EnableCutsceneInputMode;
```