### PR TITLE
Add ContextTabIndex field to AgentChatLog

### DIFF
--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentChatLog.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentChatLog.cs
@@ -17,8 +17,9 @@ public unsafe partial struct AgentChatLog {
     [FieldOffset(0x48)] public Utf8String ChannelLabel; // ie, "Say", "Party" that displays above the text input
 
     [FieldOffset(0x120)] public Utf8String TellPlayerName;
-    [FieldOffset(0x198)] public int ContextTabIndex;
     [FieldOffset(0x188)] public ushort TellWorldId;
+
+    [FieldOffset(0x198)] public int ContextTabIndex;
 
     [FieldOffset(0x1A0), FixedSizeArray] internal FixedSizeArray8<Utf8String> _channelSelectorLSNames;
     [FieldOffset(0x4E0), FixedSizeArray] internal FixedSizeArray8<Utf8String> _channelSelectorCWLSNames;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentChatLog.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentChatLog.cs
@@ -17,6 +17,7 @@ public unsafe partial struct AgentChatLog {
     [FieldOffset(0x48)] public Utf8String ChannelLabel; // ie, "Say", "Party" that displays above the text input
 
     [FieldOffset(0x120)] public Utf8String TellPlayerName;
+    [FieldOffset(0x198)] public int ContextTabIndex;
     [FieldOffset(0x188)] public ushort TellWorldId;
 
     [FieldOffset(0x1A0), FixedSizeArray] internal FixedSizeArray8<Utf8String> _channelSelectorLSNames;

--- a/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentChatLog.cs
+++ b/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentChatLog.cs
@@ -19,6 +19,7 @@ public unsafe partial struct AgentChatLog {
     [FieldOffset(0x120)] public Utf8String TellPlayerName;
     [FieldOffset(0x188)] public ushort TellWorldId;
 
+    [FieldOffset(0x194)] public int ContextTabOwnerAddonId;
     [FieldOffset(0x198)] public int ContextTabIndex;
 
     [FieldOffset(0x1A0), FixedSizeArray] internal FixedSizeArray8<Utf8String> _channelSelectorLSNames;


### PR DESCRIPTION
Found in Client::UI::Agent::AgentChatLog_ReceiveEvent

<img width="929" height="152" alt="image" src="https://github.com/user-attachments/assets/cfb70a8d-5023-4b6d-b486-1580ec570057" />

<img width="983" height="255" alt="image" src="https://github.com/user-attachments/assets/f9b0caad-6de3-47eb-b3ed-d2813303ddf4" />
