### PR TITLE
Fixing some random unks in several Addons

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonJobHud.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonJobHud.cs
@@ -9,9 +9,10 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 [Inherits<AtkUnitBase>]
 [StructLayout(LayoutKind.Explicit, Size = 0x278)]
 public unsafe partial struct AddonJobHud {
-    [FieldOffset(0x238)] private byte Unk220;
+    // Set after the gauge has received its first update.
+    [FieldOffset(0x238)] public bool IsGaugeInitialized;
     [FieldOffset(0x239)] public bool UseSimpleGauge;
-    [FieldOffset(0x23A)] private byte Unk222;
+    [FieldOffset(0x23A)] public bool IsConfigLoaded;
 
     // these 4 pointers get set in vf72, and point to varying offsets for each type of gauge
     [FieldOffset(0x240)] public AddonJobHudGauge* GaugeStandardPointer;
@@ -23,6 +24,9 @@ public unsafe partial struct AddonJobHud {
 
     [FieldOffset(0x268)] public int TimelineLabelStandard; // always set to 19 by vf75
     [FieldOffset(0x26C)] public int TimelineLabelSimple; // always set to 101 by vf75
+
+    // Uses the secondary JobHud NumberArray update flag.
+    [FieldOffset(0x270)] public bool IsSecondaryGauge;
 
     /// <summary>
     /// Base struct containing the data that each particular gauge relies on.<br/>

--- a/FFXIVClientStructs/FFXIV/Client/UI/AddonNamePlate.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/AddonNamePlate.cs
@@ -13,8 +13,18 @@ namespace FFXIVClientStructs.FFXIV.Client.UI;
 public unsafe partial struct AddonNamePlate {
     [FieldOffset(0x240)] public BakePlateRenderer BakePlate;
     [FieldOffset(0x480)] public NamePlateObject* NamePlateObjectArray; // 0 - 50
+    // Cached from NamePlateNumberArray.IsInPvPArea. A change causes all nameplates to be updated.
+    [FieldOffset(0x488)] public bool IsInPvPArea;
+    [Obsolete("This is cached PvP-area state. Use IsInPvPArea, or UpdateAllNamePlates to force an update.")]
     [FieldOffset(0x488)] public byte DoFullUpdate;
     [FieldOffset(0x48A)] public ushort AlternatePartId;
+
+    /// <summary>
+    /// Sets the update flags for every nameplate and immediately updates the addon.
+    /// </summary>
+    /// <remarks>Called by <c>OnSetup</c> and <c>Show</c>.</remarks>
+    [MemberFunction("40 56 48 83 EC ?? F6 81 ?? ?? ?? ?? ?? 48 8B F1 0F 84 ?? ?? ?? ?? 48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 7C 24 ?? 4C 89 74 24 ?? E8 ?? ?? ?? ?? 48 8B C8 E8 ?? ?? ?? ?? BB")]
+    public partial void UpdateAllNamePlates();
 
     // Client::UI::AddonNamePlate::BakePlateRenderer
     //   Component::GUI::AtkTextNodeRenderer

--- a/FFXIVClientStructs/FFXIV/Client/UI/Arrays/NamePlateNumberArray.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Arrays/NamePlateNumberArray.cs
@@ -13,11 +13,17 @@ public unsafe partial struct NamePlateNumberArray {
     [FieldOffset(0), FixedSizeArray, CExporterIgnore] internal FixedSizeArray1056<int> _data;
 
     [FieldOffset(0 * 4)] public int ActiveNamePlateCount;
+    /// <summary>
+    /// One-shot flag that causes all nameplates to be rebaked. The addon clears it after consuming it.
+    /// </summary>
     [FieldOffset(1 * 4)] public bool ForceNamePlateRebake;
     [FieldOffset(2 * 4)] public int NamePlateSize;
     [FieldOffset(3 * 4)] public bool DisableFixedFontResolution;
+    // A change causes AddonNamePlate to update all nameplates.
+    [FieldOffset(4 * 4)] public bool IsInPvPArea;
+    [Obsolete("This is PvP-area state. Use IsInPvPArea, or AddonNamePlate.UpdateAllNamePlates to force an update.")]
     [FieldOffset(4 * 4)] public bool DoFullUpdate;
-    // [FieldOffset(5 * 4)] private int UnkInt;
+    [FieldOffset(5 * 4)] public bool IsParticipatingInCustomMatchOrSpectating;
     [FieldOffset(6 * 4), FixedSizeArray] internal FixedSizeArray50<NamePlateObjectIntArrayData> _objectData;
 
     [StructLayout(LayoutKind.Explicit, Size = 21 * 4)]
@@ -40,9 +46,10 @@ public unsafe partial struct NamePlateNumberArray {
         [FieldOffset(11 * 4)] public uint GaugeContainerColor; // unused if Disable Alternate Part Id true
         [FieldOffset(12 * 4)] public int MarkerIconId;
         [FieldOffset(13 * 4)] public int NameIconId;
-        // [FieldOffset(14 * 4)] private int UnkAdjust;
+        // Set for elemental icons on Eureka battle NPC nameplates.
+        [FieldOffset(14 * 4)] public bool UseLargeNameIcon;
         [FieldOffset(15 * 4)] public int NamePlateObjectIndex;
-        // [FieldOffset(16 * 4)] private int Unk;
+        // index 16 is unused
         /// <summary>
         /// &amp; 0x1 - Is prefix title<br/>
         /// &amp; 0x4 - PvP enemy<br/>
@@ -53,11 +60,11 @@ public unsafe partial struct NamePlateNumberArray {
         /// &amp; 0x100 - Disable Alternate Part Id<br/>
         /// </summary>
         [FieldOffset(17 * 4)] public int DrawFlags;
-        // [FieldOffset(18 * 4)] private int Unk;
+        // index 18 is unused
         /// <summary>
         /// &amp; 0x1 - Draw name text<br/>
         /// &amp; 0x2 - Draw gauge<br/>
-        /// &amp; 0x4 - Unknown, seems to be set 1-2 frames after node appears<br/>
+        /// &amp; 0x4 - Nameplate already exists with unchanged data. Uses the timeline.<br/>
         /// </summary>
         [FieldOffset(19 * 4)] public int VisibilityFlags;
         [FieldOffset(20 * 4)] public uint EntityId;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.HotbarSlot.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.HotbarSlot.cs
@@ -54,12 +54,13 @@ public partial struct RaptureHotbarModule {
         /// </summary>
         [FieldOffset(0xC0)] public uint ApparentActionId;
 
-        /// Unknown field with offset 0xC4 (196), possibly overloaded
+        /// Mode-specific state used while resolving the current apparent action.
         ///
-        /// Appears to have relation to the following:
-        /// - Lost Finds Items appear to set this value to 1
-        /// - In PVP actions, the high byte controls combo icon and the low byte counts which action the combo is on
-        [FieldOffset(0xC4)] private ushort UNK_0xC4;
+        /// For <see cref="HotbarSlotApparentActionMode.GeneralActionDutyOrPhantom"/>, this is the GeneralAction row ID minus 26.<br/>
+        /// For <see cref="HotbarSlotApparentActionMode.GeneralActionPhantom"/>, this is the GeneralAction row ID minus 31.<br/>
+        /// For <see cref="HotbarSlotApparentActionMode.PvPCombo"/>, this is the current combo step.<br/>
+        /// For <see cref="HotbarSlotApparentActionMode.LostFindsItem"/>, this indicates that the action has been resolved.
+        [FieldOffset(0xC4)] public ushort ApparentActionModeParam;
 
         // 0xC6 (198) does not appear to be referenced *anywhere*. Nothing ever reads or writes to it, save for a zero-out
         // operation.
@@ -79,6 +80,9 @@ public partial struct RaptureHotbarModule {
         /// </summary>
         /// <seealso cref="ApparentActionId"/>
         [FieldOffset(0xC9)] public HotbarSlotType ApparentSlotType;
+
+        /// Selects the low-numbered mapping from <see cref="CommandType"/> to the UI intermediate action type.
+        [FieldOffset(0xCA)] private bool UseAlternateIntermediateActionType;
 
         /// Appears to be the "primary cost" of this action, mapping down to 0, 1, 2, 4, 5, 6, 7.
         ///
@@ -144,21 +148,11 @@ public partial struct RaptureHotbarModule {
         /// </remarks>
         [FieldOffset(0xE0)] public byte RecipeValid;
 
-        /// UNKNOWN. Appears to be Recipe specific.
-        ///
-        /// Always set to 1, apparently?
-        [FieldOffset(0xE1)] private byte UNK_0xE1;
+        /// Whether the recipe row has been loaded and <see cref="RecipeValid"/> has been populated.
+        [FieldOffset(0xE1)] public bool RecipeDataLoaded;
 
-        /// UNKNOWN. Appears to control UI display mode (icon and displayed name) in some way
-        ///
-        /// Known values so far:
-        /// - 2: Appears to be set for adjusted actions (e.g. upgraded spells/weaponskills)
-        /// - 3: Appears to mark a PVP combo action
-        /// - 4: Set on Squadron Order - Disengage, maybe others
-        /// - 5: Set for Lost Finds Items (?)
-        /// - 128: Appears as a flag?
-        /// - 0/255: "generic"
-        [FieldOffset(0xE2)] private byte UNK_0xE2;
+        /// Selects how the original apparent action is resolved into the current apparent action.
+        [FieldOffset(0xE2)] public HotbarSlotApparentActionMode ApparentActionMode;
 
         /// <summary>
         /// A boolean representing if this specific hotbar slot has been fully loaded. False for empty slots and slots
@@ -223,7 +217,7 @@ public partial struct RaptureHotbarModule {
         ///
         /// This method is virtually almost always called using the parameters from <see cref="ApparentSlotType"/> and <see cref="ApparentActionId"/>.
         ///
-        /// When <see cref="UNK_0xE2"/> is set to 3, this method will instead override the passed in slotType and actionId with
+        /// When <see cref="ApparentActionMode"/> is set to <see cref="HotbarSlotApparentActionMode.PvPCombo"/>, this method will instead override the passed in slotType and actionId with
         /// the values present in <see cref="OriginalApparentSlotType"/> and <see cref="OriginalApparentActionId"/>.
         /// </summary>
         /// <param name="slotType">The appearance slot type to use. Virtually almost always <see cref="ApparentSlotType"/>.</param>
@@ -357,6 +351,18 @@ public partial struct RaptureHotbarModule {
 
         [FieldOffset(0xE9)] public bool IsActive;
     }
+}
+
+public enum HotbarSlotApparentActionMode : byte {
+    GeneralActionDutyOrPhantom = 0,
+    GeneralActionPhantom = 1,
+    GeneralActionAdjusted = 2,
+    AdjustedAction = 3,
+    PvPCombo = 4,
+    BgcArmyAction = 5,
+    LostFindsItem = 6,
+    SkipActionResolution = 0x80,
+    None = 0xFF,
 }
 
 public enum SlotCostType : byte {

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.HotbarSlot.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.HotbarSlot.cs
@@ -54,12 +54,13 @@ public partial struct RaptureHotbarModule {
         /// </summary>
         [FieldOffset(0xC0)] public uint ApparentActionId;
 
-        /// Mode-specific state used while resolving the current apparent action.
-        ///
+        /// <summary>
+        /// Mode-specific state used while resolving the current apparent action.<br/>
         /// For <see cref="HotbarSlotApparentActionMode.GeneralActionDutyOrPhantom"/>, this is the GeneralAction row ID minus 26.<br/>
         /// For <see cref="HotbarSlotApparentActionMode.GeneralActionPhantom"/>, this is the GeneralAction row ID minus 31.<br/>
         /// For <see cref="HotbarSlotApparentActionMode.PvPCombo"/>, this is the current combo step.<br/>
         /// For <see cref="HotbarSlotApparentActionMode.LostFindsItem"/>, this indicates that the action has been resolved.
+        /// </summary>
         [FieldOffset(0xC4)] public ushort ApparentActionModeParam;
 
         // 0xC6 (198) does not appear to be referenced *anywhere*. Nothing ever reads or writes to it, save for a zero-out
@@ -81,8 +82,10 @@ public partial struct RaptureHotbarModule {
         /// <seealso cref="ApparentActionId"/>
         [FieldOffset(0xC9)] public HotbarSlotType ApparentSlotType;
 
+        /// <summary>
         /// Selects the low-numbered mapping from <see cref="CommandType"/> to the UI intermediate action type.
-        [FieldOffset(0xCA)] private bool UseAlternateIntermediateActionType;
+        /// </summary>
+        [FieldOffset(0xCA)] public bool UseAlternateIntermediateActionType;
 
         /// Appears to be the "primary cost" of this action, mapping down to 0, 1, 2, 4, 5, 6, 7.
         ///

--- a/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.HotbarUiIntermediate.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Misc/RaptureHotbarModule.HotbarUiIntermediate.cs
@@ -24,9 +24,9 @@ public partial struct RaptureHotbarModule {
         [FieldOffset(0x3D)] public byte CostDisplayMode; // to NumberArray idx slotBase + 2
         [FieldOffset(0x3E)] public bool ActionAvailable1; // to NumberArray idx slotBase + 5
         [FieldOffset(0x3F)] public bool ActionAvailable2; // to NumberArray idx slotBase + 6
-        [FieldOffset(0x40)] public bool ActionTargetSatisfied; // to NumberArray idx slotBase + 15
+        [FieldOffset(0x40)] public bool ActionTargetSatisfied; // to NumberArray idx slotBase + 16
         [FieldOffset(0x41)] public bool DrawAnts; // to NumberArray idx slotBase + 14
-        [FieldOffset(0x42)] private byte Unk0x42;
+        [FieldOffset(0x42)] public bool IsTransformationActionUsable; // to NumberArray idx slotBase + 15
 
         [MemberFunction("E8 ?? ?? ?? ?? 48 8B 45 ?? 4C 8D 44 24")]
         public partial HotbarUIIntermediate* Ctor();

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentBase.cs
@@ -138,7 +138,8 @@ public struct AtkCursorNavigationInfo {
     [FieldOffset(0x05)] public byte CursorType; // 0 = east, 1 = south-east (seen in Emj addon)
     [FieldOffset(0x06)] public byte OffsetX;
     [FieldOffset(0x07)] public byte OffsetY;
-    [FieldOffset(0x08)] private byte Unk08;
+    /// <inheritdoc cref="AtkUldComponentDataBase.NavigationMode"/>
+    [FieldOffset(0x08)] public byte NavigationMode;
 }
 
 public enum AtkCursorNavigationDirection {

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentList.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkComponentList.cs
@@ -89,7 +89,7 @@ public unsafe partial struct AtkComponentList : ICreatable<AtkComponentList> {
     [FieldOffset(0x1A7)] private byte Unk1A7; // select on cancel?
     [FieldOffset(0x1A8)] public bool IsCursorNavigationCrossList; // see AddonEmote where it continues the repeat on another list if enabled
     [FieldOffset(0x1A9)] private bool Unk1A9;
-    [FieldOffset(0x1AA)] private bool Unk1AA; // PlaySoundEffect(3) on InputId.CANCEL when CursorNavigationInfo.Unk08 == 1 and Unk140ItemIndex >= 0
+    [FieldOffset(0x1AA)] private bool Unk1AA; // PlaySoundEffect(3) on InputId.CANCEL when CursorNavigationInfo.NavigationMode == 1 and Unk140ItemIndex >= 0
     [FieldOffset(0x1AB)] private bool Unk1AB; // something with inputs
     [FieldOffset(0x1AC)] private bool Unk1AC; // something with inputs
     [FieldOffset(0x1AD)] private byte Unk1AD; // flags for dragdrop

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldComponentDataBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldComponentDataBase.cs
@@ -11,5 +11,7 @@ public partial struct AtkUldComponentDataBase {
     [FieldOffset(0x5)] public byte Cursor;
     [FieldOffset(0x6)] public byte OffsetX; // short in .uld file
     [FieldOffset(0x7)] public byte OffsetY; // short in .uld file
-    [FieldOffset(0x8)] private byte Unk;
+    /// List-navigation mode loaded from the component's ULD data.
+    /// Controls wrapping, cancel-to-deselect and navigation at list edges.
+    [FieldOffset(0x8)] public byte NavigationMode;
 }

--- a/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldComponentDataBase.cs
+++ b/FFXIVClientStructs/FFXIV/Component/GUI/AtkUldComponentDataBase.cs
@@ -11,7 +11,9 @@ public partial struct AtkUldComponentDataBase {
     [FieldOffset(0x5)] public byte Cursor;
     [FieldOffset(0x6)] public byte OffsetX; // short in .uld file
     [FieldOffset(0x7)] public byte OffsetY; // short in .uld file
+    /// <summary>
     /// List-navigation mode loaded from the component's ULD data.
     /// Controls wrapping, cancel-to-deselect and navigation at list edges.
+    /// </summary>
     [FieldOffset(0x8)] public byte NavigationMode;
 }

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -184,6 +184,7 @@ functions:
   0x14041E5C0: GetActionTimelineKey
   0x14041E5F0: GetWeaponTimelineKey
   0x1405E72A0: StartSpursJobEntityWorkerThread
+  0x140606730: Client::Game::IsParticipatingInCustomMatchOrSpectating
   0x1406411E0: RemoveAtkEventFromList # (AtkEvent**, AtkEvent*) Finds and removes param2 from the param1 list
   0x140671870: GetScaleListEntryFromScale
   0x1406824D0: GetScaleForListOption
@@ -20569,6 +20570,7 @@ classes:
       0x141321520: ctor
       0x1413218F0: SetCommonNamePlate  # x, y, scale, etc INLINED IN 7.0 in AddonNamePlate OnRequestedUpdate 1411CBBD5
       0x141321B20: SetPlayerNamePlate # player specific nodes INLINED IN 7.0 ^ 1411CBEB6
+      0x141325260: UpdateAllNamePlates
       0x141325310: ToggleTextRenderMode
   Client::UI::AddonCastBarEnemy: # 96
     vtbls:


### PR DESCRIPTION
The most significant one I encountered was AddonNamePlate.DoFullUpdate, this is actually IsInPvPArea and that is cached. However all the nameplates do get updated when this value changes.

Client::UI::RaptureAtkModule_OnUpdate_Nameplates
```
    Component::GUI::NumberArrayData_SetValueIfDifferent(v2, 0, v4);
    v54 = sub_140606730();
    Component::GUI::NumberArrayData_SetValueIfDifferent(v2, 5, v54);
    v55 = Client::Game::GameMain_IsInPvPArea();
    Component::GUI::NumberArrayData_SetValueIfDifferent(v2, 4, v55);
```

Client::UI::AddonNamePlate_OnRequestedUpdate
```
v12 = IntArray[4] == 0;
  v143 = *IntArray;
  v11 = v143;
  this->DoFullUpdate = !v12;
  v132 = !v12;
```

sub_140606730 checks if you're in a custom pvp match or are spectating one

```
char sub_140606730()
{
  Client::Game::SpectatorManager *Instance; // rax

  if ( g_Client::Game::Conditions_Instance.ParticipatingInCustomMatch
    || (Instance = Client::Game::SpectatorManager_GetInstance()) != 0 )
  {
    LOBYTE(Instance) = 1;
  }
  return (char)Instance;
}
```

You can check this by going to the Wolves Den or any other PvP area and see that it stays 1, however I would appreciate if someone can doublecheck the whole process for me.

<img width="677" height="179" alt="ffxiv_dx11_2026-08-27_23-20-55" src="https://github.com/user-attachments/assets/dfe1f7e9-8e86-4218-a508-cc8537010942" />

To make up for the rename (and eventual obsolete) I have sigged the method UpdateAllNamePlates that does update all the nameplates.

Some evidence for the other changes: 

<img width="1152" height="378" alt="ffxiv_dx11_2026-08-27_22-30-01" src="https://github.com/user-attachments/assets/94391a3f-2872-428d-99c6-e95c4bf686ac" />
<img width="977" height="209" alt="ffxiv_dx11_2026-08-27_22-37-21" src="https://github.com/user-attachments/assets/b6db9913-e9c1-4c01-9add-250c7dedec00" />

https://github.com/user-attachments/assets/f1e163cc-3711-4c1e-aa0d-71e81624a404

<img width="827" height="106" alt="ffxiv_dx11_2026-08-27_22-34-13" src="https://github.com/user-attachments/assets/363942a9-0d86-4c42-8b4c-476a54ee4400" />

<img width="1318" height="524" alt="ffxiv_dx11_2026-08-28_01-45-43" src="https://github.com/user-attachments/assets/1180bfc3-3fc1-4ed5-9b86-ae8c6f7247e0" />


AI was used for some of the descriptions/summaries.