### PR TITLE
ghidra: Add hack around getDataType("/float") failing

### DIFF
--- a/ida/ffxiv_structimporter.py
+++ b/ida/ffxiv_structimporter.py
@@ -1752,6 +1752,9 @@ if api is None:
 
                 dtm = currentProgram.getDataTypeManager()
                 dt = dtm.getDataType("/" + "/".join(syms))
+                # HACK: In Ghidra 12.1.3 getDataType("/float") fails, but it works if using BuiltInDataTypeManager
+                if dt is None:
+                    dt = BuiltInDataTypeManager.getDataTypeManager().getDataType("/" + "/".join(syms))
                 for i in range(pointer_count):
                     dt = dtm.getPointer(dt)
                 return dt


### PR DESCRIPTION
Testing against Ghidra 12.1.3 (and 12.1.2), getDataType("/float") doesn't work - but did work previously at some point. I don't know why it broke, and they didn't list this as an API change in their changelog.

While the program's datatype database doesn't work, it will work if we pull from the built-in one.