### PR TITLE
Add TimeAdjusted flag to LightFlags enum

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Graphics/Render/Light.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Graphics/Render/Light.cs
@@ -64,6 +64,7 @@ public enum LightFlags {
     DynamicShadows = 1 << 1,
     CharacterShadows = 1 << 2,
     ObjectShadows = 1 << 3,
+    TimeAdjusted = 1 << 4,
     SSAO_Omnishadows = 1 << 5,
 }
 


### PR DESCRIPTION
Adds the TimeAdjusted flag to LightFlags (name subject to change).

This flag determines if a light rotates with the time of day. For example the window lights in a house.