### PR TITLE
Add BeastmasterGauge

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGaugeEnums.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGaugeEnums.cs
@@ -130,17 +130,7 @@ public enum SerpentCombo : byte {
     FourthLegacy = 6,
 }
 
-// The Inner Compass runs clockwise Volant -> Rampant -> Durant -> Eldritch -> Volant, so an
-// intentional combo is simply the next affinity in sequence, wrapping Eldritch back to Volant.
-// Completing one grants a fifth or sixth affinity, which the game calls the "two additional
-// instinctual affinities". Which of the two you get is the parity of the affinity the combo
-// started from: odd -> Sunstrider, even -> Moonstalker. Pairing those two in turn triggers
-// what the game calls an "infinitive combo".
-// The upgrade only lands if the target survives the combo. Kill it with the second skill and
-// you still get Wavering Heart and a ChainCount increment, but no Sunstrider or Moonstalker.
-// These values match the player statuses the job applies, which are contiguous and in this
-// same order: Status rows 4595 Volant Heart, 4596 Rampant Heart, 4597 Durant Heart,
-// 4598 Eldritch Heart, 4599 Sunstrider, 4600 Moonstalker.
+
 public enum BeastmasterAffinity : byte {
     None = 0,
     Volant = 1,
@@ -151,10 +141,7 @@ public enum BeastmasterAffinity : byte {
     Moonstalker = 6,
 }
 
-// A familiar's kin type, which decides which Kinship status Borrow grants and therefore which
-// ability Beast Mode turns into. Matches the order of the eight contiguous Kinship statuses,
-// Status rows 4602 Beast Kinship through 4609 Ash Kinship. All eight values observed directly
-// in the gauge, each cross-checked against the Kinship status the familiar actually granted.
+
 public enum BeastmasterKinType : byte {
     None = 0,
     Beastkin = 1,

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGaugeEnums.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGaugeEnums.cs
@@ -129,3 +129,40 @@ public enum SerpentCombo : byte {
     ThirdLegacy = 5,
     FourthLegacy = 6,
 }
+
+// The Inner Compass runs clockwise Volant -> Rampant -> Durant -> Eldritch -> Volant, so an
+// intentional combo is simply the next affinity in sequence, wrapping Eldritch back to Volant.
+// Completing one grants a fifth or sixth affinity, which the game calls the "two additional
+// instinctual affinities". Which of the two you get is the parity of the affinity the combo
+// started from: odd -> Sunstrider, even -> Moonstalker. Pairing those two in turn triggers
+// what the game calls an "infinitive combo".
+// The upgrade only lands if the target survives the combo. Kill it with the second skill and
+// you still get Wavering Heart and a ChainCount increment, but no Sunstrider or Moonstalker.
+// These values match the player statuses the job applies, which are contiguous and in this
+// same order: Status rows 4595 Volant Heart, 4596 Rampant Heart, 4597 Durant Heart,
+// 4598 Eldritch Heart, 4599 Sunstrider, 4600 Moonstalker.
+public enum BeastmasterAffinity : byte {
+    None = 0,
+    Volant = 1,
+    Rampant = 2,
+    Durant = 3,
+    Eldritch = 4,
+    Sunstrider = 5,
+    Moonstalker = 6,
+}
+
+// A familiar's kin type, which decides which Kinship status Borrow grants and therefore which
+// ability Beast Mode turns into. Matches the order of the eight contiguous Kinship statuses,
+// Status rows 4602 Beast Kinship through 4609 Ash Kinship. All eight values observed directly
+// in the gauge, each cross-checked against the Kinship status the familiar actually granted.
+public enum BeastmasterKinType : byte {
+    None = 0,
+    Beastkin = 1,
+    Vilekin = 2,
+    Cloudkin = 3,
+    Seedkin = 4,
+    Wavekin = 5,
+    Scalekin = 6,
+    Soulkin = 7,
+    Ashkin = 8,
+}

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
@@ -198,6 +198,55 @@ public struct ViperGauge {
     public SerpentCombo SerpentCombo => (SerpentCombo)(SerpentComboState >> 2);
 }
 
+// Beastmaster is a limited job; its gauge drives the Inner Compass UI.
+// Verified at runtime on patch 7.56 by observing JobGaugeManager while playing.
+[StructLayout(LayoutKind.Explicit, Size = 0x10)]
+public struct BeastmasterGauge {
+    // Beastmaster's own TP, 0-250. This does NOT regenerate passively - it is granted by the
+    // combo bonuses on the player's weaponskill chain (Axeblade Bite grants +13, Shieldsplitter
+    // +15), and a broken combo grants nothing. Instinctual skills spend the entire pool.
+    [FieldOffset(0x08)] public byte TPGauge;
+    // Familiar TP, 0-250. A single pool shared across Battlehorn slots - it is NOT reset by
+    // swapping familiars. Arrives in fixed +12 increments at irregular intervals (observed
+    // 1.3s, 3.1s, 19.2s and 3.0s apart), so it is not a server tick either; it tracks the
+    // familiar's auto-attacks. Familiar actions spend the entire pool.
+    [FieldOffset(0x09)] public byte FamiliarTPGauge;
+    // Familiar TP immediately before the most recent familiar action, which scales that
+    // action's potency. A familiar action expends the ENTIRE familiar pool - FamiliarTPGauge
+    // drops to 0 on the same frame - so "TP consumed" and "TP at time of use" are the same
+    // number and this field is both. Seen taking 132 and 168 on actions that zeroed a gauge
+    // holding exactly 132 and 168.
+    [FieldOffset(0x0A)] public byte FamiliarTPAtLastUse;
+    // Which Battlehorn slot's familiar is summoned; 0 when none. This is the SLOT, not the
+    // creature - the summoned beast's identity is not exposed here.
+    [FieldOffset(0x0B)] public byte ActiveBattlehorn;
+    // Reads the active affinity, then 7 while an instinctual combo resolves, then - if the
+    // pair was clockwise and so formed an intentional combo - the resulting Sunstrider or
+    // Moonstalker affinity ~2.2s later. If the pair was not clockwise it returns to 0 from 7
+    // instead. The 7 is not an affinity: it marks the "Wavering Heart" status (Status row
+    // 4643, "Otherwise engaged. Unable to perform combos with your familiar."), which locks
+    // out further combo advancement until it clears. That is why this stays a byte while
+    // CurrentAffinity below is typed as the enum.
+    [FieldOffset(0x0C)] public byte InstinctualComboState;
+    // Affinity of the most recent instinctual skill, replaced by the resulting Sunstrider or
+    // Moonstalker affinity once an intentional combo resolves. Cleared ~7s after the last
+    // skill. Only ever observed holding 0-6.
+    [FieldOffset(0x0D)] public BeastmasterAffinity CurrentAffinity;
+    // Number of instinctual skills chained so far, shown beneath the Inner Compass.
+    // Increments on any instinctual combo, not only intentional (clockwise) ones, and
+    // increases the extra damage dealt.
+    [FieldOffset(0x0E)] public byte ChainCount;
+    // Identifies the familiar whose Kinship is currently active: high nibble is its kin type,
+    // low nibble is the Battlehorn slot it was summoned from. Set when Borrow grants a Kinship
+    // and cleared to 0 when that Kinship is lost. Latched at the moment Borrow is used, so the
+    // low nibble is NOT a mirror of ActiveBattlehorn - swapping familiars afterwards moves
+    // ActiveBattlehorn while this stays put.
+    [FieldOffset(0x0F)] public byte KinshipState;
+
+    public BeastmasterKinType KinshipKinType => (BeastmasterKinType)(KinshipState >> 4);
+    public byte KinshipBattlehorn => (byte)(KinshipState & 0x0F);
+}
+
 #endregion
 
 #region Tanks

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
@@ -198,72 +198,23 @@ public struct ViperGauge {
     public SerpentCombo SerpentCombo => (SerpentCombo)(SerpentComboState >> 2);
 }
 
-// Beastmaster is a limited job; its gauge drives the Inner Compass UI.
-// Verified at runtime on patch 7.56 by observing JobGaugeManager while playing.
+[GenerateInterop]
 [StructLayout(LayoutKind.Explicit, Size = 0x18)]
-public struct BeastmasterGauge {
-    // Beastmaster's own TP, 0-250. This does NOT regenerate passively - it is granted by the
-    // combo bonuses on the player's weaponskill chain (Axeblade Bite grants +13, Shieldsplitter
-    // +15), and a broken combo grants nothing. Instinctual skills spend the entire pool.
+public partial struct BeastmasterGauge {
     [FieldOffset(0x08)] public byte TPGauge;
-    // Familiar TP, 0-250. A single pool shared across Battlehorn slots - it is NOT reset by
-    // swapping familiars. Arrives in fixed +12 increments at irregular intervals (observed
-    // 1.3s, 3.1s, 19.2s and 3.0s apart), so it is not a server tick either; it tracks the
-    // familiar's auto-attacks. Familiar actions spend the entire pool.
     [FieldOffset(0x09)] public byte FamiliarTPGauge;
-    // Familiar TP immediately before the most recent familiar action, which scales that
-    // action's potency. A familiar action expends the ENTIRE familiar pool - FamiliarTPGauge
-    // drops to 0 on the same frame - so "TP consumed" and "TP at time of use" are the same
-    // number and this field is both. Seen taking 132 and 168 on actions that zeroed a gauge
-    // holding exactly 132 and 168.
     [FieldOffset(0x0A)] public byte FamiliarTPAtLastUse;
-    // Which Battlehorn slot's familiar is summoned; 0 when none. This is the SLOT, not the
-    // creature - the summoned beast's identity is not exposed here.
-    [FieldOffset(0x0B)] public byte ActiveBattlehorn;
-    // Reads the active affinity, then 7 while an instinctual combo resolves, then - if the
-    // pair was clockwise and so formed an intentional combo - the resulting Sunstrider or
-    // Moonstalker affinity ~2.2s later. If the pair was not clockwise it returns to 0 from 7
-    // instead. The 7 is not an affinity: it marks the "Wavering Heart" status (Status row
-    // 4643, "Otherwise engaged. Unable to perform combos with your familiar."), which locks
-    // out further combo advancement until it clears. That is why this stays a byte while
-    // CurrentAffinity below is typed as the enum.
+    [FieldOffset(0x0B)] public byte ActiveBattlehornIndex;
     [FieldOffset(0x0C)] public byte InstinctualComboState;
-    // Affinity of the most recent instinctual skill, replaced by the resulting Sunstrider or
-    // Moonstalker affinity once an intentional combo resolves. Cleared ~7s after the last
-    // skill. Only ever observed holding 0-6.
     [FieldOffset(0x0D)] public BeastmasterAffinity CurrentAffinity;
-    // Number of instinctual skills chained so far, shown beneath the Inner Compass.
-    // Increments on any instinctual combo, not only intentional (clockwise) ones, and
-    // increases the extra damage dealt.
+    /// <summary>Instinctual skills chained so far. Shown beneath the Inner Compass. Increases dmg dealt.</summary>
     [FieldOffset(0x0E)] public byte ChainCount;
-    // Identifies the familiar whose Kinship is currently active: high nibble is its kin type,
-    // low nibble is the Battlehorn slot it was summoned from. Set when Borrow grants a Kinship
-    // and cleared to 0 when that Kinship is lost. Latched at the moment Borrow is used, so the
-    // low nibble is NOT a mirror of ActiveBattlehorn - swapping familiars afterwards moves
-    // ActiveBattlehorn while this stays put.
+    [BitField<byte>(nameof(KinshipBattlehornIndex), 0, 4)]
+    [BitField<BeastmasterKinType>(nameof(KinshipKinType), 4, 4)]
     [FieldOffset(0x0F)] public byte KinshipState;
-    // Two instinct stack counters packed into one byte, two bits each, both gated behind
-    // traits - this reads 0 below level 28 and only the upper pair moves until level 40.
-    //
-    //   bits 0-1  Natural Instinct   (trait Wild Heart IV, Lv 40) - gained when a FAMILIAR
-    //             instinctual skill completes the combo. Spent by Rallying Cheer (44904) for
-    //             30 familiar TP plus 70 per stack.
-    //   bits 2-3  Mastered Instinct  (trait Wild Heart III, Lv 28) - gained when a BEASTMASTER
-    //             instinctual skill completes the combo. Spent by Rally (44905) for 40 TP plus
-    //             70 per stack, so three stacks fills an empty 250 gauge exactly. The excess is
-    //             clamped rather than scaled: three stacks spent while holding 28 TP still
-    //             landed on 250.
-    //
-    // Each field caps at 3, giving a maximum byte of 15. Observed as 8 -> 9 -> 13 -> 14 -> 15
-    // across four combos, gaining 4 whenever the player's skill completed the combo and 1
-    // whenever the familiar's did. Each spender clears only its own bits: Rally with both fields
-    // full took this from 15 to 3 while TPGauge went 0 -> 250.
+    [BitField<byte>(nameof(NaturalInstinct), 0, 2)]
+    [BitField<byte>(nameof(MasteredInstinct), 2, 2)]
     [FieldOffset(0x10)] public byte InstinctState;
-
-    public BeastmasterKinType KinshipKinType => (BeastmasterKinType)(KinshipState >> 4);
-    public byte KinshipBattlehorn => (byte)(KinshipState & 0x0F);
-    public byte NaturalInstinct => (byte)(InstinctState & 0x03);
-    public byte MasteredInstinct => (byte)((InstinctState >> 2) & 0x03);
 }
 
 #endregion

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
@@ -242,9 +242,28 @@ public struct BeastmasterGauge {
     // low nibble is NOT a mirror of ActiveBattlehorn - swapping familiars afterwards moves
     // ActiveBattlehorn while this stays put.
     [FieldOffset(0x0F)] public byte KinshipState;
+    // Two instinct stack counters packed into one byte, two bits each, both gated behind
+    // traits - this reads 0 below level 28 and only the upper pair moves until level 40.
+    //
+    //   bits 0-1  Natural Instinct   (trait Wild Heart IV, Lv 40) - gained when a FAMILIAR
+    //             instinctual skill completes the combo. Spent by Rallying Cheer (44904) for
+    //             30 familiar TP plus 70 per stack.
+    //   bits 2-3  Mastered Instinct  (trait Wild Heart III, Lv 28) - gained when a BEASTMASTER
+    //             instinctual skill completes the combo. Spent by Rally (44905) for 40 TP plus
+    //             70 per stack, so three stacks fills an empty 250 gauge exactly. The excess is
+    //             clamped rather than scaled: three stacks spent while holding 28 TP still
+    //             landed on 250.
+    //
+    // Each field caps at 3, giving a maximum byte of 15. Observed as 8 -> 9 -> 13 -> 14 -> 15
+    // across four combos, gaining 4 whenever the player's skill completed the combo and 1
+    // whenever the familiar's did. Each spender clears only its own bits: Rally with both fields
+    // full took this from 15 to 3 while TPGauge went 0 -> 250.
+    [FieldOffset(0x10)] public byte InstinctState;
 
     public BeastmasterKinType KinshipKinType => (BeastmasterKinType)(KinshipState >> 4);
     public byte KinshipBattlehorn => (byte)(KinshipState & 0x0F);
+    public byte NaturalInstinct => (byte)(InstinctState & 0x03);
+    public byte MasteredInstinct => (byte)((InstinctState >> 2) & 0x03);
 }
 
 #endregion

--- a/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/Gauge/JobGauges.cs
@@ -200,7 +200,7 @@ public struct ViperGauge {
 
 // Beastmaster is a limited job; its gauge drives the Inner Compass UI.
 // Verified at runtime on patch 7.56 by observing JobGaugeManager while playing.
-[StructLayout(LayoutKind.Explicit, Size = 0x10)]
+[StructLayout(LayoutKind.Explicit, Size = 0x18)]
 public struct BeastmasterGauge {
     // Beastmaster's own TP, 0-250. This does NOT regenerate passively - it is granted by the
     // combo bonuses on the player's weaponskill chain (Axeblade Bite grants +13, Shieldsplitter

--- a/FFXIVClientStructs/FFXIV/Client/Game/JobGaugeManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/JobGaugeManager.cs
@@ -39,5 +39,7 @@ public unsafe partial struct JobGaugeManager {
     [FieldOffset(0x08), CExporterUnion("Gauge")] public WarriorGauge Warrior;
     [FieldOffset(0x08), CExporterUnion("Gauge")] public GunbreakerGauge Gunbreaker;
 
+    [FieldOffset(0x08), CExporterUnion("Gauge")] public BeastmasterGauge Beastmaster;
+
     [FieldOffset(0x58)] public byte ClassJobId;
 }

--- a/FFXIVClientStructs/FFXIV/Client/Game/JobGaugeManager.cs
+++ b/FFXIVClientStructs/FFXIV/Client/Game/JobGaugeManager.cs
@@ -33,13 +33,12 @@ public unsafe partial struct JobGaugeManager {
     [FieldOffset(0x08), CExporterUnion("Gauge")] public SamuraiGauge Samurai;
     [FieldOffset(0x08), CExporterUnion("Gauge")] public ReaperGauge Reaper;
     [FieldOffset(0x08), CExporterUnion("Gauge")] public ViperGauge Viper;
+    [FieldOffset(0x08), CExporterUnion("Gauge")] public BeastmasterGauge Beastmaster;
 
     [FieldOffset(0x08), CExporterUnion("Gauge")] public DarkKnightGauge DarkKnight;
     [FieldOffset(0x08), CExporterUnion("Gauge")] public PaladinGauge Paladin;
     [FieldOffset(0x08), CExporterUnion("Gauge")] public WarriorGauge Warrior;
     [FieldOffset(0x08), CExporterUnion("Gauge")] public GunbreakerGauge Gunbreaker;
-
-    [FieldOffset(0x08), CExporterUnion("Gauge")] public BeastmasterGauge Beastmaster;
 
     [FieldOffset(0x58)] public byte ClassJobId;
 }


### PR DESCRIPTION
Adds `BeastmasterGauge` (ClassJobId 43).

Mapped at runtime on 7.56 with a dalamud plugin I wrote  that dumps every frame and
tracks per-byte min/max/distinct, then confirmed each field against the HUD or the combat log.


| Offset | Field | Notes |
|---|---|---|
| `0x08` | `TPGauge` | 0-250. No passive regen; granted by weaponskill combo bonuses. Instinctual skills spend the whole pool. |
| `0x09` | `FamiliarTPGauge` | 0-250. One pool shared across Battlehorn slots, not per-familiar. Arrives in +12 steps from the familiar's auto-attacks. |
| `0x0A` | `FamiliarTPAtLastUse` | Familiar TP immediately before the last familiar action, which scales its potency. |
| `0x0B` | `ActiveBattlehorn` | 0-3. The slot, not the creature. |
| `0x0C` | `InstinctualComboState` | Affinity, then `7` while Wavering Heart (Status 4643) locks out further combo advancement. |
| `0x0D` | `CurrentAffinity` | `BeastmasterAffinity`, 0-6. Clears ~7s after it is applied. |
| `0x0E` | `ChainCount` | Chained instinctual skills, matching the number drawn under the Inner Compass. |
| `0x0F` | `KinshipState` | Two nibbles: kin type high, Battlehorn slot low. |
| `0x10` | `InstinctState` | Two 2-bit counters: Natural Instinct low, Mastered Instinct high. Trait-gated, reads 0 below level 28. |

`BeastmasterAffinity` has six values the four compass affinities plus the two combo results:

```
None 0  Volant 1  Rampant 2  Durant 3  Eldritch 4  Sunstrider 5  Moonstalker 6
```

The compass runs clockwise Volant -> Rampant -> Durant -> Eldritch -> Volant, and a clockwise  pair inside the 7s window is what makes a combo. 

Sunstrider and Moonstalker are the results are the affinity you started from.  Odd = Sunstrider, Even = Moon.

The Status sheet backs this up. The six statuses the job applies are in this order (4595-4600). 

The upgrade only lands if the target survives the combo.

`0x10` holds two resources in one byte. Mastered Instinct (bits 2-3, trait Wild Heart III at
level 28) is gained when a you complete a combo...ie; You use tricks and then an axe skill.  Rally is the spender. 

Natural Instinct (bits 0-1, Wild Heart IV at level 40) is gained when a pet completes a combo....ie; you use an axe skill, then tricks. It's spent using Rallying Cheer. 

Each caps at 3, each spender clears only its own bits.

Thanks to @Taurenkey for identifying the `0x0C` `7` as Wavering Heart, and to @Haselnussbomber
for `XBMManager` and `ActionManager.BeastmasterPets`, which is where the familiar's identity
lives - the gauge only exposes the slot.