### PR TITLE
Add classes for GimmickEventHandler and its children

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
@@ -87,6 +87,14 @@ public unsafe partial struct EventHandler {
     [VirtualFunction(209)]
     public partial uint GetNameplateIconForObject(GameObject* gameObject);
 
+    /// <summary> If the GameObject from the EventHandler's perspective should be active. For example, this can control whether GimmickRects are active. </summary>
+    [VirtualFunction(213)]
+    public partial bool IsActive(GameObject* gameObject);
+
+    /// <summary> Sets the TargetableStatus update flag for every GameObject this EventHandler owns. </summary>
+    [VirtualFunction(217)]
+    public partial uint UpdateTargetableStatus();
+
     /// <summary>Changes the currently playing timelines based on the difference between oldSharedTimelineState and newSharedTimelineState.</summary>
     /// <param name="gameObject">The game object to update.</param>
     /// <param name="oldSharedTimelineState">The new SharedTimelineState value.</param>

--- a/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Event/EventHandler.cs
@@ -93,7 +93,7 @@ public unsafe partial struct EventHandler {
 
     /// <summary> Sets the TargetableStatus update flag for every GameObject this EventHandler owns. </summary>
     [VirtualFunction(217)]
-    public partial uint UpdateTargetableStatus();
+    public partial void UpdateTargetableStatus();
 
     /// <summary>Changes the currently playing timelines based on the difference between oldSharedTimelineState and newSharedTimelineState.</summary>
     /// <param name="gameObject">The game object to update.</param>

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gimmick/GimmickAccessor.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gimmick/GimmickAccessor.cs
@@ -1,0 +1,10 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game.Gimmick;
+
+// Client::Game::Gimmick::GimmickAccessor
+//   Client::Game::Gimmick::GimmickEventHandler
+//     Client::Game::Event::LuaEventHandler
+//       Client::Game::Event::EventHandler
+[GenerateInterop]
+[Inherits<GimmickEventHandler>]
+[StructLayout(LayoutKind.Explicit, Size = 0x310)]
+public unsafe partial struct GimmickAccessor;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gimmick/GimmickBill.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gimmick/GimmickBill.cs
@@ -1,0 +1,10 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game.Gimmick;
+
+// Client::Game::Gimmick::GimmickBill
+//   Client::Game::Gimmick::GimmickEventHandler
+//     Client::Game::Event::LuaEventHandler
+//       Client::Game::Event::EventHandler
+[GenerateInterop]
+[Inherits<GimmickEventHandler>]
+[StructLayout(LayoutKind.Explicit, Size = 0x2E8)]
+public unsafe partial struct GimmickBill;

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gimmick/GimmickEventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gimmick/GimmickEventHandler.cs
@@ -9,5 +9,5 @@ namespace FFXIVClientStructs.FFXIV.Client.Game.Gimmick;
 [Inherits<LuaEventHandler>]
 [StructLayout(LayoutKind.Explicit, Size = 0x2E8)]
 public unsafe partial struct GimmickEventHandler {
-    [FieldOffset(0x2E0)] private void* ExcelSheetWaiter;
+    [FieldOffset(0x2E0)] private void* ContentSheetWaiter;
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gimmick/GimmickEventHandler.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gimmick/GimmickEventHandler.cs
@@ -1,0 +1,13 @@
+using FFXIVClientStructs.FFXIV.Client.Game.Event;
+
+namespace FFXIVClientStructs.FFXIV.Client.Game.Gimmick;
+
+// Client::Game::Gimmick::GimmickEventHandler
+//   Client::Game::Event::LuaEventHandler
+//     Client::Game::Event::EventHandler
+[GenerateInterop(isInherited: true)]
+[Inherits<LuaEventHandler>]
+[StructLayout(LayoutKind.Explicit, Size = 0x2E8)]
+public unsafe partial struct GimmickEventHandler {
+    [FieldOffset(0x2E0)] private void* ExcelSheetWaiter;
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gimmick/GimmickRect.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gimmick/GimmickRect.cs
@@ -1,0 +1,14 @@
+namespace FFXIVClientStructs.FFXIV.Client.Game.Gimmick;
+
+// Client::Game::Gimmick::GimmickRect
+//   Client::Game::Gimmick::GimmickEventHandler
+//     Client::Game::Event::LuaEventHandler
+//       Client::Game::Event::EventHandler
+[GenerateInterop]
+[Inherits<GimmickEventHandler>]
+[StructLayout(LayoutKind.Explicit, Size = 0x318)]
+public unsafe partial struct GimmickRect {
+    [FieldOffset(0x310)] private byte Unk310;
+    /// <summary> Whether this GimmickRect is active or not. For example, an inactive dungeon entrance GimmickRect doesn't do anything when walked into. </summary>
+    [FieldOffset(0x311)] public bool Active;
+}

--- a/ida/data.yml
+++ b/ida/data.yml
@@ -16501,6 +16501,8 @@ classes:
       205: GetTitle # lua function "GetEventHandlerTitle"
       207: GetEventId
       209: GetNameplateIconForObject # (this, GameObject* gameObject)
+      213: IsActive
+      217: UpdateTargetableStatus
       227: GetIconId
       231: IsOccupied33
       232: GetOccupiedConditionId


### PR DESCRIPTION
This is a commonly-seen handler in instanced content, and handles a few director events (apart from the actual content director.) The one thing I was focused on is the 0x80000000 event - which apparently "activates" client-side GimmickRects like dungeon entrances.

Along the way I added missing classes under the Gimmick namespace, and a
few other things.